### PR TITLE
Fix foreground service notification not showing immediately on API 31+

### DIFF
--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/notification/TorServiceNotification.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/notification/TorServiceNotification.kt
@@ -483,6 +483,10 @@ private class RealTorServiceNotification(
                 setColor(state.color.retrieve(service))
                 setVisibility(config.visibility)
             }
+            // API 31
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+            }
         }
 
         state.actions.set(builder)


### PR DESCRIPTION
Closes #68 