### PR TITLE
Fixes declared `Port` minimum

### DIFF
--- a/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.kmp.tor.controller.common.config
 
 import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.common.address.PortProxy
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.file.Path
@@ -139,7 +140,7 @@ class TorConfigUnitTest {
     fun givenDifferentPortTypes_whenSamePort_areEqual() {
         val http = Ports.HttpTunnel()
         val socks = Ports.Socks()
-        val port = AorDorPort.Value(Port(9150))
+        val port = AorDorPort.Value(PortProxy(9150))
         http.set(port)
         socks.set(port)
 
@@ -169,7 +170,7 @@ class TorConfigUnitTest {
         val tunnelPort = Ports.HttpTunnel()
         val auto = AorDorPort.Auto
         val disabled = AorDorPort.Disable
-        val portValue = AorDorPort.Value(Port(9150))
+        val portValue = AorDorPort.Value(PortProxy(9150))
 
         val config = TorConfig.Builder {
             put(tunnelPort.set(auto))
@@ -196,7 +197,7 @@ class TorConfigUnitTest {
         val tunnelPort = Ports.HttpTunnel()
         val auto = AorDorPort.Auto
         val disabled = AorDorPort.Disable
-        val portValue = AorDorPort.Value(Port(9150))
+        val portValue = AorDorPort.Value(PortProxy(9150))
 
         val config = TorConfig.Builder {
             put(tunnelPort.set(auto))
@@ -273,7 +274,7 @@ class TorConfigUnitTest {
 
     @Test
     fun givenSamePortSettings_whenValuesDifferent_settingsAreNotEquals() {
-        val control1 = Ports.Control().set(AorDorPort.Value(Port(9051)))
+        val control1 = Ports.Control().set(AorDorPort.Value(PortProxy(9051)))
         val control2 = control1.clone().set(AorDorPort.Auto)
 
         assertNotEquals(control1, control2)
@@ -283,7 +284,7 @@ class TorConfigUnitTest {
     @Test
     fun givenPort_whenCloned_originalPortSettingsNotAffectedByModification() {
         val socks1 = Ports.Socks()
-        socks1.set(AorDorPort.Value(Port(9150)))
+        socks1.set(AorDorPort.Value(PortProxy(9150)))
 
         val socks2 = socks1.clone()
         socks2.set(AorDorPort.Auto)
@@ -297,8 +298,8 @@ class TorConfigUnitTest {
 
         val (hs1, hs2) = Pair(HiddenService(), HiddenService())
 
-        hs1.setPorts(setOf(HiddenService.Ports(11)))
-        hs2.setPorts(setOf(HiddenService.Ports(22)))
+        hs1.setPorts(setOf(HiddenService.Ports(Port(11))))
+        hs2.setPorts(setOf(HiddenService.Ports(Port(22))))
 
         hs1.setMaxStreams(HiddenService.MaxStreams(1))
         hs2.setMaxStreams(HiddenService.MaxStreams(2))
@@ -319,7 +320,7 @@ class TorConfigUnitTest {
     fun givenHiddenService_whenCloned_matchesOriginal() {
         val expectedHs = HiddenService()
         val expectedDir = FileSystemDir(Path("/some_dir"))
-        val expectedPorts = setOf(HiddenService.Ports(11))
+        val expectedPorts = setOf(HiddenService.Ports(Port(11)))
         val expectedMaxStreams = HiddenService.MaxStreams(1)
         val expectedMaxStreamsCloseCircuit = TorF.True
 

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -482,9 +482,9 @@ private class RealTorControlProcessor(
                     for (hsPort in hsPorts) {
                         append(SP)
                         append("Port=")
-                        append(hsPort.virtualPort)
+                        append(hsPort.virtualPort.value)
                         append(',')
-                        append(hsPort.targetPort)
+                        append(hsPort.targetPort.value)
                     }
                 }
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/PortProxy.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/PortProxy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Matthew Nelson
+ * Copyright (c) 2022 Matthew Nelson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,27 +19,26 @@ import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmStatic
 
 /**
- * Holder for a valid port between 0 and 65535
+ * Holder for a valid proxy port between 1024 and 65535
  *
  * @throws [IllegalArgumentException] if port is not valid
  * */
 @JvmInline
-value class Port(val value: Int) {
+value class PortProxy(val value: Int) {
 
     init {
-        require(value in MIN..MAX) {
-            "Invalid port range. Must be between $MIN and $MAX"
+        require(value in MIN..Port.MAX) {
+            "Invalid port range. Must be between $MIN and ${Port.MAX}"
         }
     }
 
     companion object {
-        const val MIN = 0
-        const val MAX = 65535
+        const val MIN = 1024
 
         @JvmStatic
-        fun fromIntOrNull(port: Int?): Port? {
+        fun fromIntOrNull(port: Int?): PortProxy? {
             return try {
-                Port(port ?: return null)
+                PortProxy(port ?: return null)
             } catch (_: IllegalArgumentException) {
                 null
             }

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvmIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/KmpTorLoaderJvmIntegrationTest.kt
@@ -15,7 +15,7 @@
  **/
 package io.matthewnelson.kmp.tor
 
-import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.common.address.PortProxy
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
@@ -28,34 +28,34 @@ class KmpTorLoaderJvmIntegrationTest: TorTestHelper() {
     override fun testConfig(testProvider: TorConfigProviderJvm): TorConfig {
         return TorConfig.Builder {
             val control = Ports.Control()
-            put(control.set(AorDorPort.Value(Port(9150))))
-            put(control.set(AorDorPort.Value(Port(9151))))
-            put(control.set(AorDorPort.Value(Port(9152))))
-            put(control.set(AorDorPort.Value(Port(9153))))
+            put(control.set(AorDorPort.Value(PortProxy(9150))))
+            put(control.set(AorDorPort.Value(PortProxy(9151))))
+            put(control.set(AorDorPort.Value(PortProxy(9152))))
+            put(control.set(AorDorPort.Value(PortProxy(9153))))
 
             val dns = Ports.Dns()
-            put(dns.set(AorDorPort.Value(Port(9154))))
-            put(dns.set(AorDorPort.Value(Port(9155))))
-            put(dns.set(AorDorPort.Value(Port(9156))))
-            put(dns.set(AorDorPort.Value(Port(9157))))
+            put(dns.set(AorDorPort.Value(PortProxy(9154))))
+            put(dns.set(AorDorPort.Value(PortProxy(9155))))
+            put(dns.set(AorDorPort.Value(PortProxy(9156))))
+            put(dns.set(AorDorPort.Value(PortProxy(9157))))
 
             val socks = Ports.Socks()
-            put(socks.set(AorDorPort.Value(Port(9158))))
-            put(socks.set(AorDorPort.Value(Port(9159))))
-            put(socks.set(AorDorPort.Value(Port(9160))))
-            put(socks.set(AorDorPort.Value(Port(9161))))
+            put(socks.set(AorDorPort.Value(PortProxy(9158))))
+            put(socks.set(AorDorPort.Value(PortProxy(9159))))
+            put(socks.set(AorDorPort.Value(PortProxy(9160))))
+            put(socks.set(AorDorPort.Value(PortProxy(9161))))
 
             val http = Ports.HttpTunnel()
-            put(http.set(AorDorPort.Value(Port(9162))))
-            put(http.set(AorDorPort.Value(Port(9163))))
-            put(http.set(AorDorPort.Value(Port(9164))))
-            put(http.set(AorDorPort.Value(Port(9165))))
+            put(http.set(AorDorPort.Value(PortProxy(9162))))
+            put(http.set(AorDorPort.Value(PortProxy(9163))))
+            put(http.set(AorDorPort.Value(PortProxy(9164))))
+            put(http.set(AorDorPort.Value(PortProxy(9165))))
 
             val trans = Ports.Trans()
-            put(trans.set(AorDorPort.Value(Port(9166))))
-            put(trans.set(AorDorPort.Value(Port(9167))))
-            put(trans.set(AorDorPort.Value(Port(9168))))
-            put(trans.set(AorDorPort.Value(Port(9169))))
+            put(trans.set(AorDorPort.Value(PortProxy(9166))))
+            put(trans.set(AorDorPort.Value(PortProxy(9167))))
+            put(trans.set(AorDorPort.Value(PortProxy(9168))))
+            put(trans.set(AorDorPort.Value(PortProxy(9169))))
 
             put(ClientOnionAuthDir().set(FileSystemDir(
                 testProvider.workDir.builder { addSegment(ClientOnionAuthDir.DEFAULT_NAME) }

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.tor.controller
 import io.matthewnelson.kmp.tor.common.address.OnionAddress
 import io.matthewnelson.kmp.tor.common.address.OnionAddressV3
 import io.matthewnelson.kmp.tor.common.address.OnionAddressV3PrivateKey_ED25519
+import io.matthewnelson.kmp.tor.common.address.Port
 import io.matthewnelson.kmp.tor.common.clientauth.ClientName
 import io.matthewnelson.kmp.tor.common.clientauth.OnionClientAuthPrivateKey_B32_X25519
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
@@ -172,10 +173,10 @@ class TorControllerIntegrationTest: TorTestHelper() {
         val entry = manager.onionAddNew(
             type = OnionAddress.PrivateKey.Type.ED25519_V3,
             hsPorts = setOf(
-                TorConfig.Setting.HiddenService.Ports(virtualPort = 8761, targetPort = 8760),
-                TorConfig.Setting.HiddenService.Ports(virtualPort = 8762, targetPort = 8760),
-                TorConfig.Setting.HiddenService.Ports(virtualPort = 8763, targetPort = 8760),
-                TorConfig.Setting.HiddenService.Ports(virtualPort = 8764, targetPort = 8760),
+                TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8761), targetPort = Port(8760)),
+                TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8762), targetPort = Port(8760)),
+                TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8763), targetPort = Port(8760)),
+                TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8764), targetPort = Port(8760)),
             ),
             flags = setOf(
                 TorControlOnionAdd.Flag.MaxStreamsCloseCircuit,
@@ -196,7 +197,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
             val entry = manager.onionAdd(
                 privateKey = OnionAddressV3PrivateKey_ED25519("gGNRsNtSKe38fPr/J1UW2nOCNetZNl3qNySlPs9M5Fait1VVruWEBOoNU7fuPRkC4yrS1G7f/VjohBdzKTIQ6Q"),
                 hsPorts = setOf(
-                    TorConfig.Setting.HiddenService.Ports(virtualPort = 8770, targetPort = 8770),
+                    TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8770), targetPort = Port(8770)),
                 ),
                 flags = setOf(
                     TorControlOnionAdd.Flag.DiscardPK,
@@ -236,14 +237,14 @@ class TorControllerIntegrationTest: TorTestHelper() {
         val entry = manager.onionAddNew(
             type = OnionAddress.PrivateKey.Type.ED25519_V3,
             hsPorts = setOf(
-                TorConfig.Setting.HiddenService.Ports(virtualPort = 8771, targetPort = 8770),
+                TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8771), targetPort = Port(8770)),
             ),
         ).getOrThrow()
 
         val result = manager.onionAdd(
             privateKey = entry.privateKey!!,
             hsPorts = setOf(
-                TorConfig.Setting.HiddenService.Ports(virtualPort = 8772, targetPort = 8770),
+                TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8772), targetPort = Port(8770)),
             ),
         )
 

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
@@ -20,6 +20,7 @@ import io.matthewnelson.kmp.tor.PlatformInstaller
 import io.matthewnelson.kmp.tor.PlatformInstaller.InstallOption
 import io.matthewnelson.kmp.tor.TorConfigProviderJvm
 import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.common.address.PortProxy
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
@@ -85,15 +86,15 @@ abstract class TorTestHelper {
 
     protected open fun testConfig(testProvider: TorConfigProviderJvm): TorConfig {
         return TorConfig.Builder {
-            put(Ports.Control().set(AorDorPort.Value(Port(9155))))
+            put(Ports.Control().set(AorDorPort.Value(PortProxy(9155))))
             put(Ports.Socks().set(AorDorPort.Auto))
             put(Ports.HttpTunnel().set(AorDorPort.Auto))
             put(Ports.Trans().set(AorDorPort.Auto))
 
             put(HiddenService()
                 .setPorts(ports = setOf(
-                    HiddenService.Ports(virtualPort = 1025, targetPort = 1027),
-                    HiddenService.Ports(virtualPort = 1026, targetPort = 1027)
+                    HiddenService.Ports(virtualPort = Port(1025), targetPort = Port(1027)),
+                    HiddenService.Ports(virtualPort = Port(1026), targetPort = Port(1027))
                 ))
                 .setMaxStreams(maxStreams = HiddenService.MaxStreams(value = 2))
                 .setMaxStreamsCloseCircuit(value = TorF.True)
@@ -107,8 +108,8 @@ abstract class TorTestHelper {
 
             put(HiddenService()
                 .setPorts(ports = setOf(
-                    HiddenService.Ports(virtualPort = 1028, targetPort = 1030),
-                    HiddenService.Ports(virtualPort = 1029, targetPort = 1030)
+                    HiddenService.Ports(virtualPort = Port(1028), targetPort = Port(1030)),
+                    HiddenService.Ports(virtualPort = Port(1029), targetPort = Port(1030))
                 ))
                 .set(FileSystemDir(
                     testProvider.workDir.builder {

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidator.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidator.kt
@@ -57,7 +57,7 @@ internal class PortValidator internal constructor() {
                     validatedPorts.add(port)
                 }
                 is AorDorPort.Value -> {
-                    if (isPortAvailable.invoke(option.port)) {
+                    if (isPortAvailable.invoke(Port(option.port.value))) {
                         validatedPorts.add(port)
                     } else {
                         // Unavailable. Set to auto

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
@@ -38,13 +38,13 @@ expect object PortUtil {
      *   9050 to 9100
      *
      * ex2: (port = Port(65535), limit = 50) will check availability from
-     *   65535, and 1024 to 1073
+     *   65535, and 0 to 48
      *
      * If the initial [port] is available, it will be returned.
      *
      * @throws [RuntimeException] if:
      *   - [limit] has been reached
-     *   - [limit] is less than 1
+     *   - [limit] is less than 1 or greater than 65535
      *   - called from Android's Main Thread.
      * */
     @JvmStatic

--- a/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
+++ b/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
@@ -15,7 +15,7 @@
  **/
 package io.matthewnelson.kmp.tor.manager.internal.util
 
-import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.common.address.PortProxy
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.Ports
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.AorDorPort
 import kotlin.test.Test
@@ -28,7 +28,7 @@ class PortValidatorUnitTest {
 
     @Test
     fun givenPortWithValue_whenPortUnavailable_setsToAuto() {
-        val port = Port(9150)
+        val port = PortProxy(9150)
         val socks = Ports.Socks()
         socks.set(AorDorPort.Value(port))
 

--- a/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -15,7 +15,6 @@
  **/
 package io.matthewnelson.kmp.tor.manager
 
-import io.matthewnelson.kmp.tor.common.address.Port
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.controller.TorController
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig

--- a/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
+++ b/library/manager/kmp-tor-manager/src/jvmCommonMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
@@ -53,28 +53,24 @@ actual object PortUtil {
      *   9050 to 9100
      *
      * ex2: (port = Port(65535), limit = 50) will check availability from
-     *   65535, and 1024 to 1073
+     *   65535, and 0 to 48
      *
      * If the initial [port] is available, it will be returned.
      *
      * @throws [RuntimeException] if:
      *   - [limit] has been reached
-     *   - [limit] is less than 1
+     *   - [limit] is less than 1 or greater than 65535
      *   - called from Android's Main Thread.
      * */
     @JvmStatic
     @Throws(RuntimeException::class)
     actual fun findNextAvailableTcpPort(port: Port, limit: Int): Port {
-        if (limit < 1) {
+        if (limit !in 1..Port.MAX) {
             throw RuntimeException("limit must be greater than or equal to 1")
         }
 
         var currentPort = port.value
-        var countDown = if (limit > Port.MAX - Port.MIN) {
-            Port.MAX - Port.MIN
-        } else {
-            limit
-        }
+        var countDown = limit
 
         while (countDown >= 0) {
             try {

--- a/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
+++ b/library/manager/kmp-tor-manager/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
@@ -38,13 +38,13 @@ actual object PortUtil {
      *   9050 to 9100
      *
      * ex2: (port = Port(65535), limit = 50) will check availability from
-     *   65535, and 1024 to 1073
+     *   65535, and 0 to 48
      *
      * If the initial [port] is available, it will be returned.
      *
      * @throws [RuntimeException] if:
      *   - [limit] has been reached
-     *   - [limit] is less than 1
+     *   - [limit] is less than 1 or greater than 65535
      *   - called from Android's Main Thread.
      * */
     @Throws(RuntimeException::class)

--- a/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
+++ b/samples/android/src/main/java/io/matthewnelson/kmp/tor/sample/android/SampleApp.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.MutableLiveData
 import io.matthewnelson.kmp.tor.TorConfigProviderAndroid
 import io.matthewnelson.kmp.tor.KmpTorLoaderAndroid
 import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.common.address.PortProxy
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
@@ -46,32 +47,32 @@ class SampleApp: Application() {
                 return TorConfig.Builder {
                     // Set multiple ports for all of the things
                     val dns = Ports.Dns()
-                    put(dns.set(AorDorPort.Value(Port(9252))))
-                    put(dns.set(AorDorPort.Value(Port(9253))))
+                    put(dns.set(AorDorPort.Value(PortProxy(9252))))
+                    put(dns.set(AorDorPort.Value(PortProxy(9253))))
 
                     val socks = Ports.Socks()
-                    put(socks.set(AorDorPort.Value(Port(9254))))
-                    put(socks.set(AorDorPort.Value(Port(9255))))
+                    put(socks.set(AorDorPort.Value(PortProxy(9254))))
+                    put(socks.set(AorDorPort.Value(PortProxy(9255))))
 
                     val http = Ports.HttpTunnel()
-                    put(http.set(AorDorPort.Value(Port(9258))))
-                    put(http.set(AorDorPort.Value(Port(9259))))
+                    put(http.set(AorDorPort.Value(PortProxy(9258))))
+                    put(http.set(AorDorPort.Value(PortProxy(9259))))
 
                     val trans = Ports.Trans()
-                    put(trans.set(AorDorPort.Value(Port(9262))))
-                    put(trans.set(AorDorPort.Value(Port(9263))))
+                    put(trans.set(AorDorPort.Value(PortProxy(9262))))
+                    put(trans.set(AorDorPort.Value(PortProxy(9263))))
 
                     // If a port (9263) is already taken (by ^^^^ trans port above)
                     // this will take its place and "overwrite" the trans port entry
                     // because port 9263 is taken.
-                    put(socks.set(AorDorPort.Value(Port(9263))))
+                    put(socks.set(AorDorPort.Value(PortProxy(9263))))
 
                     // Set Flags
                     socks.setFlags(setOf(
                         Ports.Socks.Flag.OnionTrafficOnly
                     )).setIsolationFlags(setOf(
                         Ports.IsolationFlag.IsolateClientAddr
-                    )).set(AorDorPort.Value(Port(9264)))
+                    )).set(AorDorPort.Value(PortProxy(9264)))
                     put(socks)
 
                     // reset our socks object to defaults
@@ -107,8 +108,8 @@ class SampleApp: Application() {
                     // Add Hidden services
                     put(HiddenService()
                         .setPorts(ports = setOf(
-                            HiddenService.Ports(virtualPort = 1025, targetPort = 1027),
-                            HiddenService.Ports(virtualPort = 1026, targetPort = 1027)
+                            HiddenService.Ports(virtualPort = Port(1025), targetPort = Port(1027)),
+                            HiddenService.Ports(virtualPort = Port(1026), targetPort = Port(1027))
                         ))
                         .setMaxStreams(maxStreams = HiddenService.MaxStreams(value = 2))
                         .setMaxStreamsCloseCircuit(value = TorF.True)
@@ -122,8 +123,8 @@ class SampleApp: Application() {
 
                     put(HiddenService()
                         .setPorts(ports = setOf(
-                            HiddenService.Ports(virtualPort = 1028, targetPort = 1030),
-                            HiddenService.Ports(virtualPort = 1029, targetPort = 1030)
+                            HiddenService.Ports(virtualPort = Port(1028), targetPort = Port(1030)),
+                            HiddenService.Ports(virtualPort = Port(1029), targetPort = Port(1030))
                         ))
                         .set(FileSystemDir(
                             workDir.builder {

--- a/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
+++ b/samples/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt
@@ -20,6 +20,7 @@ import io.matthewnelson.kmp.tor.PlatformInstaller
 import io.matthewnelson.kmp.tor.PlatformInstaller.InstallOption
 import io.matthewnelson.kmp.tor.TorConfigProviderJvm
 import io.matthewnelson.kmp.tor.common.address.Port
+import io.matthewnelson.kmp.tor.common.address.PortProxy
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
@@ -93,32 +94,32 @@ class SampleApp: App(SampleView::class) {
                 return TorConfig.Builder {
                     // Set multiple ports for all of the things
                     val dns = Ports.Dns()
-                    put(dns.set(AorDorPort.Value(Port(9252))))
-                    put(dns.set(AorDorPort.Value(Port(9253))))
+                    put(dns.set(AorDorPort.Value(PortProxy(9252))))
+                    put(dns.set(AorDorPort.Value(PortProxy(9253))))
 
                     val socks = Ports.Socks()
-                    put(socks.set(AorDorPort.Value(Port(9254))))
-                    put(socks.set(AorDorPort.Value(Port(9255))))
+                    put(socks.set(AorDorPort.Value(PortProxy(9254))))
+                    put(socks.set(AorDorPort.Value(PortProxy(9255))))
 
                     val http = Ports.HttpTunnel()
-                    put(http.set(AorDorPort.Value(Port(9258))))
-                    put(http.set(AorDorPort.Value(Port(9259))))
+                    put(http.set(AorDorPort.Value(PortProxy(9258))))
+                    put(http.set(AorDorPort.Value(PortProxy(9259))))
 
                     val trans = Ports.Trans()
-                    put(trans.set(AorDorPort.Value(Port(9262))))
-                    put(trans.set(AorDorPort.Value(Port(9263))))
+                    put(trans.set(AorDorPort.Value(PortProxy(9262))))
+                    put(trans.set(AorDorPort.Value(PortProxy(9263))))
 
                     // If a port (9263) is already taken (by ^^^^ trans port above)
                     // this will take its place and "overwrite" the trans port entry
                     // because port 9263 is taken.
-                    put(socks.set(AorDorPort.Value(Port(9263))))
+                    put(socks.set(AorDorPort.Value(PortProxy(9263))))
 
                     // Set Flags
                     socks.setFlags(setOf(
                         Ports.Socks.Flag.OnionTrafficOnly
                     )).setIsolationFlags(setOf(
                         Ports.IsolationFlag.IsolateClientAddr
-                    )).set(AorDorPort.Value(Port(9264)))
+                    )).set(AorDorPort.Value(PortProxy(9264)))
                     put(socks)
 
                     // reset our socks object to defaults
@@ -145,8 +146,8 @@ class SampleApp: App(SampleView::class) {
                     // Add Hidden services
                     put(HiddenService()
                         .setPorts(ports = setOf(
-                            HiddenService.Ports(virtualPort = 1025, targetPort = 1027),
-                            HiddenService.Ports(virtualPort = 1026, targetPort = 1027)
+                            HiddenService.Ports(virtualPort = Port(1025), targetPort = Port(1027)),
+                            HiddenService.Ports(virtualPort = Port(1026), targetPort = Port(1027))
                         ))
                         .setMaxStreams(maxStreams = HiddenService.MaxStreams(value = 2))
                         .setMaxStreamsCloseCircuit(value = TorF.True)
@@ -160,8 +161,8 @@ class SampleApp: App(SampleView::class) {
 
                     put(HiddenService()
                         .setPorts(ports = setOf(
-                            HiddenService.Ports(virtualPort = 1028, targetPort = 1030),
-                            HiddenService.Ports(virtualPort = 1029, targetPort = 1030)
+                            HiddenService.Ports(virtualPort = Port(1028), targetPort = Port(1030)),
+                            HiddenService.Ports(virtualPort = Port(1029), targetPort = Port(1030))
                         ))
                         .set(FileSystemDir(
                             workDir.builder {


### PR DESCRIPTION
Adds a new `PortProxy` wrapper class to constrain socks/http/dns/trans port values to previous range of `1024..65535`

this is a breaking change. :cry: 

closes #65 