### PR TITLE
Adds better functionality to `Destroyable` interface

### DIFF
--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/Destroyable.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/Destroyable.kt
@@ -21,7 +21,16 @@ interface Destroyable {
 
     /**
      * Destroys the instance rendering it unusable. In [TorManager]'s case,
-     * it stops Tor, removes all listeners, cancels it's scope, etc.
+     * it stops Tor, removes all listeners, cancels it's scope, shuts down
+     * threads, etc.
+     *
+     * Tf [stopCleanly] is true, [RealTorManager.destroy] launches a coroutine
+     * in order to stop Tor via it's control port so it can clean up properly.
+     * This takes approximately 500ms (if Tor is running).
+     *
+     * By passing a lambda via [onCompletion] you can perform other necessary
+     * post destruction tasks and cleanup after Tor has been shutdown (or killed
+     * if [stopCleanly] is set to false).
      * */
-    fun destroy()
+    fun destroy(stopCleanly: Boolean = true, onCompletion: (() -> Unit)? = null)
 }


### PR DESCRIPTION
Adds ability to destroy immediately via setting `stopCleanly` to false.
Adds ability to pass a lambda to `destroy` which will be invoked upon completion.

Closes #22 