### PR TITLE
Fix `LOADCONF` functionality

### DIFF
--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -335,6 +335,8 @@ class TorConfig private constructor(
         val isDefault: Boolean get() = value == default
         var isMutable: Boolean = true
             protected set
+        @InternalTorApi
+        abstract val isStartArgument: Boolean
 
         @JvmSynthetic
         internal fun setImmutable(): Setting<T> {
@@ -378,6 +380,8 @@ class TorConfig private constructor(
         class AutomapHostsOnResolve         : Setting<Option.TorF>("AutomapHostsOnResolve") {
             override val default: Option.TorF get() = Option.TorF.True
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = false
 
             override fun clone(): AutomapHostsOnResolve {
                 return AutomapHostsOnResolve().set(value) as AutomapHostsOnResolve
@@ -391,6 +395,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemDir? = null
             override var value: Option.FileSystemDir? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): CacheDirectory {
                 return CacheDirectory().set(value) as CacheDirectory
@@ -404,6 +410,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemDir? = null
             override var value: Option.FileSystemDir? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): ClientOnionAuthDir {
                 return ClientOnionAuthDir().set(value) as ClientOnionAuthDir
@@ -420,6 +428,8 @@ class TorConfig private constructor(
         class ConnectionPadding             : Setting<Option.AorTorF>("ConnectionPadding") {
             override val default: Option.AorTorF get() = Option.AorTorF.Auto
             override var value: Option.AorTorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = false
 
             override fun clone(): ConnectionPadding {
                 return ConnectionPadding().set(value) as ConnectionPadding
@@ -432,6 +442,8 @@ class TorConfig private constructor(
         class ConnectionPaddingReduced      : Setting<Option.TorF>("ReducedConnectionPadding") {
             override val default: Option.TorF get() = Option.TorF.False
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = false
 
             override fun clone(): ConnectionPaddingReduced {
                 return ConnectionPaddingReduced().set(value) as ConnectionPaddingReduced
@@ -445,6 +457,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemFile? = null
             override var value: Option.FileSystemFile? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): ControlPortWriteToFile {
                 return ControlPortWriteToFile().set(value) as ControlPortWriteToFile
@@ -461,6 +475,8 @@ class TorConfig private constructor(
         class CookieAuthentication          : Setting<Option.TorF>("CookieAuthentication") {
             override val default: Option.TorF get() = Option.TorF.True
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): CookieAuthentication {
                 return CookieAuthentication().set(value) as CookieAuthentication
@@ -474,6 +490,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemFile? = null
             override var value: Option.FileSystemFile? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): CookieAuthFile {
                 return CookieAuthFile().set(value) as CookieAuthFile
@@ -491,6 +509,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemDir? = null
             override var value: Option.FileSystemDir? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): DataDirectory {
                 return DataDirectory().set(value) as DataDirectory
@@ -507,6 +527,8 @@ class TorConfig private constructor(
         class DisableNetwork                : Setting<Option.TorF>("DisableNetwork") {
             override val default: Option.TorF get() = Option.TorF.False
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): DisableNetwork {
                 return DisableNetwork().set(value) as DisableNetwork
@@ -519,6 +541,8 @@ class TorConfig private constructor(
         class DormantCanceledByStartup      : Setting<Option.TorF>("DormantCanceledByStartup") {
             override val default: Option.TorF get() = Option.TorF.False
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): DormantCanceledByStartup {
                 return DormantCanceledByStartup().set(value) as DormantCanceledByStartup
@@ -539,6 +563,8 @@ class TorConfig private constructor(
                         value
                     }
                 }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = false
 
             override fun clone(): DormantClientTimeout {
                 return DormantClientTimeout().set(value) as DormantClientTimeout
@@ -551,6 +577,8 @@ class TorConfig private constructor(
         class DormantOnFirstStartup         : Setting<Option.TorF>("DormantOnFirstStartup") {
             override val default: Option.TorF get() = Option.TorF.False
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): DormantOnFirstStartup {
                 return DormantOnFirstStartup().set(value) as DormantOnFirstStartup
@@ -563,6 +591,8 @@ class TorConfig private constructor(
         class DormantTimeoutDisabledByIdleStreams   : Setting<Option.TorF>("DormantTimeoutDisabledByIdleStreams") {
             override val default: Option.TorF get() = Option.TorF.True
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = false
 
             override fun clone(): DormantTimeoutDisabledByIdleStreams {
                 return DormantTimeoutDisabledByIdleStreams().set(value) as DormantTimeoutDisabledByIdleStreams
@@ -575,6 +605,8 @@ class TorConfig private constructor(
         class GeoIPExcludeUnknown           : Setting<Option.AorTorF>("GeoIPExcludeUnknown") {
             override val default: Option.AorTorF get() = Option.AorTorF.Auto
             override var value: Option.AorTorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = false
 
             override fun clone(): GeoIPExcludeUnknown {
                 return GeoIPExcludeUnknown().set(value) as GeoIPExcludeUnknown
@@ -588,6 +620,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemFile? = null
             override var value: Option.FileSystemFile? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): GeoIpV4File {
                 return GeoIpV4File().set(value) as GeoIpV4File
@@ -601,6 +635,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemFile? = null
             override var value: Option.FileSystemFile? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): GeoIpV6File {
                 return GeoIpV6File().set(value) as GeoIpV6File
@@ -634,6 +670,8 @@ class TorConfig private constructor(
             override val default: Option.FileSystemDir? = null
             override var value: Option.FileSystemDir? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = false
 
             /**
              * See [HiddenService.Ports]
@@ -782,6 +820,8 @@ class TorConfig private constructor(
         class OwningControllerProcess       : Setting<Option.ProcessId?>("__OwningControllerProcess") {
             override val default: Option.ProcessId? = null
             override var value: Option.ProcessId? = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): OwningControllerProcess {
                 return OwningControllerProcess().set(value) as OwningControllerProcess
@@ -840,6 +880,8 @@ class TorConfig private constructor(
                             field = value
                         }
                     }
+                @InternalTorApi
+                override val isStartArgument: Boolean get() = true
 
                 var flags: Set<Flag>? = null
                     private set
@@ -879,6 +921,8 @@ class TorConfig private constructor(
                 override var value: Option.AorDorPort = default
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
+                @InternalTorApi
+                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): Dns {
                     if (isMutable) {
@@ -908,6 +952,8 @@ class TorConfig private constructor(
                 override var value: Option.AorDorPort = default
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
+                @InternalTorApi
+                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): HttpTunnel {
                     if (isMutable) {
@@ -940,6 +986,8 @@ class TorConfig private constructor(
                     private set
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
+                @InternalTorApi
+                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): Socks {
                     if (isMutable) {
@@ -996,6 +1044,8 @@ class TorConfig private constructor(
                 override var value: Option.AorDorPort = default
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
+                @InternalTorApi
+                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): Trans {
                     if (isMutable) {
@@ -1058,6 +1108,8 @@ class TorConfig private constructor(
         class RunAsDaemon                   : Setting<Option.TorF>("RunAsDaemon") {
             override val default: Option.TorF get() = Option.TorF.False
             override var value: Option.TorF = default
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): RunAsDaemon {
                 return RunAsDaemon().set(value) as RunAsDaemon
@@ -1071,6 +1123,8 @@ class TorConfig private constructor(
             override val default: Option.FieldId? get() = null
             override var value: Option.FieldId? = default
                 set(value) { field = value?.nullIfEmpty }
+            @InternalTorApi
+            override val isStartArgument: Boolean get() = true
 
             override fun clone(): SyslogIdentityTag {
                 return SyslogIdentityTag().set(value) as SyslogIdentityTag

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -188,28 +188,7 @@ private class RealTorControlProcessor(
             try {
                 val command = StringBuilder("+LOADCONF").apply {
                     append(CLRF)
-
-                    val kControlPort = TorConfig.Setting.Ports.Control::class
-                    val kControlPortWriteToFile = TorConfig.Setting.ControlPortWriteToFile::class
-                    var needsModification = false
-                    for (setting in config.settings) {
-                        val clazz = setting::class
-                        if (clazz == kControlPort || clazz == kControlPortWriteToFile) {
-                            needsModification = true
-                            break
-                        }
-                    }
-
-                    if (needsModification) {
-                        val newConfig: TorConfig = config.newBuilder {
-                            removeInstanceOf(kControlPort)
-                            removeInstanceOf(kControlPortWriteToFile)
-                        }.build()
-                        append(newConfig.text)
-                    } else {
-                        append(config.text)
-                    }
-
+                    append(config.text)
                     append(CLRF)
                     append(MULTI_LINE_END)
                     append(CLRF)

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -89,11 +89,11 @@ private class RealTorControlProcessor(
     override suspend fun authenticate(bytes: ByteArray): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("AUTHENTICATE")
-                    .append(SP)
-                    .append(bytes.encodeBase16())
-                    .append(CLRF)
-                    .toString()
+                val command = StringBuilder("AUTHENTICATE").apply {
+                    append(SP)
+                    append(bytes.encodeBase16())
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -157,13 +157,12 @@ private class RealTorControlProcessor(
     override suspend fun configGet(settings: Set<TorConfig.Setting<*>>): Result<List<ConfigEntry>> {
         return lock.withLock {
             try {
-                val command = StringBuilder("GETCONF").let { sb ->
+                val command = StringBuilder("GETCONF").apply {
                     if (settings.isNotEmpty()) {
-                        settings.joinTo(sb, SP, SP) { it.keyword }
+                        settings.joinTo(this, SP, SP) { it.keyword }
                     }
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                }.toString()
 
                 val configEntry = processCommand(command) {
                     map { reply ->
@@ -187,8 +186,8 @@ private class RealTorControlProcessor(
     override suspend fun configLoad(config: TorConfig): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("+LOADCONF").let { sb ->
-                    sb.append(CLRF)
+                val command = StringBuilder("+LOADCONF").apply {
+                    append(CLRF)
 
                     val kControlPort = TorConfig.Setting.Ports.Control::class
                     val kControlPortWriteToFile = TorConfig.Setting.ControlPortWriteToFile::class
@@ -206,16 +205,15 @@ private class RealTorControlProcessor(
                             removeInstanceOf(kControlPort)
                             removeInstanceOf(kControlPortWriteToFile)
                         }.build()
-                        sb.append(newConfig.text)
+                        append(newConfig.text)
                     } else {
-                        sb.append(config.text)
+                        append(config.text)
                     }
 
-                    sb.append(CLRF)
-                    sb.append(MULTI_LINE_END)
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                    append(MULTI_LINE_END)
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -237,7 +235,7 @@ private class RealTorControlProcessor(
     ): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("RESETCONF").let { sb ->
+                val command = StringBuilder("RESETCONF").apply {
                     for (setting in settings) {
                         when (setting) {
                             // ControlPort can only be set upon startup
@@ -247,20 +245,20 @@ private class RealTorControlProcessor(
                             else -> { /* no-op */ }
                         }
 
-                        sb.append(SP)
-                        sb.append(setting.keyword)
+                        append(SP)
+                        append(setting.keyword)
 
                         if (!setDefault) {
                             setting.value?.value?.let { kwv ->
-                                sb.append('=')
-                                sb.append(kwv)
+                                append('=')
+                                append(kwv)
                             }
                         }
 
                     }
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                    toString()
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -272,14 +270,13 @@ private class RealTorControlProcessor(
     override suspend fun configSave(force: Boolean): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("SAVECONF").let { sb ->
+                val command = StringBuilder("SAVECONF").apply {
                     if (force) {
-                        sb.append(SP)
-                        sb.append("FORCE")
+                        append(SP)
+                        append("FORCE")
                     }
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -295,7 +292,7 @@ private class RealTorControlProcessor(
     override suspend fun configSet(settings: Set<TorConfig.Setting<*>>): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("SETCONF").let { sb ->
+                val command = StringBuilder("SETCONF").apply {
                     for (setting in settings) {
                         when (setting) {
                             // ControlPort can only be set upon startup
@@ -305,17 +302,16 @@ private class RealTorControlProcessor(
                             else -> { /* no-op */ }
                         }
 
-                        sb.append(SP)
-                        sb.append(setting.keyword)
+                        append(SP)
+                        append(setting.keyword)
 
                         setting.value?.value?.let { kwv ->
-                            sb.append('=')
-                            sb.append(kwv)
+                            append('=')
+                            append(kwv)
                         }
                     }
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -367,21 +363,20 @@ private class RealTorControlProcessor(
     ): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("HSFETCH").let { sb ->
-                    sb.append(SP)
-                    sb.append(address.value)
+                val command = StringBuilder("HSFETCH").apply {
+                    append(SP)
+                    append(address.value)
 
                     if (servers != null && servers.isNotEmpty()) {
                         for (server in servers) {
-                            sb.append(SP)
-                            sb.append("SERVER=")
-                            sb.append(server.value)
+                            append(SP)
+                            append("SERVER=")
+                            append(server.value)
                         }
                     }
 
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -407,13 +402,12 @@ private class RealTorControlProcessor(
     override suspend fun infoGet(keywords: Set<KeyWord>): Result<Map<String, String>> {
         return lock.withLock {
             try {
-                val command = StringBuilder("GETINFO").let { sb ->
+                val command = StringBuilder("GETINFO").apply {
                     if (keywords.isNotEmpty()) {
-                        keywords.joinTo(sb, separator = SP, prefix = SP) { it.value }
+                        keywords.joinTo(this, separator = SP, prefix = SP) { it.value }
                     }
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                }.toString()
 
                 val map = processCommand(command) { toMap() }
 
@@ -585,11 +579,11 @@ private class RealTorControlProcessor(
     override suspend fun onionDel(address: OnionAddress): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("DEL_ONION")
-                    .append(SP)
-                    .append(address.value)
-                    .append(CLRF)
-                    .toString()
+                val command = StringBuilder("DEL_ONION").apply {
+                    append(SP)
+                    append(address.value)
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -606,26 +600,25 @@ private class RealTorControlProcessor(
     ): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("ONION_CLIENT_AUTH_ADD").let { sb ->
-                    sb.append(SP)
-                    sb.append(address.value)
-                    sb.append(SP)
-                    sb.append(key.keyType)
-                    sb.append(':')
-                    sb.append(key.base64(padded = false))
+                val command = StringBuilder("ONION_CLIENT_AUTH_ADD").apply {
+                    append(SP)
+                    append(address.value)
+                    append(SP)
+                    append(key.keyType)
+                    append(':')
+                    append(key.base64(padded = false))
                     if (clientName != null) {
-                        sb.append(SP)
-                        sb.append("ClientName=")
-                        sb.append(clientName.value)
+                        append(SP)
+                        append("ClientName=")
+                        append(clientName.value)
                     }
                     if (flags != null && flags.isNotEmpty()) {
-                        sb.append(SP)
-                        sb.append("Flags=")
-                        flags.joinTo(sb, separator = ",")
+                        append(SP)
+                        append("Flags=")
+                        flags.joinTo(this, separator = ",")
                     }
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -637,11 +630,11 @@ private class RealTorControlProcessor(
     override suspend fun onionClientAuthRemove(address: OnionAddressV3): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("ONION_CLIENT_AUTH_REMOVE")
-                    .append(SP)
-                    .append(address.value)
-                    .append(CLRF)
-                    .toString()
+                val command = StringBuilder("ONION_CLIENT_AUTH_REMOVE").apply {
+                    append(SP)
+                    append(address.value)
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -675,14 +668,13 @@ private class RealTorControlProcessor(
 
     private suspend fun onionClientAuthView(address: String?): List<ClientAuthEntry> {
         lock.withLock {
-            val command = StringBuilder("ONION_CLIENT_AUTH_VIEW").let { sb ->
+            val command = StringBuilder("ONION_CLIENT_AUTH_VIEW").apply {
                 if (address != null) {
-                    sb.append(SP)
-                    sb.append(address)
+                    append(SP)
+                    append(address)
                 }
-                sb.append(CLRF)
-                sb.toString()
-            }
+                append(CLRF)
+            }.toString()
 
             return processCommand(command) {
                 mapNotNull { reply ->
@@ -759,17 +751,16 @@ private class RealTorControlProcessor(
     override suspend fun setEvents(events: Set<TorEvent>, extended: Boolean): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("SETEVENTS").let { sb ->
+                val command = StringBuilder("SETEVENTS").apply {
                     if (extended) {
-                        sb.append(SP)
-                        sb.append("EXTENDED")
+                        append(SP)
+                        append("EXTENDED")
                     }
                     if (events.isNotEmpty()) {
-                        events.joinTo(sb, separator = SP, prefix = SP)
+                        events.joinTo(this, separator = SP, prefix = SP)
                     }
-                    sb.append(CLRF)
-                    sb.toString()
-                }
+                    append(CLRF)
+                }.toString()
 
                 Result.success(processCommand(command))
             } catch (e: Exception) {
@@ -781,11 +772,11 @@ private class RealTorControlProcessor(
     override suspend fun signal(signal: TorControlSignal.Signal): Result<Any?> {
         return lock.withLock {
             try {
-                val command = StringBuilder("SIGNAL")
-                    .append(SP)
-                    .append(signal)
-                    .append(CLRF)
-                    .toString()
+                val command = StringBuilder("SIGNAL").apply {
+                    append(SP)
+                    append(signal)
+                    append(CLRF)
+                }.toString()
 
                 val result = processCommand(command)
 

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
@@ -199,9 +199,7 @@ abstract class TorTestHelper {
                 println(event.toString())
             }
 
-            override fun onEvent(event: TorEvent.Type.SingleLineEvent, output: String) {
-                println("event=${event.javaClass.simpleName}, output=$output")
-            }
+            override fun onEvent(event: TorEvent.Type.SingleLineEvent, output: String) {}
 
             override fun onEvent(
                 event: TorEvent.Type.MultiLineEvent,

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
@@ -86,7 +86,7 @@ abstract class TorTestHelper {
 
     protected open fun testConfig(testProvider: TorConfigProviderJvm): TorConfig {
         return TorConfig.Builder {
-            put(Ports.Control().set(AorDorPort.Value(PortProxy(9155))))
+            put(Ports.Control().set(AorDorPort.Auto))
             put(Ports.Socks().set(AorDorPort.Auto))
             put(Ports.HttpTunnel().set(AorDorPort.Auto))
             put(Ports.Trans().set(AorDorPort.Auto))

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -55,7 +55,7 @@ expect abstract class KmpTorLoader {
         managerScope: CoroutineScope,
         stateMachine: TorStateMachine,
         notify: (TorManagerEvent) -> Unit,
-    ): Result<TorController>
+    ): Result<Pair<TorController, TorConfig?>>
 
     @JvmSynthetic
     internal open fun close()

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -464,7 +464,7 @@ private class RealTorManager(
 
                 // Startup via TorManager always starts with DisableNetwork set
                 // to true, which configLoad will default back to.
-                if (networkEnabledBefore) {
+                if (networkEnabledBefore && networkObserver?.isNetworkConnected() != false) {
                     configSet(disableNetwork.set(TorConfig.Option.TorF.False))
                 }
             }

--- a/library/manager/kmp-tor-manager/src/jsMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jsMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -42,7 +42,7 @@ actual abstract class KmpTorLoader(provider: TorConfigProvider) {
         managerScope: CoroutineScope,
         stateMachine: TorStateMachine,
         notify: (TorManagerEvent) -> Unit,
-    ): Result<TorController> {
+    ): Result<Pair<TorController, TorConfig?>> {
         TODO("Not yet implemented")
     }
 

--- a/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -98,7 +98,7 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
         managerScope: CoroutineScope,
         stateMachine: TorStateMachine,
         notify: (TorManagerEvent) -> Unit,
-    ): Result<TorController> {
+    ): Result<Pair<TorController, TorConfig?>> {
         provider.lastValidatedTorConfig?.let { validated ->
             val controlPortFile = validated.controlPortFile.toFile()
             val cookieAuthFile = validated.cookieAuthFile?.toFile()
@@ -170,7 +170,7 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
             }
 
             notify.invoke(TorManagerEvent.Log.Debug("Re-connection attempt successful!"))
-            return Result.success(controller)
+            return Result.success(Pair(controller, null))
         }
 
         torJob?.cancel()
@@ -331,7 +331,7 @@ actual abstract class KmpTorLoader @JvmOverloads constructor(
             ))
         }
 
-        return Result.success(controller)
+        return Result.success(Pair(controller, validated.torConfig))
     }
 
     @JvmSynthetic

--- a/library/manager/kmp-tor-manager/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -44,7 +44,7 @@ actual abstract class KmpTorLoader(provider: TorConfigProvider) {
         managerScope: CoroutineScope,
         stateMachine: TorStateMachine,
         notify: (TorManagerEvent) -> Unit,
-    ): Result<TorController> {
+    ): Result<Pair<TorController, TorConfig?>> {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
This PR modifies startup operations such that only `TorConfig.Setting`s where `isStartArgument` is `true` are passed as cmd line arguments when initially starting Tor. Remaining `TorConfig.Setting`s where `isStartArgument` is `false` are loaded via `TorControlConfigLoad.configLoad`.

This means that upon library user calling `configLoad`, all settings where `isStartArgument` is `false` will not be loaded.

Closes #134 