### PR TITLE
Return `Result.Success` from `TorController` on `25x` coded replies

### DIFF
--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -600,6 +600,7 @@ private class RealTorControlProcessor(
                 val command = StringBuilder("ONION_CLIENT_AUTH_REMOVE")
                     .append(SP)
                     .append(address.value)
+                    .append(CLRF)
                     .toString()
 
                 Result.success(processCommand(command))

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/controller/ReplyLine.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/controller/ReplyLine.kt
@@ -26,7 +26,7 @@ sealed class ReplyLine {
         override val status: String,
         val message: String
     ): ReplyLine() {
-        inline val isCommandResponseStatusSuccess: Boolean get() = status == "250"
+        inline val isCommandResponseStatusSuccess: Boolean get() = status.startsWith("25")
         inline val isEventStatusSuccess: Boolean get() = status == "650" && message == "OK"
     }
 


### PR DESCRIPTION
This also fixes a big with the `clientAuthRemove` call, as it was not appending `CLRF` to the command when being built which was resulting in an incorrectly escaped command being sent to Tor.

Closes #62 