### PR TITLE
Make calling `exitProcess` from `TorService.onDestroy` when task is removed a configurable option

### DIFF
--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/TorServiceConfig.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/TorServiceConfig.kt
@@ -48,6 +48,7 @@ abstract class TorServiceConfig internal constructor() {
     abstract val enableForeground: Boolean
 
     abstract val stopServiceOnTaskRemoved: Boolean
+    abstract val ifForegroundExitProcessOnDestroyWhenTaskRemoved: Boolean
 
     abstract val notificationId: Int
     abstract val channelId: String
@@ -79,6 +80,7 @@ abstract class TorServiceConfig internal constructor() {
             TorServiceConfig(
                 enableForeground=$enableForeground,
                 stopServiceOnTaskRemoved=$stopServiceOnTaskRemoved,
+                ifForegroundExitProcessOnDestroyWhenTaskRemoved=$ifForegroundExitProcessOnDestroyWhenTaskRemoved,
                 notificationId=$notificationId,
                 channelId=$channelId,
                 channelName=$channelName,
@@ -102,6 +104,7 @@ abstract class TorServiceConfig internal constructor() {
                 other is TorServiceConfig                                       &&
                 other.enableForeground == enableForeground                      &&
                 other.stopServiceOnTaskRemoved == stopServiceOnTaskRemoved      &&
+                other.ifForegroundExitProcessOnDestroyWhenTaskRemoved == ifForegroundExitProcessOnDestroyWhenTaskRemoved &&
                 other.notificationId == notificationId                          &&
                 other.channelId == channelId                                    &&
                 other.channelName == channelName                                &&
@@ -122,6 +125,7 @@ abstract class TorServiceConfig internal constructor() {
         var result = 17
         result = result * 31 + enableForeground.hashCode()
         result = result * 31 + stopServiceOnTaskRemoved.hashCode()
+        result = result * 31 + ifForegroundExitProcessOnDestroyWhenTaskRemoved.hashCode()
         result = result * 31 + notificationId.hashCode()
         result = result * 31 + channelId.hashCode()
         result = result * 31 + channelName.hashCode()
@@ -158,6 +162,7 @@ private class RealTorServiceConfig(context: Context): TorServiceConfig() {
     override val enableForeground: Boolean
 
     override val stopServiceOnTaskRemoved: Boolean
+    override val ifForegroundExitProcessOnDestroyWhenTaskRemoved: Boolean
 
     override val notificationId: Int
     override val channelId: String
@@ -216,6 +221,7 @@ private class RealTorServiceConfig(context: Context): TorServiceConfig() {
         stopServiceOnTaskRemoved = meta?.getBoolean(KEY_STOP_SERVICE_ON_TASK_REMOVED, true) ?: true
 
         if (!enableForeground) {
+            ifForegroundExitProcessOnDestroyWhenTaskRemoved = false
             notificationId = 0
             channelId = ""
             channelName = ""
@@ -248,6 +254,11 @@ private class RealTorServiceConfig(context: Context): TorServiceConfig() {
                     """.trimIndent()
                 )
             }
+
+            ifForegroundExitProcessOnDestroyWhenTaskRemoved = meta.getBoolean(
+                KEY_IF_FOREGROUND_EXIT_PROCESS_ON_DESTROY_WHEN_TASK_REMOVED,
+                true
+            )
 
             notificationId = meta.getInt(KEY_NOTIFICATION_ID, 0).let { id ->
                 if (id !in 1..9999) {
@@ -582,6 +593,7 @@ private class RealTorServiceConfig(context: Context): TorServiceConfig() {
 
         const val KEY_ENABLE_FOREGROUND = "$BASE.enable_foreground"
         const val KEY_STOP_SERVICE_ON_TASK_REMOVED = "$BASE.stop_service_on_task_removed"
+        const val KEY_IF_FOREGROUND_EXIT_PROCESS_ON_DESTROY_WHEN_TASK_REMOVED = "$BASE.if_foreground_exit_process_on_destroy_when_task_removed"
 
         const val KEY_NOTIFICATION_ID = "$BASE.notification_id"
         const val KEY_CHANNEL_ID = "$BASE.notification_channel_id"

--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -67,6 +67,9 @@
             android:name="io.matthewnelson.kmp.tor.stop_service_on_task_removed"
             android:value="@bool/tor_service_stop_service_on_task_removed" />
         <meta-data
+            android:name="io.matthewnelson.kmp.tor.if_foreground_exit_process_on_destroy_when_task_removed"
+            android:value="@bool/tor_service_if_foreground_exit_process_on_destroy_when_task_removed" />
+        <meta-data
             android:name="io.matthewnelson.kmp.tor.notification_id"
             android:value="@integer/tor_service_notification_id" />
         <meta-data

--- a/samples/android/src/main/res/values/attrs.xml
+++ b/samples/android/src/main/res/values/attrs.xml
@@ -32,13 +32,9 @@
     `tor_service_stop_service_on_task_removed` is unset or `true`), Tor takes a
     moment to shutdown. As such, there is approximately 1 second where your
     application's State is still started (as if the app was not swiped from the
-    recent app's tray).
-
-    This is monitored by TorService and, if the Task is still removed after Tor
-    finally shuts down, exitProcess(0) is called. If the User returns to your
-    application before Tor finally stops (when exitProcess is called) and the
-    last action prior to Task removal was _not_ STOP, TorService will attempt to
-    start itself in order to return to the originally intended state of Tor ON.
+    recent app's tray). See attribute
+    `tor_service_if_foreground_exit_process_on_destroy_when_task_removed` below
+    for more information.
     -->
     <bool name="tor_service_enable_foreground">true</bool>
 
@@ -52,11 +48,36 @@
     This can be useful if:
       - You are running TorService in the background, with another
         service that is running in the Foreground keeping the application alive
-        past task removal.
+        past Task removal.
       - You are running TorService in the foreground and wish to keep the application
-        alive until an explicit call to `stop` Tor is made.
+        alive until an explicit call to `stop` TorService is made.
     -->
     <bool name="tor_service_stop_service_on_task_removed">false</bool>
+
+    <!--
+    Not Required
+    Default: whatever `tor_service_enable_foreground` is set to
+
+    If `tor_service_enable_foreground` is set to `true`, no matter what value is
+    set for `tor_service_stop_service_on_task_removed` your application will _not_
+    be killed when TorService.onDestroy is called when the Task has been removed.
+    This is attributed to how Foreground Services work in Android, not KmpTor.
+
+    When TorService.onDestroy is called, TorManager.destroy is also called (it takes
+    approximately 1s to shut down cleanly). Upon TorManager destruction completion,
+    TorService will check to see if the Task is still removed (user has not returned
+    to the application). If it is still removed and this setting is `true`, exitProcess(0)
+    will be called to kill the application. This would be the same behavior as if
+    TorService was running as a background service and the user swipes the application
+    from recent app's tray.
+
+    If this setting is `false`, exitProcess will _not_ be called after TorManager.destroy
+    completes. Your application will continue to run in the background until either:
+      - The user returns to the application
+          - Note that TorService will automatically re-start if the last action was _not_ STOP
+      - Android kills the process to recoup memory (approximately 1m)
+    -->
+    <bool name="tor_service_if_foreground_exit_process_on_destroy_when_task_removed">true</bool>
 
 
     <!-- NOTIFICATION INFO -->


### PR DESCRIPTION
Closes #73 