### PR TITLE
`TorService` configuration modifications

### DIFF
--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/TorServiceConfig.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/TorServiceConfig.kt
@@ -213,8 +213,9 @@ private class RealTorServiceConfig(context: Context): TorServiceConfig() {
             }
         }
 
+        stopServiceOnTaskRemoved = meta?.getBoolean(KEY_STOP_SERVICE_ON_TASK_REMOVED, true) ?: true
+
         if (!enableForeground) {
-            stopServiceOnTaskRemoved = true
             notificationId = 0
             channelId = ""
             channelName = ""
@@ -247,8 +248,6 @@ private class RealTorServiceConfig(context: Context): TorServiceConfig() {
                     """.trimIndent()
                 )
             }
-
-            stopServiceOnTaskRemoved = meta.getBoolean(KEY_STOP_SERVICE_ON_TASK_REMOVED, true)
 
             notificationId = meta.getInt(KEY_NOTIFICATION_ID, 0).let { id ->
                 if (id !in 1..9999) {

--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorService.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/TorService.kt
@@ -126,8 +126,7 @@ internal class TorService: Service() {
             }
         }
 
-        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
-        override fun onActivityStarted(activity: Activity) {
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
             if (isTaskRemoved) {
                 isTaskRemoved = false
                 when (lastAction) {
@@ -136,14 +135,15 @@ internal class TorService: Service() {
 
                     is TorManagerEvent.Action.Restart,
                     is TorManagerEvent.Action.Start -> {
-                        TorServiceController.notify(
-                            TorManagerEvent.Lifecycle(application ?: activity, ON_TASK_RETURNED)
-                        )
                         startQuietly?.second?.invoke()
                     }
                 }
+                TorServiceController.notify(
+                    TorManagerEvent.Lifecycle(application ?: activity, ON_TASK_RETURNED)
+                )
             }
         }
+        override fun onActivityStarted(activity: Activity) {}
         override fun onActivityResumed(activity: Activity) {}
         override fun onActivityPaused(activity: Activity) {}
         override fun onActivityStopped(activity: Activity) {}

--- a/samples/android/src/main/res/values/attrs.xml
+++ b/samples/android/src/main/res/values/attrs.xml
@@ -47,10 +47,14 @@
     Default: true
 
     If set to `false`, when the user swipes your application from the recent app's
-    tray, the service will continue running.
+    tray, stop service will not be called.
 
-    It is highly advisable to, if setting this option to `false`, also enable the
-    stop notification action.
+    This can be useful if:
+      - You are running TorService in the background, with another
+        service that is running in the Foreground keeping the application alive
+        past task removal.
+      - You are running TorService in the foreground and wish to keep the application
+        alive until an explicit call to `stop` Tor is made.
     -->
     <bool name="tor_service_stop_service_on_task_removed">false</bool>
 


### PR DESCRIPTION
 - Config option `stop_service_on_task_removed` can now be set regardless of `enable_foreground` being true or false.
 - Adds check to notification for if the service is destroyed or not as a fallback.

Closes #38 