### PR TITLE
Fix project configuration for IntelliJ IDEA usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 


### PR DESCRIPTION
Android Studio's latest release hates Kotlin Multiplatform, especially when there are both `jvm` and `android` targets declared in the same module.

This PR bumps dependencies to latest stable versions, and downgrades AGP to `7.0.4` such that the project can be opened in IntelliJ IDEA