### PR TITLE
Add ability to declare multiple ports in `TorConfig`

### DIFF
--- a/library/controller/kmp-tor-controller-common/build.gradle.kts
+++ b/library/controller/kmp-tor-controller-common/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+import io.matthewnelson.kotlin.components.dependencies.deps
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
@@ -51,6 +52,7 @@ kmpConfiguration {
         commonMainSourceSet = {
             dependencies {
                 api(project(":library:kmp-tor-common"))
+                implementation(deps.kotlin.reflect)
             }
         },
         commonTestSourceSet = {

--- a/library/controller/kmp-tor-controller-common/build.gradle.kts
+++ b/library/controller/kmp-tor-controller-common/build.gradle.kts
@@ -51,8 +51,8 @@ kmpConfiguration {
         ),
         commonMainSourceSet = {
             dependencies {
-                api(project(":library:kmp-tor-common"))
                 implementation(deps.kotlin.reflect)
+                api(project(":library:kmp-tor-common"))
             }
         },
         commonTestSourceSet = {

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -98,6 +98,20 @@ class TorConfig private constructor(
             settings.remove(setting)
         }
 
+        @Suppress("unchecked_cast")
+        fun <T: Setting<*>> removeInstanceOf(clazz: KClass<T>): Builder = apply {
+            val toRemove = mutableListOf<T>()
+            for (setting in settings.keys) {
+                if (setting::class == clazz) {
+                    toRemove.add(setting as T)
+                }
+            }
+
+            for (setting in toRemove) {
+                settings.remove(setting)
+            }
+        }
+
         fun put(config: TorConfig): Builder = apply {
             settings.putAll(config.settings)
         }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -539,16 +539,36 @@ class TorConfig private constructor(
         sealed class Ports(keyword: String) : Setting<Option.AorDorPort>(keyword) {
 
             override fun equals(other: Any?): Boolean {
-                return  other != null               &&
-                        other is Ports              &&
-                        other.keyword == keyword    &&
-                        other.value == value
+                if (other == null) {
+                    return false
+                }
+
+                if (other !is Ports) {
+                    return false
+                }
+
+                val otherValue = other.value
+                val thisValue = value
+                return if (
+                    otherValue is Option.AorDorPort.Value &&
+                    thisValue is Option.AorDorPort.Value
+                ) {
+                    // compare ports as to disallow setting same port for different Ports
+                    otherValue == thisValue
+                } else {
+                    other.keyword == keyword && otherValue == thisValue
+                }
             }
 
             override fun hashCode(): Int {
-                var result = 17
-                result = result * 31 + keyword.hashCode()
-                result = result * 31 + value.hashCode()
+                var result = 17 - 2
+                if (value is Option.AorDorPort.Value) {
+                    // take value of the port only
+                    result = result * 31 + value.hashCode()
+                } else {
+                    result = result * 31 + keyword.hashCode()
+                    result = result * 31 + value.hashCode()
+                }
                 return result
             }
 

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -111,23 +111,32 @@ class TorConfig private constructor(
         }
 
         fun put(config: TorConfig): Builder = apply {
-            settings.addAll(config.settings)
+            for (setting in config.settings) {
+                if (!settings.add(setting)) {
+                    settings.remove(setting)
+                    settings.add(setting)
+                }
+            }
         }
 
         fun put(setting: TorConfig.Setting<*>): Builder = apply {
-            setting.value?.let { settings.add(setting.clone()) } ?: remove(setting)
+            setting.value?.let {
+                val clone = setting.clone()
+                if (!settings.add(clone)) {
+                    settings.remove(clone)
+                    settings.add(clone)
+                }
+            } ?: remove(setting)
         }
 
         fun put(settings: Collection<TorConfig.Setting<*>>): Builder = apply {
             for (setting in settings) {
-                setting.value?.let { this.settings.add(setting.clone()) } ?: remove(setting)
+                put(setting)
             }
         }
 
         fun putIfAbsent(setting: TorConfig.Setting<*>): Builder = apply {
-            if (!settings.contains(setting)) {
-                setting.value?.let { settings.add(setting.clone()) }
-            }
+            setting.value?.let { settings.add(setting.clone()) } ?: remove(setting)
         }
 
         @OptIn(InternalTorApi::class)

--- a/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
@@ -16,6 +16,8 @@
 package io.matthewnelson.kmp.tor.controller.common.config
 
 import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.file.Path
 import kotlin.test.*
 
@@ -23,8 +25,8 @@ class TorConfigUnitTest {
 
     @Test
     fun givenTorConfigBuilder_whenBuilt_containsExpectedArguments() {
-        val expectedKey = TorConfig.Setting.DisableNetwork()
-        val expectedValue = TorConfig.Option.TorF.True
+        val expectedKey = DisableNetwork()
+        val expectedValue = TorF.True
 
         val config: TorConfig = TorConfig.Builder {
             put(expectedKey.set(expectedValue))
@@ -34,15 +36,15 @@ class TorConfigUnitTest {
         assertTrue(config.text.contains(expectedValue.value))
         assertTrue(config.settings.contains(expectedKey))
         assertEquals(
-            config.settings.filterIsInstance<TorConfig.Setting.DisableNetwork>().first().value,
+            config.settings.filterIsInstance<DisableNetwork>().first().value,
             expectedValue
         )
     }
 
     @Test
     fun givenTorConfig_whenNewBuilder_containsExpectedArguments() {
-        val expectedKey = TorConfig.Setting.DisableNetwork()
-        val expectedValue = TorConfig.Option.TorF.True
+        val expectedKey = DisableNetwork()
+        val expectedValue = TorF.True
 
         val config: TorConfig = TorConfig.Builder {
             put(expectedKey.set(expectedValue))
@@ -61,8 +63,8 @@ class TorConfigUnitTest {
 
     @Test
     fun givenTorConfig_whenNewBuilderAndRemoveIfPresent_containsNewArguments() {
-        val expectedKey = TorConfig.Setting.DisableNetwork()
-        val keyToRemove = TorConfig.Setting.ConnectionPadding()
+        val expectedKey = DisableNetwork()
+        val keyToRemove = ConnectionPadding()
 
         val config: TorConfig = TorConfig.Builder {
             put(expectedKey)
@@ -79,17 +81,17 @@ class TorConfigUnitTest {
         assertNotEquals(config, newConfig)
         assertNotEquals(config.text, newConfig.text)
         assertNotEquals(config.settings.size, newConfig.settings.size)
-        assertFalse(config.settings.filterIsInstance<TorConfig.Setting.ConnectionPadding>().isEmpty())
-        assertTrue(newConfig.settings.filterIsInstance<TorConfig.Setting.ConnectionPadding>().isEmpty())
+        assertFalse(config.settings.filterIsInstance<ConnectionPadding>().isEmpty())
+        assertTrue(newConfig.settings.filterIsInstance<ConnectionPadding>().isEmpty())
     }
 
     @Test
     fun givenTorConfigBuilder_whenRemoveInstanceOf_removesAllInstances() {
-        val expectedRemove = TorConfig.Setting.DisableNetwork()
+        val expectedRemove = DisableNetwork()
         val expectedContains = buildSet {
-            add(TorConfig.Setting.Ports.Control())
-            add(TorConfig.Setting.Ports.Dns())
-            add(TorConfig.Setting.Ports.HttpTunnel())
+            add(Ports.Control())
+            add(Ports.Dns())
+            add(Ports.HttpTunnel())
         }
 
         val config = TorConfig.Builder {
@@ -110,11 +112,40 @@ class TorConfigUnitTest {
     }
 
     @Test
+    fun givenDifferentPortTypes_whenSamePort_areEqual() {
+        val http = Ports.HttpTunnel()
+        val socks = Ports.Socks()
+        val port = AorDorPort.Value(Port(9150))
+        http.set(port)
+        socks.set(port)
+
+        assertTrue(http.equals(socks))
+
+        val config = TorConfig.Builder {
+            put(http)
+            put(socks)
+        }.build()
+
+        assertEquals(1, config.settings.size)
+
+        http.set(AorDorPort.Auto)
+        assertEquals(AorDorPort.Auto, http.value)
+        assertFalse(http.equals(socks))
+
+        val newConfig = TorConfig.Builder {
+            put(http)
+            put(socks)
+        }.build()
+
+        assertEquals(2, newConfig.settings.size)
+    }
+
+    @Test
     fun givenMultiplePorts_whenContainsDisable_buildDoesNotInclude() {
-        val tunnelPort = TorConfig.Setting.Ports.HttpTunnel()
-        val auto = TorConfig.Option.AorDorPort.Auto
-        val disabled = TorConfig.Option.AorDorPort.Disable
-        val portValue = TorConfig.Option.AorDorPort.Value(Port(9150))
+        val tunnelPort = Ports.HttpTunnel()
+        val auto = AorDorPort.Auto
+        val disabled = AorDorPort.Disable
+        val portValue = AorDorPort.Value(Port(9150))
 
         val config = TorConfig.Builder {
             put(tunnelPort.set(auto))
@@ -138,10 +169,10 @@ class TorConfigUnitTest {
 
     @Test
     fun givenTorConfig_whenTryModifySetting_settingRemainsUnchanged() {
-        val tunnelPort = TorConfig.Setting.Ports.HttpTunnel()
-        val auto = TorConfig.Option.AorDorPort.Auto
-        val disabled = TorConfig.Option.AorDorPort.Disable
-        val portValue = TorConfig.Option.AorDorPort.Value(Port(9150))
+        val tunnelPort = Ports.HttpTunnel()
+        val auto = AorDorPort.Auto
+        val disabled = AorDorPort.Disable
+        val portValue = AorDorPort.Value(Port(9150))
 
         val config = TorConfig.Builder {
             put(tunnelPort.set(auto))
@@ -150,14 +181,14 @@ class TorConfigUnitTest {
 
         assertTrue(tunnelPort.isMutable)
 
-        val setting1 = config.settings.first() as TorConfig.Setting.Ports.HttpTunnel
+        val setting1 = config.settings.first() as Ports.HttpTunnel
         assertEquals(setting1.value, auto)
         assertTrue(setting1.isolationFlags.isNullOrEmpty())
         assertFalse(setting1.isMutable)
 
         setting1
             .setIsolationFlags(setOf(
-                TorConfig.Setting.Ports.IsolationFlag.IsolateClientAddr
+                Ports.IsolationFlag.IsolateClientAddr
             ))
             .set(disabled)
         assertEquals(setting1.value, auto)
@@ -166,8 +197,8 @@ class TorConfigUnitTest {
 
     @Test
     fun givenSetting_whenImmutable_becomesMutableWhenCloned() {
-        val tunnelPort = TorConfig.Setting.Ports.HttpTunnel()
-        val auto = TorConfig.Option.AorDorPort.Auto
+        val tunnelPort = Ports.HttpTunnel()
+        val auto = AorDorPort.Auto
 
         val tunnelPort2 = tunnelPort.set(auto).setImmutable().clone()
         assertFalse(tunnelPort.isMutable)
@@ -176,39 +207,39 @@ class TorConfigUnitTest {
 
     @Test
     fun givenPortsControl_whenTrySetDisable_remainsUnchanged() {
-        val ctrl = TorConfig.Setting.Ports.Control().set(TorConfig.Option.AorDorPort.Disable)
-        assertTrue(ctrl.default is TorConfig.Option.AorDorPort.Auto)
+        val ctrl = Ports.Control().set(AorDorPort.Disable)
+        assertTrue(ctrl.default is AorDorPort.Auto)
         assertTrue(ctrl.isDefault)
     }
 
     @Test
     fun givenCacheDirectory_whenEmptyPath_remainsNull() {
-        val cacheDir = TorConfig.Setting.CacheDirectory().set(TorConfig.Option.FileSystemDir(Path("")))
+        val cacheDir = CacheDirectory().set(FileSystemDir(Path("")))
         assertNull(cacheDir.value)
     }
 
     @Test
     fun givenCookieAuthFile_whenEmptyPath_remainsNull() {
-        val cookieFile = TorConfig.Setting.CookieAuthFile().set(TorConfig.Option.FileSystemFile(Path("")))
+        val cookieFile = CookieAuthFile().set(FileSystemFile(Path("")))
         assertNull(cookieFile.value)
     }
 
     @Test
     fun givenDataDirectory_whenEmptyPath_remainsNull() {
-        val dataDir = TorConfig.Setting.DataDirectory().set(TorConfig.Option.FileSystemDir(Path("")))
+        val dataDir = DataDirectory().set(FileSystemDir(Path("")))
         assertNull(dataDir.value)
     }
 
     @Test
     fun givenDormantClientTimeout_whenLessThan10Minutes_defaultsTo10Minutes() {
-        val dormant = TorConfig.Setting.DormantClientTimeout().set(TorConfig.Option.Time.Minutes(2))
-        assertEquals(10, (dormant.value as TorConfig.Option.Time.Minutes).time)
+        val dormant = DormantClientTimeout().set(Time.Minutes(2))
+        assertEquals(10, (dormant.value as Time.Minutes).time)
     }
 
     @Test
     fun givenSameSettings_whenValuesDifferent_settingsStillReturnTrueWhenCompared() {
-        val padding1 = TorConfig.Setting.ConnectionPadding().set(TorConfig.Option.AorTorF.Auto)
-        val padding2 = padding1.clone().set(TorConfig.Option.AorTorF.False)
+        val padding1 = ConnectionPadding().set(AorTorF.Auto)
+        val padding2 = padding1.clone().set(AorTorF.False)
 
         // equals override compares only the keyword for that setting, so they should register as equal
         assertEquals(padding1, padding2)
@@ -218,8 +249,8 @@ class TorConfigUnitTest {
 
     @Test
     fun givenSamePortSettings_whenValuesDifferent_settingsAreNotEquals() {
-        val control1 = TorConfig.Setting.Ports.Control().set(TorConfig.Option.AorDorPort.Value(Port(9051)))
-        val control2 = control1.clone().set(TorConfig.Option.AorDorPort.Auto)
+        val control1 = Ports.Control().set(AorDorPort.Value(Port(9051)))
+        val control2 = control1.clone().set(AorDorPort.Auto)
 
         assertNotEquals(control1, control2)
         assertNotEquals(control1.value, control2.value)
@@ -227,11 +258,11 @@ class TorConfigUnitTest {
 
     @Test
     fun givenPort_whenCloned_originalPortSettingsNotAffectedByModification() {
-        val socks1 = TorConfig.Setting.Ports.Socks()
-        socks1.set(TorConfig.Option.AorDorPort.Value(Port(9150)))
+        val socks1 = Ports.Socks()
+        socks1.set(AorDorPort.Value(Port(9150)))
 
         val socks2 = socks1.clone()
-        socks2.set(TorConfig.Option.AorDorPort.Auto)
+        socks2.set(AorDorPort.Auto)
 
         assertNotEquals(socks1.value, socks2.value)
     }

--- a/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
@@ -128,6 +128,32 @@ class TorConfigUnitTest {
     }
 
     @Test
+    fun givenTorConfigBuilder_whenRemoveInstanceOf_removesAllInstances() {
+        val expectedRemove = TorConfig.Setting.DisableNetwork()
+        val expectedContains = buildSet {
+            add(TorConfig.Setting.Ports.Control())
+            add(TorConfig.Setting.Ports.Dns())
+            add(TorConfig.Setting.Ports.HttpTunnel())
+        }
+
+        val config = TorConfig.Builder {
+            put(expectedRemove)
+            put(expectedContains)
+        }.build()
+
+        assertTrue(config.settings.containsKey(expectedRemove))
+
+        val newConfig = config.newBuilder {
+            removeInstanceOf(expectedRemove::class)
+        }.build()
+
+        assertFalse(newConfig.settings.containsKey(expectedRemove))
+        for (expected in expectedContains) {
+            assertTrue(newConfig.settings.containsKey(expected))
+        }
+    }
+
+    @Test
     fun givenKeyWordPortControl_whenTrySetDisable_remainsUnchanged() {
         val ctrl = TorConfig.Setting.Ports.Control().set(TorConfig.Option.AorDorPort.Disable)
         assertTrue(ctrl.default is TorConfig.Option.AorDorPort.Auto)

--- a/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
@@ -86,6 +86,30 @@ class TorConfigUnitTest {
     }
 
     @Test
+    fun givenTorConfigBuilder_whenSameSettingPut_replacesOldSetting() {
+        val expected = TorF.True
+        val disableNetwork = DisableNetwork().set(TorF.False)
+        val config = TorConfig.Builder {
+            put(disableNetwork)
+            put(disableNetwork.set(expected))
+        }.build()
+
+        assertEquals(expected, config.settings.first().value)
+    }
+
+    @Test
+    fun givenTorConfigBuilder_whenSameSettingPutIfAbsent_doesNotReplaceOldSetting() {
+        val expected = TorF.True
+        val disableNetwork = DisableNetwork().set(TorF.False)
+        val config = TorConfig.Builder {
+            put(disableNetwork)
+            putIfAbsent(disableNetwork.set(expected))
+        }.build()
+
+        assertNotEquals(expected, config.settings.first().value)
+    }
+
+    @Test
     fun givenTorConfigBuilder_whenRemoveInstanceOf_removesAllInstances() {
         val expectedRemove = DisableNetwork()
         val expectedContains = buildSet {

--- a/library/controller/kmp-tor-controller/build.gradle.kts
+++ b/library/controller/kmp-tor-controller/build.gradle.kts
@@ -55,16 +55,17 @@ kmpConfiguration {
         commonPluginIds = setOf("kotlinx-atomicfu"),
         commonMainSourceSet = {
             dependencies {
+                implementation(deps.components.encoding.base16)
                 implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.coroutines.core.core)
-                implementation(deps.components.encoding.base16)
+                implementation(deps.kotlin.reflect)
                 api(project(":library:controller:kmp-tor-controller-common"))
             }
         },
         commonTestSourceSet = {
             dependencies {
-                implementation(kotlin("test"))
                 implementation(depsTest.kotlin.coroutines)
+                implementation(kotlin("test"))
             }
         },
         kotlin = {

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -185,16 +185,21 @@ private class RealTorControlProcessor(
                 val command = StringBuilder("+LOADCONF").let { sb ->
                     sb.append(CLRF)
 
-                    val controlPort = TorConfig.Setting.Ports.Control()
-                    val controlPortWriteToFile = TorConfig.Setting.ControlPortWriteToFile()
+                    val kControlPort = TorConfig.Setting.Ports.Control::class
+                    val kControlPortWriteToFile = TorConfig.Setting.ControlPortWriteToFile::class
+                    var needsModification = false
+                    for (setting in config.settings) {
+                        val clazz = setting::class
+                        if (clazz == kControlPort || clazz == kControlPortWriteToFile) {
+                            needsModification = true
+                            break
+                        }
+                    }
 
-                    if (
-                        config.settings.containsKey(controlPort)                ||
-                        config.settings.containsKey(controlPortWriteToFile)
-                    ) {
+                    if (needsModification) {
                         val newConfig: TorConfig = config.newBuilder {
-                            remove(controlPort)
-                            remove(controlPortWriteToFile)
+                            removeInstanceOf(kControlPort)
+                            removeInstanceOf(kControlPortWriteToFile)
                         }.build()
                         sb.append(newConfig.text)
                     } else {

--- a/library/kmp-tor/build.gradle.kts
+++ b/library/kmp-tor/build.gradle.kts
@@ -137,8 +137,8 @@ kmpConfiguration {
         },
         commonTestSourceSet = {
             dependencies {
-                implementation(kotlin("test"))
                 implementation(depsTest.kotlin.coroutines)
+                implementation(kotlin("test"))
             }
         },
         kotlin = {

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvmIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvmIntegrationTest.kt
@@ -15,11 +15,56 @@
  **/
 package io.matthewnelson.kmp.tor
 
+import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
 import io.matthewnelson.kmp.tor.helper.TorTestHelper
 import kotlinx.coroutines.*
 import org.junit.*
 
 class KmpTorLoaderJvmIntegrationTest: TorTestHelper() {
+
+    override fun testConfig(testProvider: TorConfigProviderJvm): TorConfig {
+        return TorConfig.Builder {
+            val control = Ports.Control()
+            put(control.set(AorDorPort.Value(Port(9150))))
+            put(control.set(AorDorPort.Value(Port(9151))))
+            put(control.set(AorDorPort.Value(Port(9152))))
+            put(control.set(AorDorPort.Value(Port(9153))))
+
+            val dns = Ports.Dns()
+            put(dns.set(AorDorPort.Value(Port(9154))))
+            put(dns.set(AorDorPort.Value(Port(9155))))
+            put(dns.set(AorDorPort.Value(Port(9156))))
+            put(dns.set(AorDorPort.Value(Port(9157))))
+
+            val socks = Ports.Socks()
+            put(socks.set(AorDorPort.Value(Port(9158))))
+            put(socks.set(AorDorPort.Value(Port(9159))))
+            put(socks.set(AorDorPort.Value(Port(9160))))
+            put(socks.set(AorDorPort.Value(Port(9161))))
+
+            val http = Ports.HttpTunnel()
+            put(http.set(AorDorPort.Value(Port(9162))))
+            put(http.set(AorDorPort.Value(Port(9163))))
+            put(http.set(AorDorPort.Value(Port(9164))))
+            put(http.set(AorDorPort.Value(Port(9165))))
+
+            val trans = Ports.Trans()
+            put(trans.set(AorDorPort.Value(Port(9166))))
+            put(trans.set(AorDorPort.Value(Port(9167))))
+            put(trans.set(AorDorPort.Value(Port(9168))))
+            put(trans.set(AorDorPort.Value(Port(9169))))
+
+            put(ClientOnionAuthDir().set(FileSystemDir(
+                testProvider.workDir.builder { addSegment(ClientOnionAuthDir.DEFAULT_NAME) }
+            )))
+
+            put(DormantClientTimeout().set(Time.Minutes(10)))
+            put(DormantCanceledByStartup().set(TorF.True))
+        }.build()
+    }
 
     @Test
     fun testRestart() = runBlocking {

--- a/library/manager/kmp-tor-manager-common/build.gradle.kts
+++ b/library/manager/kmp-tor-manager-common/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+import io.matthewnelson.kotlin.components.dependencies.deps
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
@@ -51,6 +52,7 @@ kmpConfiguration {
         commonMainSourceSet = {
             dependencies {
                 api(project(":library:controller:kmp-tor-controller-common"))
+                implementation(deps.kotlin.reflect)
             }
         },
         commonTestSourceSet = {

--- a/library/manager/kmp-tor-manager-common/build.gradle.kts
+++ b/library/manager/kmp-tor-manager-common/build.gradle.kts
@@ -51,8 +51,8 @@ kmpConfiguration {
         ),
         commonMainSourceSet = {
             dependencies {
-                api(project(":library:controller:kmp-tor-controller-common"))
                 implementation(deps.kotlin.reflect)
+                api(project(":library:controller:kmp-tor-controller-common"))
             }
         },
         commonTestSourceSet = {

--- a/library/manager/kmp-tor-manager-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/common/event/AddressInfoUnitTest.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/common/event/AddressInfoUnitTest.kt
@@ -24,7 +24,7 @@ class AddressInfoUnitTest {
         const val ADDRESS = "127.0.0.1"
         const val PORT = "48494"
     }
-    private val info = AddressInfo(dns = "$ADDRESS:$PORT")
+    private val info = AddressInfo(dns = setOf("$ADDRESS:$PORT"))
 
     @Test
     fun givenPortInfo_whenNoConstructorArgs_portsAreNull() {
@@ -37,9 +37,9 @@ class AddressInfoUnitTest {
         result.onFailure { ex ->
             fail(cause = ex)
         }
-        result.onSuccess { pair ->
-            assertEquals(ADDRESS, pair?.first)
-            assertEquals(PORT.toInt(), pair?.second?.value)
+        result.onSuccess { set ->
+            assertEquals(ADDRESS, set.first().address)
+            assertEquals(PORT.toInt(), set.first().port.value)
         }
     }
 

--- a/library/manager/kmp-tor-manager/build.gradle.kts
+++ b/library/manager/kmp-tor-manager/build.gradle.kts
@@ -70,6 +70,7 @@ kmpConfiguration {
             dependencies {
                 implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.coroutines.core.core)
+                implementation(deps.kotlin.reflect)
                 implementation(project(":library:controller:kmp-tor-controller")) {
                     exclude(kmpPublishRootProjectConfiguration!!.group, "kmp-tor-common")
                     exclude(kmpPublishRootProjectConfiguration!!.group, "kmp-tor-controller-common")
@@ -79,8 +80,8 @@ kmpConfiguration {
         },
         commonTestSourceSet = {
             dependencies {
-                implementation(kotlin("test"))
                 implementation(depsTest.kotlin.coroutines)
+                implementation(kotlin("test"))
             }
         },
     )

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -26,6 +26,12 @@ import kotlin.jvm.JvmSynthetic
 
 expect abstract class KmpTorLoader {
 
+    /**
+     * Calls [TorConfig.Builder.removeInstanceOf] for all present
+     * settings. This is to ensure platform specific settings are
+     * removed during the [TorConfigProvider.retrieve] process, prior
+     * to starting Tor.
+     * */
     protected open val excludeSettings: Set<TorConfig.Setting<*>>
 
     @Throws(TorManagerException::class, CancellationException::class)

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -428,7 +428,7 @@ private class RealTorManager(
         return provide<TorControlConfigLoad, Any?> {
             // TODO: Check settings
             val result = configLoad(config)
-            config.settings.keys.checkNetworkState(this as TorController)
+            config.settings.checkNetworkState(this as TorController)
             result
         }
     }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/ext/AddressInfoExt.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/ext/AddressInfoExt.kt
@@ -21,8 +21,10 @@ import kotlin.jvm.JvmSynthetic
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.dnsOpened(value: String): AddressInfo? {
-    return if (dns != value) {
-        copy(dns = value)
+    val mDns = dns?.toMutableSet() ?: return copy(dns = setOf(value))
+
+    return if (mDns.add(value)) {
+        copy(dns = mDns.toSet())
     } else {
         null
     }
@@ -31,8 +33,14 @@ internal inline fun AddressInfo.dnsOpened(value: String): AddressInfo? {
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.dnsClosed(value: String): AddressInfo? {
-    return if (dns == value) {
-        copy(dns = null)
+    val mDns = dns?.toMutableSet() ?: return null
+
+    return if (mDns.remove(value)) {
+        if (mDns.isEmpty()) {
+            copy(dns = null)
+        } else {
+            copy(dns = mDns.toSet())
+        }
     } else {
         null
     }
@@ -41,8 +49,10 @@ internal inline fun AddressInfo.dnsClosed(value: String): AddressInfo? {
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.httpOpened(value: String): AddressInfo? {
-    return if (http != value) {
-        copy(http = value)
+    val mHttp = http?.toMutableSet() ?: return copy(http = setOf(value))
+
+    return if (mHttp.add(value)) {
+        copy(http = mHttp.toSet())
     } else {
         null
     }
@@ -51,8 +61,14 @@ internal inline fun AddressInfo.httpOpened(value: String): AddressInfo? {
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.httpClosed(value: String): AddressInfo? {
-    return if (http == value) {
-        copy(http = null)
+    val mHttp = http?.toMutableSet() ?: return null
+
+    return if (mHttp.remove(value)) {
+        if (mHttp.isEmpty()) {
+            copy(http = null)
+        } else {
+            copy(http = mHttp.toSet())
+        }
     } else {
         null
     }
@@ -61,8 +77,10 @@ internal inline fun AddressInfo.httpClosed(value: String): AddressInfo? {
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.socksOpened(value: String): AddressInfo? {
-    return if (socks != value) {
-        copy(socks = value)
+    val mSocks = socks?.toMutableSet() ?: return copy(socks = setOf(value))
+
+    return if (mSocks.add(value)) {
+        copy(socks = mSocks.toSet())
     } else {
         null
     }
@@ -71,8 +89,14 @@ internal inline fun AddressInfo.socksOpened(value: String): AddressInfo? {
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.socksClosed(value: String): AddressInfo? {
-    return if (socks == value) {
-        copy(socks = null)
+    val mSocks = socks?.toMutableSet() ?: return null
+
+    return if (mSocks.remove(value)) {
+        if (mSocks.isEmpty()) {
+            copy(socks = null)
+        } else {
+            copy(socks = mSocks.toSet())
+        }
     } else {
         null
     }
@@ -81,8 +105,10 @@ internal inline fun AddressInfo.socksClosed(value: String): AddressInfo? {
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.transOpened(value: String): AddressInfo? {
-    return if (trans != value) {
-        copy(trans = value)
+    val mTrans = trans?.toMutableSet() ?: return copy(trans = setOf(value))
+
+    return if (mTrans.add(value)) {
+        copy(trans = mTrans.toSet())
     } else {
         null
     }
@@ -91,8 +117,14 @@ internal inline fun AddressInfo.transOpened(value: String): AddressInfo? {
 @JvmSynthetic
 @Suppress("nothing_to_inline")
 internal inline fun AddressInfo.transClosed(value: String): AddressInfo? {
-    return if (trans == value) {
-        copy(trans = null)
+    val mTrans = trans?.toMutableSet() ?: return null
+
+    return if (mTrans.remove(value)) {
+        if (mTrans.isEmpty()) {
+            copy(trans = null)
+        } else {
+            copy(trans = mTrans.toSet())
+        }
     } else {
         null
     }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidator.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidator.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.manager.internal.util
+
+import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.AorDorPort
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.Ports
+
+internal class PortValidator internal constructor() {
+    private val configPorts: MutableSet<Ports> = mutableSetOf()
+    var hasControlPort = false
+        private set
+    var hasSocksPort = false
+        private set
+
+    fun add(port: Ports) {
+        if (port is Ports.Control) {
+            hasControlPort = true
+        } else if (port is Ports.Socks) {
+            hasSocksPort = true
+        }
+        configPorts.add(port)
+    }
+
+    @Suppress("unchecked_cast")
+    fun validate(isPortAvailable: (Port) -> Boolean): Set<Ports> {
+        if (!hasSocksPort) {
+            // Try to add default 9050 so we can validate that it is open
+            val socks = Ports.Socks()
+            if (!configPorts.add(socks)) {
+                // set to auto if another port type is set to 9050
+                socks.set(AorDorPort.Auto)
+                configPorts.add(socks)
+            }
+            hasSocksPort = true
+        }
+
+        val validatedPorts: MutableSet<Ports> = mutableSetOf()
+
+        for (port in configPorts) {
+            when (val option = port.value) {
+                is AorDorPort.Auto,
+                is AorDorPort.Disable -> {
+                    validatedPorts.add(port)
+                }
+                is AorDorPort.Value -> {
+                    if (isPortAvailable.invoke(option.port)) {
+                        validatedPorts.add(port)
+                    } else {
+                        // Unavailable. Set to auto
+                        validatedPorts.add(port.clone().set(AorDorPort.Auto) as Ports)
+                    }
+                }
+            }
+        }
+
+        if (!hasControlPort) {
+            validatedPorts.add(Ports.Control().set(AorDorPort.Auto) as Ports)
+        }
+
+        return validatedPorts
+    }
+}

--- a/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/ext/AddressInfoExtUnitTest.kt
+++ b/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/ext/AddressInfoExtUnitTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertTrue
 
 class AddressInfoExtUnitTest {
 
-    private val info = AddressInfo(socks = "127.0.0.1:9050")
+    private val info = AddressInfo(socks = setOf("127.0.0.1:9050"))
     private val nullInfo = AddressInfo()
 
     @Test

--- a/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
+++ b/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
@@ -16,7 +16,6 @@
 package io.matthewnelson.kmp.tor.manager.internal.util
 
 import io.matthewnelson.kmp.tor.common.address.Port
-import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.Ports
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.AorDorPort
 import kotlin.test.Test
@@ -28,25 +27,16 @@ class PortValidatorUnitTest {
     private val validator = PortValidator()
 
     @Test
-    fun givenDifferentConfigPortType_whenHasSamePorts_setsToAuto() {
+    fun givenPortWithValue_whenPortUnavailable_setsToAuto() {
         val port = Port(9150)
         val socks = Ports.Socks()
         socks.set(AorDorPort.Value(port))
-        val http = Ports.HttpTunnel()
-        http.set(AorDorPort.Value(port))
-
-        TorConfig.Builder {
-            put(socks)
-            put(http)
-        }
 
         validator.add(socks)
-        validator.add(http)
 
-        val validated = validator.validate { true }
+        val validated = validator.validate { false }
 
-        assertEquals(port, (validated.first().value as AorDorPort.Value).port)
-        assertEquals(AorDorPort.Auto, validated.elementAt(1).value)
+        assertEquals(AorDorPort.Auto, validated.first().value)
     }
 
     @Test

--- a/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
+++ b/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.manager.internal.util
+
+import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.Ports
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.AorDorPort
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class PortValidatorUnitTest {
+
+    private val validator = PortValidator()
+
+    @Test
+    fun givenDifferentConfigPortType_whenHasSamePorts_setsToAuto() {
+        val port = Port(9150)
+        val socks = Ports.Socks()
+        socks.set(AorDorPort.Value(port))
+        val http = Ports.HttpTunnel()
+        http.set(AorDorPort.Value(port))
+
+        TorConfig.Builder {
+            put(socks)
+            put(http)
+        }
+
+        validator.add(socks)
+        validator.add(http)
+
+        val validated = validator.validate { true }
+
+        assertEquals(port, (validated.first().value as AorDorPort.Value).port)
+        assertEquals(AorDorPort.Auto, validated.elementAt(1).value)
+    }
+
+    @Test
+    fun givenNoSocksPort_whenValidationCalled_socksPortIsAddedAndValidated() {
+        validator.add(Ports.HttpTunnel())
+        val validated = validator.validate { true }
+        val socks = validated.filterIsInstance<Ports.Socks>()
+        assertEquals(1, socks.size)
+        assertEquals(Ports.Socks(), socks.first())
+    }
+
+    @Test
+    fun givenNoSocksPort_when9050TakenAndValidationCalled_socksPortAutoIsAdded() {
+        val http = Ports.HttpTunnel()
+        val socks = Ports.Socks()
+        http.set(socks.default)
+
+        validator.add(http)
+        val validated = validator.validate { true }
+        val socksInstance = validated.filterIsInstance<Ports.Socks>()
+        assertEquals(AorDorPort.Auto, socksInstance.first().value)
+        assertNotEquals(socks, socksInstance.first())
+    }
+
+    @Test
+    fun givenNoControlPort_whenValidationCalled_controlPortIsAdded() {
+        val validated = validator.validate { true }
+        val controlPort = validated.filterIsInstance<Ports.Control>()
+        assertEquals(1, controlPort.size)
+        assertEquals(Ports.Control(), controlPort.first())
+    }
+}

--- a/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -20,15 +20,20 @@ import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
 import io.matthewnelson.kmp.tor.manager.internal.TorStateMachine
-import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.cancellation.CancellationException
 
 @Suppress("CanBePrimaryConstructorProperty")
 actual abstract class KmpTorLoader(provider: TorConfigProvider) {
 
-    private val provider = provider
+    /**
+     * Calls [TorConfig.Builder.removeInstanceOf] for all present
+     * settings. This is to ensure platform specific settings are
+     * removed during the [TorConfigProvider.retrieve] process, prior
+     * to starting Tor.
+     * */
     protected actual open val excludeSettings: Set<TorConfig.Setting<*>> = emptySet()
+    private val provider = provider
     internal actual open suspend fun load(
         managerScope: CoroutineScope,
         stateMachine: TorStateMachine,

--- a/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
+++ b/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
@@ -39,12 +39,42 @@ class SampleApp: Application() {
         val configProvider = object : TorConfigProviderAndroid(context = this@SampleApp) {
             override fun provide(): TorConfig {
                 return TorConfig.Builder {
-                    // Any conflicting or unavailable ports provided will fall
-                    // back to "auto".
-                    put(Ports.Socks().set(AorDorPort.Value(Port(9150))))
-                    put(Ports.HttpTunnel().set(AorDorPort.Value(Port(9150))))
-                    put(Ports.Dns().set(AorDorPort.Value(Port(9150))))
-                    put(Ports.Trans().set(AorDorPort.Value(Port(9150))))
+                    // Set multiple ports for all of the things
+                    val dns = Ports.Dns()
+                    put(dns.set(AorDorPort.Value(Port(9252))))
+                    put(dns.set(AorDorPort.Value(Port(9253))))
+
+                    val socks = Ports.Socks()
+                    put(socks.set(AorDorPort.Value(Port(9254))))
+                    put(socks.set(AorDorPort.Value(Port(9255))))
+
+                    val http = Ports.HttpTunnel()
+                    put(http.set(AorDorPort.Value(Port(9258))))
+                    put(http.set(AorDorPort.Value(Port(9259))))
+
+                    val trans = Ports.Trans()
+                    put(trans.set(AorDorPort.Value(Port(9262))))
+                    put(trans.set(AorDorPort.Value(Port(9263))))
+
+                    // If a Port is already taken (9263) for any Port type (trans), it
+                    // will not be added and the Ports type set first (trans) will take
+                    // precedent.
+                    put(socks.set(AorDorPort.Value(Port(9263))))
+
+                    // Set Flags
+                    socks.setFlags(setOf(
+                        Ports.Socks.Flag.OnionTrafficOnly
+                    )).setIsolationFlags(setOf(
+                        Ports.IsolationFlag.IsolateClientAddr
+                    )).set(AorDorPort.Value(Port(9264)))
+                    put(socks)
+
+                    // reset our socks object to defaults
+                    socks.setDefault()
+
+                    // Not necessary, as if ControlPort is missing it will be
+                    // automatically added for you; but for demonstration purposes...
+                    put(Ports.Control().set(AorDorPort.Auto))
 
                     // For Android, disabling & reducing connection padding is
                     // advisable to minimize mobile data usage.

--- a/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
+++ b/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
@@ -56,9 +56,9 @@ class SampleApp: Application() {
                     put(trans.set(AorDorPort.Value(Port(9262))))
                     put(trans.set(AorDorPort.Value(Port(9263))))
 
-                    // If a Port is already taken (9263) for any Port type (trans), it
-                    // will not be added and the Ports type set first (trans) will take
-                    // precedent.
+                    // If a port (9263) is already taken (by ^^^^ trans port above)
+                    // this will take its place and "overwrite" the trans port entry
+                    // because port 9263 is taken.
                     put(socks.set(AorDorPort.Value(Port(9263))))
 
                     // Set Flags

--- a/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
+++ b/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
@@ -105,9 +105,9 @@ class SampleApp: App(SampleView::class) {
                     put(trans.set(AorDorPort.Value(Port(9262))))
                     put(trans.set(AorDorPort.Value(Port(9263))))
 
-                    // If a Port is already taken (9263) for any Port type (trans), it
-                    // will not be added and the Ports type set first (trans) will take
-                    // precedent.
+                    // If a port (9263) is already taken (by ^^^^ trans port above)
+                    // this will take its place and "overwrite" the trans port entry
+                    // because port 9263 is taken.
                     put(socks.set(AorDorPort.Value(Port(9263))))
 
                     // Set Flags

--- a/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
+++ b/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
@@ -88,12 +88,42 @@ class SampleApp: App(SampleView::class) {
 
             override fun provide(): TorConfig {
                 return TorConfig.Builder {
-                    // Any conflicting or unavailable ports provided will fall
-                    // back to "auto".
-                    put(Ports.Socks().set(AorDorPort.Value(Port(9150))))
-                    put(Ports.HttpTunnel().set(AorDorPort.Value(Port(9150))))
-                    put(Ports.Dns().set(AorDorPort.Value(Port(9150))))
-                    put(Ports.Trans().set(AorDorPort.Value(Port(9150))))
+                    // Set multiple ports for all of the things
+                    val dns = Ports.Dns()
+                    put(dns.set(AorDorPort.Value(Port(9252))))
+                    put(dns.set(AorDorPort.Value(Port(9253))))
+
+                    val socks = Ports.Socks()
+                    put(socks.set(AorDorPort.Value(Port(9254))))
+                    put(socks.set(AorDorPort.Value(Port(9255))))
+
+                    val http = Ports.HttpTunnel()
+                    put(http.set(AorDorPort.Value(Port(9258))))
+                    put(http.set(AorDorPort.Value(Port(9259))))
+
+                    val trans = Ports.Trans()
+                    put(trans.set(AorDorPort.Value(Port(9262))))
+                    put(trans.set(AorDorPort.Value(Port(9263))))
+
+                    // If a Port is already taken (9263) for any Port type (trans), it
+                    // will not be added and the Ports type set first (trans) will take
+                    // precedent.
+                    put(socks.set(AorDorPort.Value(Port(9263))))
+
+                    // Set Flags
+                    socks.setFlags(setOf(
+                        Ports.Socks.Flag.OnionTrafficOnly
+                    )).setIsolationFlags(setOf(
+                        Ports.IsolationFlag.IsolateClientAddr
+                    )).set(AorDorPort.Value(Port(9264)))
+                    put(socks)
+
+                    // reset our socks object to defaults
+                    socks.setDefault()
+
+                    // Not necessary, as if ControlPort is missing it will be
+                    // automatically added for you; but for demonstration purposes...
+                    put(Ports.Control().set(AorDorPort.Auto))
 
                     // Tor defaults this setting to false which would mean if
                     // Tor goes dormant (default is after 24h), the next time it


### PR DESCRIPTION
This PR:
 - Refactors `TorConfig` to enable submitting of multiple `TorConfig.Setting` of certain types with differing values (in this case, `TorConfig.Setting.Ports`)
 - Refactors `TorConfig.Builder` methods.
 - Refactors `TorManagerEvent.AddressInfo` to hold multiple ports for their given types (dns/http/socks/trans)

Closes #36 