### PR TITLE
Adds ProcessStreamEater

### DIFF
--- a/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
+++ b/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
@@ -16,15 +16,15 @@
 package io.matthewnelson.kmp.tor
 
 import io.matthewnelson.kmp.tor.controller.common.file.toFile
+import io.matthewnelson.kmp.tor.internal.ProcessStreamEater
 import io.matthewnelson.kmp.tor.internal.isStillAlive
 import io.matthewnelson.kmp.tor.manager.KmpTorLoader
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.*
 import java.io.File
 import java.io.IOException
+import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -69,6 +69,8 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
 
         newLines.addAll(configLines)
 
+        val parentContext = currentCoroutineContext()
+
         var process: Process? = null
         try {
             val builder = ProcessBuilder(newLines)
@@ -78,18 +80,26 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
             val p = builder.start()
             process = p
 
+            ProcessStreamEater(
+                parentJob = parentContext.job,
+                input = p.inputStream.bufferedReader(),
+                error = p.errorStream.bufferedReader(),
+                notify = notify
+            )
+
             // Process.waitFor() is runBlocking which we do not want here.
             // Below allows us to monitor a few things that, when no longer
             // true, will drop the while loop suspension and automatically destroy
             // our process:
             //  - The underlying coroutine (or dispatcher) is cancelled/closed
             //  - Tor stops running for some reason
-            while (p.isStillAlive() && currentCoroutineContext().isActive) {
+            while (p.isStillAlive() && parentContext.isActive) {
                 delay(100L)
             }
         } catch (e: IOException) {
             throw TorManagerException("Failed to start Tor", e)
         } finally {
+            notify.invoke(TorManagerEvent.Log.Debug("Tor Process destroyed"))
             process?.destroy()
         }
     }

--- a/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
+++ b/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.tor
 import io.matthewnelson.kmp.tor.controller.common.file.toFile
 import io.matthewnelson.kmp.tor.internal.isStillAlive
 import io.matthewnelson.kmp.tor.manager.KmpTorLoader
+import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -40,7 +41,10 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
 
     @Suppress("BlockingMethodInNonBlockingContext")
     @Throws(TorManagerException::class, CancellationException::class)
-    override suspend fun startTor(configLines: List<String>) {
+    override suspend fun startTor(
+        configLines: List<String>,
+        notify: (TorManagerEvent.Log) -> Unit,
+    ) {
         val tor: File = nativeDir.listFiles().let { nDirFiles ->
             var libKmpTor: File? = null
 

--- a/library/kmp-tor/src/darwinCommonMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderDarwin.kt
+++ b/library/kmp-tor/src/darwinCommonMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderDarwin.kt
@@ -17,9 +17,13 @@ package io.matthewnelson.kmp.tor
 
 import io.matthewnelson.kmp.tor.manager.TorConfigProvider
 import io.matthewnelson.kmp.tor.manager.KmpTorLoader
+import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 
 class KmpTorLoaderDarwin(provider: TorConfigProvider): KmpTorLoader(provider) {
-    override suspend fun startTor(configLines: List<String>) {
+    override suspend fun startTor(
+        configLines: List<String>,
+        notify: (TorManagerEvent.Log) -> Unit,
+    ) {
         TODO("Not yet implemented")
     }
 }

--- a/library/kmp-tor/src/jsMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJs.kt
+++ b/library/kmp-tor/src/jsMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJs.kt
@@ -17,9 +17,13 @@ package io.matthewnelson.kmp.tor
 
 import io.matthewnelson.kmp.tor.manager.TorConfigProvider
 import io.matthewnelson.kmp.tor.manager.KmpTorLoader
+import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 
 class KmpTorLoaderJs(provider: TorConfigProvider): KmpTorLoader(provider) {
-    override suspend fun startTor(configLines: List<String>) {
+    override suspend fun startTor(
+        configLines: List<String>,
+        notify: (TorManagerEvent.Log) -> Unit,
+    ) {
         TODO("Not yet implemented")
     }
 }

--- a/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
+++ b/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.internal
+
+import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
+import kotlinx.coroutines.*
+import java.io.BufferedReader
+import java.util.*
+import java.util.concurrent.Executors
+
+@Suppress("BlockingMethodInNonBlockingContext")
+internal class ProcessStreamEater(
+    parentJob: Job,
+    input: BufferedReader,
+    error: BufferedReader,
+    notify: (TorManagerEvent.Log) -> Unit
+) {
+
+    private val supervisor = SupervisorJob(parentJob)
+    private val dispatcher = Executors.newFixedThreadPool(2).asCoroutineDispatcher()
+    private val scope = CoroutineScope(supervisor + dispatcher)
+
+    init {
+        scope.launch(CoroutineName("Process.inputStream Reader")) {
+            notify.invoke(TorManagerEvent.Log.Debug("Reading Process.inputStream"))
+            var inputScan: Scanner? = null
+
+            try {
+                inputScan = Scanner(input)
+
+                while (currentCoroutineContext().isActive  && inputScan.hasNextLine()) {
+                    notify.invoke(TorManagerEvent.Log.Info(inputScan.nextLine()))
+                }
+            } catch (e: Exception) {
+                notify.invoke(TorManagerEvent.Log.Error(e))
+            } finally {
+                notify.invoke(TorManagerEvent.Log.Debug("Stopped reading Process.inputStream"))
+                try {
+                    input.close()
+                } catch (e: Exception) {}
+                try {
+                    inputScan?.close()
+                } catch (e: Exception) {}
+            }
+        }
+
+        scope.launch(CoroutineName("Process.errorStream Reader")) {
+            notify.invoke(TorManagerEvent.Log.Debug("Reading Process.errorStream"))
+            var errorScan: Scanner? = null
+
+            try {
+                errorScan = Scanner(error)
+
+                while (currentCoroutineContext().isActive && errorScan.hasNextLine()) {
+                    notify.invoke(TorManagerEvent.Log.Warn(errorScan.nextLine()))
+                }
+            } catch (e: Exception) {
+                notify.invoke(TorManagerEvent.Log.Error(e))
+            } finally {
+                notify.invoke(TorManagerEvent.Log.Debug("Stopped reading Process.errorStream"))
+                try {
+                    error.close()
+                } catch (e: Exception) {}
+                try {
+                    errorScan?.close()
+                } catch (e: Exception) {}
+            }
+        }
+
+        supervisor.invokeOnCompletion {
+            dispatcher.close()
+        }
+    }
+}

--- a/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvm.kt
+++ b/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvm.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.tor
 import io.matthewnelson.kmp.tor.controller.common.file.toFile
 import io.matthewnelson.kmp.tor.internal.isStillAlive
 import io.matthewnelson.kmp.tor.manager.KmpTorLoader
+import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -39,7 +40,10 @@ class KmpTorLoaderJvm(
 
     @Suppress("BlockingMethodInNonBlockingContext")
     @Throws(TorManagerException::class, CancellationException::class)
-    override suspend fun startTor(configLines: List<String>) {
+    override suspend fun startTor(
+        configLines: List<String>,
+        notify: (TorManagerEvent.Log) -> Unit,
+    ) {
         val installationDir = (provider as TorConfigProviderJvm).installationDir.toFile()
         val tor = installer.retrieveTor(installationDir)
 

--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/TorOperationManager.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/TorOperationManager.kt
@@ -30,7 +30,7 @@ interface TorOperationManager {
      * Will start Tor using TorManager's coroutine scope.
      *
      * Error response is directed to the [TorManagerEvent.SealedListener] via
-     * [TorManagerEvent.Error]
+     * [TorManagerEvent.Log.Error]
      * */
     fun startQuietly()
 
@@ -43,7 +43,7 @@ interface TorOperationManager {
      * Will restart Tor using TorManager's coroutine scope.
      *
      * Error response is directed to the [TorManagerEvent.SealedListener] via
-     * [TorManagerEvent.Error]
+     * [TorManagerEvent.Log.Error]
      * */
     fun restartQuietly()
 
@@ -56,7 +56,7 @@ interface TorOperationManager {
      * Will stop Tor using TorManager's coroutine scope.
      *
      * Error response is directed to the [TorManagerEvent.SealedListener] via
-     * [TorManagerEvent.Error]
+     * [TorManagerEvent.Log.Error]
      * */
     fun stopQuietly()
 }

--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
@@ -63,7 +63,7 @@ sealed interface TorManagerEvent {
          * */
         @JvmInline
         value class Debug(val value: String): Log {
-            override fun toString(): String = value
+            override fun toString(): String = "D/$value"
         }
 
         /**
@@ -71,13 +71,22 @@ sealed interface TorManagerEvent {
          * with TorManager.
          * */
         @JvmInline
-        value class Error(val value: Throwable): Log
+        value class Error(val value: Throwable): Log {
+            override fun toString(): String = "E/${value.stackTraceToString()}"
+        }
+
+        @JvmInline
+        value class Info(val value: String): Log {
+            override fun toString(): String = "I/$value"
+        }
 
         /**
          * Warning events. Currently, the only warning is [WAITING_ON_NETWORK].
          * */
         @JvmInline
         value class Warn(val value: String): Log {
+            override fun toString(): String = "W/$value"
+
             companion object {
                 const val WAITING_ON_NETWORK = "No Network Connectivity. Waiting..."
             }
@@ -203,6 +212,7 @@ sealed interface TorManagerEvent {
         open fun managerEventAddressInfo(info: AddressInfo) {}
         open fun managerEventDebug(message: String) {}
         open fun managerEventError(t: Throwable) {}
+        open fun managerEventInfo(message: String) {}
         open fun managerEventWarn(message: String) {}
         open fun managerEventLifecycle(lifecycle: Lifecycle<*>) {}
         open fun managerEventState(state: State) {}
@@ -216,6 +226,7 @@ sealed interface TorManagerEvent {
                 is AddressInfo -> managerEventAddressInfo(event)
                 is Log.Debug -> managerEventDebug(event.value)
                 is Log.Error -> managerEventError(event.value)
+                is Log.Info -> managerEventInfo(event.value)
                 is Log.Warn -> managerEventWarn(event.value)
                 is Lifecycle<*> -> managerEventLifecycle(event)
                 is State -> managerEventState(event)

--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
@@ -56,31 +56,31 @@ sealed interface TorManagerEvent {
         }
     }
 
-    /**
-     * Debug events. Will only be dispatched if debug is enabled.
-     * */
-    sealed interface Debug: TorManagerEvent {
+    sealed interface Log: TorManagerEvent {
 
+        /**
+         * Debug events. Will only be dispatched if debug is enabled.
+         * */
         @JvmInline
-        value class Message(val value: String): Debug {
+        value class Debug(val value: String): Log {
             override fun toString(): String = value
         }
-    }
 
-    /**
-     * Error events that are not returned as a [Result] from interacting
-     * with TorManager.
-     * */
-    @JvmInline
-    value class Error(val value: Throwable): TorManagerEvent
+        /**
+         * Error events that are not returned as a [Result] from interacting
+         * with TorManager.
+         * */
+        @JvmInline
+        value class Error(val value: Throwable): Log
 
-    /**
-     * Warning events. Currently, the only warning is [WAITING_ON_NETWORK].
-     * */
-    @JvmInline
-    value class Warn(val value: String): TorManagerEvent {
-        companion object {
-            const val WAITING_ON_NETWORK = "No Network Connectivity. Waiting..."
+        /**
+         * Warning events. Currently, the only warning is [WAITING_ON_NETWORK].
+         * */
+        @JvmInline
+        value class Warn(val value: String): Log {
+            companion object {
+                const val WAITING_ON_NETWORK = "No Network Connectivity. Waiting..."
+            }
         }
     }
 
@@ -214,9 +214,9 @@ sealed interface TorManagerEvent {
                 is Action.Start -> managerEventActionStart()
                 is Action.Stop -> managerEventActionStop()
                 is AddressInfo -> managerEventAddressInfo(event)
-                is Debug.Message -> managerEventDebug(event.value)
-                is Error -> managerEventError(event.value)
-                is Warn -> managerEventWarn(event.value)
+                is Log.Debug -> managerEventDebug(event.value)
+                is Log.Error -> managerEventError(event.value)
+                is Log.Warn -> managerEventWarn(event.value)
                 is Lifecycle<*> -> managerEventLifecycle(event)
                 is State -> managerEventState(event)
             }

--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -224,7 +224,7 @@ private class RealTorManagerAndroid(
 
         scope.launch {
             start().onFailure { ex ->
-                TorServiceController.notify(TorManagerEvent.Error(ex))
+                TorServiceController.notify(TorManagerEvent.Log.Error(ex))
             }
         }
     }
@@ -297,7 +297,7 @@ private class RealTorManagerAndroid(
 
         scope.launch {
             restart().onFailure { ex ->
-                TorServiceController.notify(TorManagerEvent.Error(ex))
+                TorServiceController.notify(TorManagerEvent.Log.Error(ex))
             }
         }
     }
@@ -340,7 +340,7 @@ private class RealTorManagerAndroid(
 
         scope.launch {
             stop().onFailure { ex ->
-                TorServiceController.notify(TorManagerEvent.Error(ex))
+                TorServiceController.notify(TorManagerEvent.Log.Error(ex))
             }
         }
     }

--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/NetworkObserver.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/NetworkObserver.kt
@@ -36,7 +36,7 @@ internal fun networkObserverOrNull(service: TorService): NetworkObserver? {
         ?: return null
 
     if (!service.isPermissionGranted(ACCESS_NETWORK_STATE)) {
-        TorServiceController.notify(TorManagerEvent.Warn(
+        TorServiceController.notify(TorManagerEvent.Log.Warn(
             "Permission ACCESS_NETWORK_STATE not granted. Disabling NetworkObserver"
         ))
         return null

--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorServiceController.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorServiceController.kt
@@ -114,7 +114,7 @@ internal object TorServiceController:
 
     @JvmSynthetic
     fun notify(event: TorManagerEvent) {
-        if (event is TorManagerEvent.Debug && !debug) return
+        if (event is TorManagerEvent.Log && !debug) return
 
         listeners.withLock {
             for (listener in this) {

--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorServiceController.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorServiceController.kt
@@ -114,7 +114,7 @@ internal object TorServiceController:
 
     @JvmSynthetic
     fun notify(event: TorManagerEvent) {
-        if (event is TorManagerEvent.Log && !debug) return
+        if (event is TorManagerEvent.Log.Debug && !debug) return
 
         listeners.withLock {
             for (listener in this) {

--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/notification/TorServiceNotification.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/notification/TorServiceNotification.kt
@@ -167,6 +167,7 @@ internal abstract class TorServiceNotification(
             is AddressInfo,
             is Log.Debug,
             is Log.Error,
+            is Log.Info,
             is Lifecycle<*> -> { /* no-op */ }
 
             is EventAction.Restart -> {

--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/notification/TorServiceNotification.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/notification/TorServiceNotification.kt
@@ -33,7 +33,7 @@ import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.*
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.Lifecycle.Companion.ON_CREATE
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.Lifecycle.Companion.ON_REGISTER
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.Lifecycle.Companion.ON_UNREGISTER
-import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.Warn.Companion.WAITING_ON_NETWORK
+import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.Log.Warn.Companion.WAITING_ON_NETWORK
 import io.matthewnelson.kmp.tor.manager.common.state.*
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.Action as EventAction
 import io.matthewnelson.kmp.tor.manager.internal.TorService
@@ -165,8 +165,8 @@ internal abstract class TorServiceNotification(
         when (event) {
             is EventAction.Controller,
             is AddressInfo,
-            is Debug.Message,
-            is Error,
+            is Log.Debug,
+            is Log.Error,
             is Lifecycle<*> -> { /* no-op */ }
 
             is EventAction.Restart -> {
@@ -184,7 +184,7 @@ internal abstract class TorServiceNotification(
                     contentText = event.provideStringFor()
                 ))
             }
-            is Warn -> {
+            is Log.Warn -> {
                 if (event.value == WAITING_ON_NETWORK) {
                     render(currentState.copy(contentText = provideStringForWaitingOnNetwork()))
                 }
@@ -597,7 +597,7 @@ private class RealTorServiceNotification(
                     val action = try {
                         Action.valueOf(intent.getStringExtra(intentFilter) ?: return)
                     } catch (e: Exception) {
-                        TorServiceController.notify(Error(e))
+                        TorServiceController.notify(Log.Error(e))
                     }
 
                     when (action) {
@@ -645,7 +645,7 @@ private class RealTorServiceNotification(
                                     }
                                 }
                                 result.onFailure {
-                                    TorServiceController.notify(Error(it))
+                                    TorServiceController.notify(Log.Error(it))
                                 }
                             }
                         }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -29,7 +29,10 @@ expect abstract class KmpTorLoader {
     protected open val excludeSettings: Set<TorConfig.Setting<*>>
 
     @Throws(TorManagerException::class, CancellationException::class)
-    protected abstract suspend fun startTor(configLines: List<String>)
+    protected abstract suspend fun startTor(
+        configLines: List<String>,
+        notify: (TorManagerEvent.Log) -> Unit,
+    )
 
     @JvmSynthetic
     internal open suspend fun load(

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -43,4 +43,7 @@ expect abstract class KmpTorLoader {
 
     @JvmSynthetic
     internal open fun close()
+
+    @JvmSynthetic
+    internal open fun cancelTorJob()
 }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -927,6 +927,10 @@ private class RealTorManager(
                 loader.close()
             }
 
+            if (isRestart) {
+                loader.cancelTorJob()
+            }
+
             return result
         }
     }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -764,7 +764,7 @@ private class RealTorManager(
     }
 
     private fun notifyListeners(event: TorManagerEvent) {
-        if (event is TorManagerEvent.Log && !debug.value) return
+        if (event is TorManagerEvent.Log.Debug && !debug.value) return
 
         scope.launch {
             notifyListenersNoScope(event)

--- a/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -91,7 +91,7 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
             if (!controlPortFile.exists() || cookieAuthFile?.exists() == false) {
                 return@let
             }
-            notify.invoke(TorManagerEvent.Debug.Message(value=
+            notify.invoke(TorManagerEvent.Log.Debug(value=
                 "Attempting to re-connect to already running Tor process"
             ))
             // attempt re-connect to already running Tor instance
@@ -154,7 +154,7 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
                 }
             }
 
-            notify.invoke(TorManagerEvent.Debug.Message("Re-connection attempt successful!"))
+            notify.invoke(TorManagerEvent.Log.Debug("Re-connection attempt successful!"))
             return Result.success(controller)
         }
 
@@ -217,7 +217,7 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
         ) {
             runLock.withLock {
 
-                notify.invoke(TorManagerEvent.Debug.Message(value=
+                notify.invoke(TorManagerEvent.Log.Debug(value=
                     "Starting Tor with the following settings:\n" +
                     "----------------------------------------------------------------" +
                     "\n${validated.torConfig.text}" +

--- a/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -308,7 +308,13 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
 
     @JvmSynthetic
     internal actual open fun close() {
+        cancelTorJob()
         torDispatcher.close()
+    }
+
+    @JvmSynthetic
+    internal actual open fun cancelTorJob() {
+        torJob?.cancel()
     }
 
     @Throws(TorManagerException::class)

--- a/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -225,7 +225,11 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
                 ))
 
                 withContext(dispatcher) {
-                    startTor(validated.configLines)
+                    startTor(validated.configLines) { log ->
+                        managerScope.launch {
+                            notify.invoke(log)
+                        }
+                    }
                 }
 
                 // throw exception here so it is propagated to the handler in
@@ -418,5 +422,8 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
     }
 
     @Throws(TorManagerException::class, CancellationException::class)
-    protected actual abstract suspend fun startTor(configLines: List<String>)
+    protected actual abstract suspend fun startTor(
+        configLines: List<String>,
+        notify: (TorManagerEvent.Log) -> Unit,
+    )
 }

--- a/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -40,5 +40,8 @@ actual abstract class KmpTorLoader(provider: TorConfigProvider) {
     internal actual open fun close() { /* no-op */ }
 
     @Throws(TorManagerException::class, CancellationException::class)
-    protected actual abstract suspend fun startTor(configLines: List<String>)
+    protected actual abstract suspend fun startTor(
+        configLines: List<String>,
+        notify: (TorManagerEvent.Log) -> Unit,
+    )
 }

--- a/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -39,6 +39,8 @@ actual abstract class KmpTorLoader(provider: TorConfigProvider) {
 
     internal actual open fun close() { /* no-op */ }
 
+    internal actual open fun cancelTorJob() { /* no-op */ }
+
     @Throws(TorManagerException::class, CancellationException::class)
     protected actual abstract suspend fun startTor(
         configLines: List<String>,

--- a/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
+++ b/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
@@ -121,7 +121,7 @@ class SampleApp: Application() {
 
         override fun onEvent(event: TorManagerEvent) {
             addLine(event.toString())
-            if (event is TorManagerEvent.Error) {
+            if (event is TorManagerEvent.Log.Error) {
                 event.value.printStackTrace()
             }
 

--- a/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
+++ b/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
@@ -206,7 +206,7 @@ class SampleApp: App(SampleView::class) {
 
         override fun onEvent(event: TorManagerEvent) {
             addLine(event.toString())
-            if (event is TorManagerEvent.Error) {
+            if (event is TorManagerEvent.Log.Error) {
                 event.value.printStackTrace()
             }
 


### PR DESCRIPTION
- Adds to Jvm and Android the `ProcessStreamEater` class such that input/error streams can be read for the Tor Process.
- Restructures `TorManagerEvent` Logging hierarchy to include `Debug`/`Error`/`Info`/`Warn`
- Improves logging
- Fixes TorJob cancellation by adding `cancelTorJob` method to `KmpTorLoader`

Closes #25 