### PR TITLE
Adds TorManagerEvent to proc one time start up operations

### DIFF
--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
@@ -212,7 +212,7 @@ sealed interface TorManagerEvent {
     }
 
     /**
-     * Will be issued a single time for a given Tor instance start operation
+     * Will be dispatched a single time for a given Tor instance start operation
      * after bootstrapping has been completed. This can be relied on to perform
      * one time operations, such as adding hidden services and client auth keys.
      *

--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
@@ -216,8 +216,8 @@ sealed interface TorManagerEvent {
      * after bootstrapping has been completed. This can be relied on to perform
      * one time operations, such as adding hidden services and client auth keys.
      *
-     * A new [StartUpCompleteForTorInstance] will be issued in the event Tor is
-     * stopped or restarted, and completes it's bootstrapping process.
+     * A new [StartUpCompleteForTorInstance] will be dispatched in the event Tor
+     * is stopped, then started again and completes it's bootstrapping process.
      * */
     object StartUpCompleteForTorInstance: TorManagerEvent {
         override fun toString(): String {

--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
@@ -211,6 +211,16 @@ sealed interface TorManagerEvent {
         }
     }
 
+    /**
+     * Will be issued a single time for a given Tor instance start operation
+     * after bootstrapping has been completed. This can be relied on to perform
+     * one time operations, such as adding hidden services and client auth keys.
+     *
+     * A new [StartUpCompleteForTorInstance] will be issued in the event Tor is
+     * stopped or restarted, and completes it's bootstrapping process.
+     * */
+    object StartUpCompleteForTorInstance: TorManagerEvent
+
     data class State(val torState: TorState, val networkState: TorNetworkState): TorManagerEvent {
         inline val isOff: Boolean get() = torState.isOff()
         inline val isOn: Boolean get() = torState.isOn()
@@ -242,6 +252,7 @@ sealed interface TorManagerEvent {
         open fun managerEventInfo(message: String) {}
         open fun managerEventWarn(message: String) {}
         open fun managerEventLifecycle(lifecycle: Lifecycle<*>) {}
+        open fun managerEventStartUpCompleteForTorInstance() {}
         open fun managerEventState(state: State) {}
 
         override fun onEvent(event: TorManagerEvent) {
@@ -256,6 +267,7 @@ sealed interface TorManagerEvent {
                 is Log.Info -> managerEventInfo(event.value)
                 is Log.Warn -> managerEventWarn(event.value)
                 is Lifecycle<*> -> managerEventLifecycle(event)
+                is StartUpCompleteForTorInstance -> managerEventStartUpCompleteForTorInstance()
                 is State -> managerEventState(event)
             }
         }

--- a/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
+++ b/library/manager/kmp-tor-manager-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/common/event/TorManagerEvent.kt
@@ -219,7 +219,11 @@ sealed interface TorManagerEvent {
      * A new [StartUpCompleteForTorInstance] will be issued in the event Tor is
      * stopped or restarted, and completes it's bootstrapping process.
      * */
-    object StartUpCompleteForTorInstance: TorManagerEvent
+    object StartUpCompleteForTorInstance: TorManagerEvent {
+        override fun toString(): String {
+            return "StartUpCompleteForTorInstance"
+        }
+    }
 
     data class State(val torState: TorState, val networkState: TorNetworkState): TorManagerEvent {
         inline val isOff: Boolean get() = torState.isOff()

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -573,7 +573,7 @@ private class RealTorManager(
                     )
                 }
 
-                controller.value?.let {
+                controller.value?.first?.let {
                     notifyListenersNoScope(Controller)
                     block.invoke(it as T)
                 } ?: Result.failure(TorNotStartedException("Tor is not started"))

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -165,7 +165,7 @@ private class RealTorManager(
         networkObserver?.attach { connectivity ->
             when (connectivity) {
                 NetworkObserver.Connectivity.Connected -> {
-                    controller.value?.let { controller ->
+                    controller.value?.first?.let { controller ->
                         networkObserverJob.update { job ->
                             job?.cancel()
                             scope.launch {
@@ -182,7 +182,7 @@ private class RealTorManager(
                     }
                 }
                 NetworkObserver.Connectivity.Disconnected -> {
-                    controller.value?.let { controller ->
+                    controller.value?.first?.let { controller ->
                         networkObserverJob.update { job ->
                             job?.cancel()
                             scope.launch {
@@ -204,18 +204,34 @@ private class RealTorManager(
         loader
     }
     private val actions: ActionProcessor = ActionProcessor.newInstance(useStaticLock = true)
-    private val controller: AtomicRef<TorController?> = atomic(null)
+    private val controller: AtomicRef<Pair<
+        TorController,
+        TorManagerEvent.StartUpCompleteForTorInstance?
+    >?> = atomic(null)
 
     // State should be dispatched immediately. as such, only update state machine
     // from Dispatchers.Main
     private val stateMachine: TorStateMachine = TorStateMachine.newInstance { old, new ->
         notifyListenersNoScope(new)
+
         addressInfo.update { info ->
             info.onStateChange(old, new)?.let { newInfo ->
                 addressInfoJob.value?.cancel()
                 notifyListenersNoScope(newInfo)
                 newInfo
             } ?: info
+        }
+
+        // Bootstrapping completed
+        if (!old.torState.isBootstrapped && new.torState.isBootstrapped && new.isNetworkEnabled) {
+            controller.update { pair ->
+                if (pair == null) return@update null
+                if (pair.second != null) return@update pair
+
+                notifyListenersNoScope(TorManagerEvent.StartUpCompleteForTorInstance)
+
+                Pair(pair.first, TorManagerEvent.StartUpCompleteForTorInstance)
+            }
         }
     }
     override val state: TorState get() = stateMachine.state
@@ -231,7 +247,7 @@ private class RealTorManager(
             networkObserver?.detach()
 
             if (!stopCleanly) {
-                controller.value?.disconnect()
+                controller.value?.first?.disconnect()
                 supervisor.cancel()
                 loader.close()
 
@@ -252,7 +268,7 @@ private class RealTorManager(
                 CoroutineName(name ="${Stop}_${coroutineCounter.getAndIncrement()}")
             ) {
                 actions.withProcessorLock(Stop) {
-                    controller.value?.let { controller ->
+                    controller.value?.first?.let { controller ->
                         realStop(controller, isRestart = false)
                     } ?: Result.success("Tor was already stopped")
                 }
@@ -343,7 +359,7 @@ private class RealTorManager(
                     )
                 }
 
-                controller.value?.let { controller ->
+                controller.value?.first?.let { controller ->
                     realStop(controller, isRestart = true)
 
                     if ((actions as ActionQueue).contains(Stop)) {
@@ -403,7 +419,7 @@ private class RealTorManager(
                     )
                 }
 
-                controller.value?.let {
+                controller.value?.first?.let {
                     realStop(it, false)
                 } ?: run {
                     loader.close()
@@ -776,7 +792,7 @@ private class RealTorManager(
     }
 
     private suspend fun realStart(isRestart: Boolean = false): Result<Any?> {
-        if (controller.value?.isConnected == true && state is TorState.On) {
+        if (controller.value?.first?.isConnected == true && state is TorState.On) {
             return Result.success("Tor is already started")
         }
 
@@ -855,7 +871,7 @@ private class RealTorManager(
             notifyListenersNoScope(TorManagerEvent.Log.Warn(WAITING_ON_NETWORK))
         }
 
-        this.controller.value = controller
+        this.controller.value = Pair(controller, null)
         stateMachine.updateState(TorState.On(state.bootstrap))
 
         return Result.success("Tor started successfully")


### PR DESCRIPTION
- Adds the TorManagerEvent `StartUpCompleteForTorInstance` such that listeners can be trigger one time start up operations for the given instance of Tor.
- Refactors the Android notification to a `TorManagerEvent.Listener` instead of a `TorManagerEvent.SealedListener`

Closes #51 