### PR TITLE
Tweak/Improve Logging

### DIFF
--- a/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
+++ b/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
@@ -80,6 +80,7 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
             val p = builder.start()
             process = p
 
+            var errorTime: Long = 0
             var processError: TorManagerException? = null
             ProcessStreamEater(
                 parentJob = parentContext.job,
@@ -87,6 +88,7 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
                 error = p.errorStream.bufferedReader(),
             ) { log ->
                 if (log is TorManagerEvent.Log.Error && log.value is TorManagerException) {
+                    errorTime = System.currentTimeMillis()
                     processError = log.value as TorManagerException
                 }
                 notify.invoke(log)
@@ -103,7 +105,10 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
             }
 
             processError?.let { ex ->
-                throw ex
+                // Don't throw if error is stale
+                if ((System.currentTimeMillis() - errorTime) < 250L) {
+                    throw ex
+                }
             }
         } catch (e: IOException) {
             throw TorManagerException("Failed to start Tor", e)

--- a/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
+++ b/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
@@ -24,7 +24,6 @@ import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
 import kotlinx.coroutines.*
 import java.io.File
 import java.io.IOException
-import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -33,7 +32,7 @@ import kotlin.coroutines.cancellation.CancellationException
  *
  * @see [TorConfigProviderAndroid]
  * @see [KmpTorLoader]
- * @sample [io.matthewnelson.kmp.tor.sample.android.App]
+ * @sample [io.matthewnelson.kmp.tor.sample.android.SampleApp]
  * */
 class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(provider) {
 

--- a/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
+++ b/library/kmp-tor/src/androidMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderAndroid.kt
@@ -80,12 +80,17 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
             val p = builder.start()
             process = p
 
+            var processError: TorManagerException? = null
             ProcessStreamEater(
                 parentJob = parentContext.job,
                 input = p.inputStream.bufferedReader(),
                 error = p.errorStream.bufferedReader(),
-                notify = notify
-            )
+            ) { log ->
+                if (log is TorManagerEvent.Log.Error && log.value is TorManagerException) {
+                    processError = log.value as TorManagerException
+                }
+                notify.invoke(log)
+            }
 
             // Process.waitFor() is runBlocking which we do not want here.
             // Below allows us to monitor a few things that, when no longer
@@ -95,6 +100,10 @@ class KmpTorLoaderAndroid(provider: TorConfigProviderAndroid): KmpTorLoader(prov
             //  - Tor stops running for some reason
             while (p.isStillAlive() && parentContext.isActive) {
                 delay(100L)
+            }
+
+            processError?.let { ex ->
+                throw ex
             }
         } catch (e: IOException) {
             throw TorManagerException("Failed to start Tor", e)

--- a/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
+++ b/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
@@ -43,7 +43,18 @@ internal class ProcessStreamEater(
                 inputScan = Scanner(input)
 
                 while (currentCoroutineContext().isActive  && inputScan.hasNextLine()) {
-                    notify.invoke(TorManagerEvent.Log.Info(inputScan.nextLine()))
+                    val line = inputScan.nextLine()
+                    when {
+                        line.contains(" [err] ") -> {
+                            notify.invoke(TorManagerEvent.Log.Error(TorManagerException(line)))
+                        }
+                        line.contains(" [warn] ") -> {
+                            notify.invoke(TorManagerEvent.Log.Warn(line))
+                        }
+                        else -> {
+                            notify.invoke(TorManagerEvent.Log.Info(line))
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 notify.invoke(TorManagerEvent.Log.Error(e))

--- a/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
+++ b/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
@@ -46,15 +46,21 @@ internal class ProcessStreamEater(
                     val line = inputScan.nextLine()
                     when {
                         line.contains(ERROR) -> {
-                            notify.invoke(TorManagerEvent.Log.Error(TorManagerException(line)))
+                            notify.invoke(TorManagerEvent.Log.Error(
+                                TorManagerException(line.substringAfter(ERROR))
+                            ))
                         }
                         line.contains(NOTICE) -> {
                             // pipe notices to debug as we are already listening for them
                             // via the control port by default.
-                            notify.invoke(TorManagerEvent.Log.Debug(line))
+                            notify.invoke(TorManagerEvent.Log.Debug(
+                                line.substringAfter(NOTICE)
+                            ))
                         }
                         line.contains(WARN) -> {
-                            notify.invoke(TorManagerEvent.Log.Warn(line))
+                            notify.invoke(TorManagerEvent.Log.Warn(
+                                line.substringAfter(WARN)
+                            ))
                         }
                         else -> {
                             notify.invoke(TorManagerEvent.Log.Info(line))

--- a/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
+++ b/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.kmp.tor.internal
 
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
+import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
 import kotlinx.coroutines.*
 import java.io.BufferedReader
 import java.util.*
@@ -65,7 +66,9 @@ internal class ProcessStreamEater(
                 errorScan = Scanner(error)
 
                 while (currentCoroutineContext().isActive && errorScan.hasNextLine()) {
-                    notify.invoke(TorManagerEvent.Log.Warn(errorScan.nextLine()))
+                    notify.invoke(TorManagerEvent.Log.Error(
+                        TorManagerException(errorScan.nextLine())
+                    ))
                 }
             } catch (e: Exception) {
                 notify.invoke(TorManagerEvent.Log.Error(e))

--- a/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
+++ b/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
@@ -46,21 +46,15 @@ internal class ProcessStreamEater(
                     val line = inputScan.nextLine()
                     when {
                         line.contains(ERROR) -> {
-                            notify.invoke(TorManagerEvent.Log.Error(
-                                TorManagerException(line.substringAfter(ERROR))
-                            ))
+                            notify.invoke(TorManagerEvent.Log.Error(TorManagerException(line)))
                         }
                         line.contains(NOTICE) -> {
                             // pipe notices to debug as we are already listening for them
                             // via the control port by default.
-                            notify.invoke(TorManagerEvent.Log.Debug(
-                                line.substringAfter(NOTICE)
-                            ))
+                            notify.invoke(TorManagerEvent.Log.Debug(line))
                         }
                         line.contains(WARN) -> {
-                            notify.invoke(TorManagerEvent.Log.Warn(
-                                line.substringAfter(WARN)
-                            ))
+                            notify.invoke(TorManagerEvent.Log.Warn(line))
                         }
                         else -> {
                             notify.invoke(TorManagerEvent.Log.Info(line))

--- a/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
+++ b/library/kmp-tor/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessStreamEater.kt
@@ -45,10 +45,15 @@ internal class ProcessStreamEater(
                 while (currentCoroutineContext().isActive  && inputScan.hasNextLine()) {
                     val line = inputScan.nextLine()
                     when {
-                        line.contains(" [err] ") -> {
+                        line.contains(ERROR) -> {
                             notify.invoke(TorManagerEvent.Log.Error(TorManagerException(line)))
                         }
-                        line.contains(" [warn] ") -> {
+                        line.contains(NOTICE) -> {
+                            // pipe notices to debug as we are already listening for them
+                            // via the control port by default.
+                            notify.invoke(TorManagerEvent.Log.Debug(line))
+                        }
+                        line.contains(WARN) -> {
                             notify.invoke(TorManagerEvent.Log.Warn(line))
                         }
                         else -> {
@@ -97,5 +102,11 @@ internal class ProcessStreamEater(
         supervisor.invokeOnCompletion {
             dispatcher.close()
         }
+    }
+
+    companion object {
+        private const val ERROR = " [err] "
+        private const val NOTICE = " [notice] "
+        private const val WARN = " [warn] "
     }
 }

--- a/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvm.kt
+++ b/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvm.kt
@@ -35,6 +35,7 @@ import kotlin.coroutines.cancellation.CancellationException
  * @see [PlatformInstaller]
  * @see [TorConfigProviderJvm]
  * @see [KmpTorLoader]
+ * @sample [io.matthewnelson.kmp.tor.sample.javafx.SampleApp]
  * */
 class KmpTorLoaderJvm(
     val installer: PlatformInstaller,

--- a/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvm.kt
+++ b/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvm.kt
@@ -54,7 +54,7 @@ class KmpTorLoaderJvm(
         notify: (TorManagerEvent.Log) -> Unit,
     ) {
         val installationDir = (provider as TorConfigProviderJvm).installationDir.toFile()
-        val tor = installer.retrieveTor(installationDir)
+        val tor = installer.retrieveTor(installationDir, notify)
 
         val newLines: MutableList<String> = ArrayList(configLines.size + 1)
         newLines.add(tor.absolutePath)

--- a/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/TorConfigProviderJvm.kt
+++ b/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/TorConfigProviderJvm.kt
@@ -44,7 +44,7 @@ abstract class TorConfigProviderJvm: TorConfigProvider() {
      * loading/starting Tor.
      * */
     open val installationDir: Path by lazy {
-        workDir.builder { addSegment("kmptor") }
+        workDir.builder { addSegment(".kmptor") }
     }
     override val geoIpV4File: Path? by lazy {
         workDir.builder { addSegment("geoip") }

--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
@@ -72,7 +72,7 @@ sealed interface TorManagerEvent {
          * */
         @JvmInline
         value class Error(val value: Throwable): Log {
-            override fun toString(): String = "E/${value.stackTraceToString()}"
+            override fun toString(): String = "E/$value"
         }
 
         @JvmInline

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -799,6 +799,7 @@ private class RealTorManager(
         }
 
         val result = loader.load(scope, stateMachine) { event ->
+            if (event is TorManagerEvent.Log.Debug && !debug.value) return@load
             notifyListenersNoScope(event)
         }
 

--- a/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -217,7 +217,7 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
         ) {
             runLock.withLock {
 
-                notify.invoke(TorManagerEvent.Log.Debug(value=
+                notify.invoke(TorManagerEvent.Log.Info(value=
                     "Starting Tor with the following settings:\n" +
                     "----------------------------------------------------------------" +
                     "\n${validated.torConfig.text}" +


### PR DESCRIPTION
- Cleans up `StreamProcessEater` Log levels (debug/error/info/warn)
- Fixes debug logs being dispatched from `RealTorManager` when debug != true
- Modifies default Jvm install directory by making it hidden (dir name = `.kmptor`)
- Propagates Errors from `StreamProcessEater` to `KmpTorLoader.startTor` method so more informative exceptions can be thrown.
- Modifies Log level of config settings upon startup from `Debug` to `Info`

Closes #31 