### PR TITLE
Add `Jvm*` annotations to `TorConfigProvider.ValidatedTorConfig`

### DIFF
--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorConfigProvider.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorConfigProvider.kt
@@ -107,9 +107,13 @@ abstract class TorConfigProvider {
     val lastValidatedTorConfig: ValidatedTorConfig? get() = _lastValidatedTorConfig.value
 
     data class ValidatedTorConfig(
+        @JvmField
         val torConfig: TorConfig,
+        @JvmField
         val configLines: List<String>,
+        @JvmField
         val controlPortFile: Path,
+        @get:JvmSynthetic
         internal val cookieAuthFile: Path?, // if null, cookieAuth is set to False
     )
 


### PR DESCRIPTION
Closes #143 