### PR TITLE
Tweak `TorConfig.text` output by sorting settings

### DIFF
--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -146,16 +146,21 @@ class TorConfig private constructor(
             val sb = StringBuilder()
 
             val disabledPorts = mutableSetOf<String>()
-            for (setting in settings) {
-                if (setting is Setting.Ports && setting.value is Option.AorDorPort.Disable) {
-                    disabledPorts.add(setting.keyword)
+            val sorted = settings.sortedBy { setting ->
+                if (setting is Setting.Ports) {
+                    if (setting.value is Option.AorDorPort.Disable) {
+                        disabledPorts.add(setting.keyword)
+                    }
+                    "AAA${setting.keyword}"
+                } else {
+                    setting.keyword
                 }
             }
 
             val writtenDisabledPorts: MutableSet<String> = LinkedHashSet(disabledPorts.size)
 
             val newSettings = mutableSetOf<Setting<*>>()
-            for (setting in settings) {
+            for ((i, setting) in sorted.withIndex()) {
                 val value = setting.value ?: continue
 
                 if (setting is Setting.Ports) {
@@ -233,6 +238,10 @@ class TorConfig private constructor(
 
                     if (hsPorts == null || hsPorts.isEmpty()) {
                         continue
+                    }
+
+                    if (sorted.elementAtOrNull(i - 1) !is Setting.HiddenService) {
+                        sb.appendLine()
                     }
 
                     sb.append(setting.keyword)


### PR DESCRIPTION
When `TorConfig.Builder.build()` is called, settings are sorted by:
 - first: if they are a `Setting.Port`
 - second: their defined `keyword`