### PR TITLE
Add multi-instance support to `NetworkObserver` abstraction

### DIFF
--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -177,13 +177,13 @@ private class RealTorManager(
                             job?.cancel()
                             scope.launch {
                                 delay(300L)
-                                val result = controller.configSet(
+
+                                if (networkState.isEnabled()) return@launch
+
+                                controller.configSet(
                                     TorConfig.Setting.DisableNetwork()
                                         .set(TorConfig.Option.TorF.False)
                                 )
-                                if (result.isSuccess) {
-                                    stateMachine.updateState(TorNetworkState.Enabled)
-                                }
                             }
                         }
                     }
@@ -194,13 +194,13 @@ private class RealTorManager(
                             job?.cancel()
                             scope.launch {
                                 delay(300L)
-                                val result = controller.configSet(
+
+                                if (networkState.isDisabled()) return@launch
+
+                                controller.configSet(
                                     TorConfig.Setting.DisableNetwork()
                                         .set(TorConfig.Option.TorF.True)
                                 )
-                                if (result.isSuccess) {
-                                    stateMachine.updateState(TorNetworkState.Disabled)
-                                }
                             }
                         }
                     }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -172,36 +172,30 @@ private class RealTorManager(
         networkObserver?.attach(instanceId) { connectivity ->
             when (connectivity) {
                 NetworkObserver.Connectivity.Connected -> {
-                    controller.value?.first?.let { controller ->
-                        networkObserverJob.update { job ->
-                            job?.cancel()
-                            scope.launch {
-                                delay(300L)
+                    networkObserverJob.update { job ->
+                        job?.cancel()
+                        scope.launch {
+                            delay(300L)
 
-                                if (networkState.isEnabled()) return@launch
+                            if (networkState.isEnabled()) return@launch
 
-                                controller.configSet(
-                                    TorConfig.Setting.DisableNetwork()
-                                        .set(TorConfig.Option.TorF.False)
-                                )
-                            }
+                            controller.value?.first?.configSet(
+                                TorConfig.Setting.DisableNetwork().set(TorConfig.Option.TorF.False)
+                            )
                         }
                     }
                 }
                 NetworkObserver.Connectivity.Disconnected -> {
-                    controller.value?.first?.let { controller ->
-                        networkObserverJob.update { job ->
-                            job?.cancel()
-                            scope.launch {
-                                delay(300L)
+                    networkObserverJob.update { job ->
+                        job?.cancel()
+                        scope.launch {
+                            delay(300L)
 
-                                if (networkState.isDisabled()) return@launch
+                            if (networkState.isDisabled()) return@launch
 
-                                controller.configSet(
-                                    TorConfig.Setting.DisableNetwork()
-                                        .set(TorConfig.Option.TorF.True)
-                                )
-                            }
+                            controller.value?.first?.configSet(
+                                TorConfig.Setting.DisableNetwork().set(TorConfig.Option.TorF.True)
+                            )
                         }
                     }
                 }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -40,10 +40,7 @@ import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent.Log.Warn.Co
 import io.matthewnelson.kmp.tor.manager.common.exceptions.InterruptedException
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorNotStartedException
-import io.matthewnelson.kmp.tor.manager.common.state.TorNetworkState
-import io.matthewnelson.kmp.tor.manager.common.state.TorState
-import io.matthewnelson.kmp.tor.manager.common.state.TorStateManager
-import io.matthewnelson.kmp.tor.manager.common.state.isEnabled
+import io.matthewnelson.kmp.tor.manager.common.state.*
 import io.matthewnelson.kmp.tor.manager.internal.actions.ActionProcessor
 import io.matthewnelson.kmp.tor.manager.internal.actions.ActionQueue
 import io.matthewnelson.kmp.tor.manager.internal.BaseTorManager
@@ -172,7 +169,7 @@ private class RealTorManager(
         notifyListenersNoScope(TorManagerEvent.Lifecycle(this, ON_CREATE))
 
         // Attach to network observer
-        networkObserver?.attach { connectivity ->
+        networkObserver?.attach(instanceId) { connectivity ->
             when (connectivity) {
                 NetworkObserver.Connectivity.Connected -> {
                     controller.value?.first?.let { controller ->
@@ -264,7 +261,7 @@ private class RealTorManager(
         synchronized(this) {
             if (isDestroyed) return@synchronized
             _isDestroyed.value = true
-            networkObserver?.detach()
+            networkObserver?.detach(instanceId)
 
             if (!stopCleanly) {
                 controller.value?.first?.disconnect()

--- a/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/NetworkObserverUnitTest.kt
+++ b/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/NetworkObserverUnitTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.manager
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NetworkObserverUnitTest {
+
+    private class TestNetworkObserver: NetworkObserver() {
+        var attachedCalledCounter = 0
+            private set
+
+        override fun isNetworkConnected(): Boolean {
+            return true
+        }
+
+        override fun onManagerAttach() {
+            attachedCalledCounter++
+        }
+
+        override fun onManagerDetach() {
+            attachedCalledCounter--
+        }
+
+        fun changeConnectivity(connectivity: Connectivity) {
+            dispatchConnectivityChange(connectivity)
+        }
+    }
+
+    private val networkObserver = TestNetworkObserver()
+
+    @Test
+    fun givenAttachment_whenMultipleInstances_onAttachCalledOnlyOnFirstAttachment() {
+        networkObserver.attach(instanceId = "instance1") {}
+        assertEquals(1, networkObserver.attachedCalledCounter)
+
+        networkObserver.attach(instanceId = "instance2") {}
+        assertEquals(1, networkObserver.attachedCalledCounter)
+    }
+
+    @Test
+    fun givenDetachment_whenMultipleInstances_onDetachCalledOnlyOnLastDetachment() {
+        networkObserver.attach(instanceId = "instance1") {}
+        networkObserver.attach(instanceId = "instance2") {}
+        assertEquals(1, networkObserver.attachedCalledCounter)
+
+        networkObserver.detach(instanceId = "instance1")
+        assertEquals(1, networkObserver.attachedCalledCounter)
+
+        networkObserver.detach(instanceId = "instance2")
+        assertEquals(0, networkObserver.attachedCalledCounter)
+    }
+
+    @Test
+    fun givenUnattachedInstance_whenDetached_onDetachIsNotCalled() {
+        assertEquals(0, networkObserver.attachedCalledCounter)
+        networkObserver.detach("instance")
+        assertEquals(0, networkObserver.attachedCalledCounter)
+    }
+
+    @Test
+    fun givenConnectivityDispatch_whenMultipleInstancesAttached_allAreUpdated() {
+        var instance1State = NetworkObserver.Connectivity.Disconnected
+        var instance2State = NetworkObserver.Connectivity.Disconnected
+
+        networkObserver.attach(instanceId = "instance1") {
+            instance1State = it
+        }
+        networkObserver.attach(instanceId = "instance2") {
+            instance2State = it
+        }
+
+        networkObserver.changeConnectivity(NetworkObserver.Connectivity.Connected)
+        assertEquals(NetworkObserver.Connectivity.Connected, instance1State)
+        assertEquals(NetworkObserver.Connectivity.Connected, instance2State)
+
+        networkObserver.changeConnectivity(NetworkObserver.Connectivity.Disconnected)
+        assertEquals(NetworkObserver.Connectivity.Disconnected, instance1State)
+        assertEquals(NetworkObserver.Connectivity.Disconnected, instance2State)
+    }
+}


### PR DESCRIPTION
Adds support for re-using an instance of `NetworkObserver` across multiple instances by allowing several `TorManager`'s to attach (upon first start) and detach (upon destruction).

Closes #87 