### PR TITLE
Adds better handling of `TorManager.destroy` arguments

### DIFF
--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorService.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorService.kt
@@ -285,7 +285,7 @@ internal class TorService: Service() {
     override fun onDestroy() {
         TorServiceController.notify(TorManagerEvent.Lifecycle(this, ON_DESTROY))
         supervisor.cancel()
-        managerHolder.instance?.destroy(stopCleanly = true) {
+        managerHolder.instance?.destroy(stopCleanly = config.enableForeground || !isTaskRemoved) {
             // onCompletion
             if (config.enableForeground && isTaskRemoved) {
                 exitProcess(0)


### PR DESCRIPTION
Adds better handling of `TorManager.destroy` call from `TorService.onDestroy` to take into consideration `TorServiceConfig` and if the task has been removed or not.