### PR TITLE
Bump `kotlin-components`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kmp-tor
 [![Kotlin](https://img.shields.io/badge/kotlin-1.6.21-blue.svg?logo=kotlin)](http://kotlinlang.org)
-[![Kotlin Coroutines](https://img.shields.io/badge/coroutines-1.6.1-blue.svg?logo=kotlin)](https://github.com/Kotlin/kotlinx.coroutines)
-[![Kotlin Atomicfu](https://img.shields.io/badge/atomicfu-0.17.2-blue.svg?logo=kotlin)](https://github.com/Kotlin/kotlinx.atomicfu)
+[![Kotlin Coroutines](https://img.shields.io/badge/coroutines-1.6.2-blue.svg?logo=kotlin)](https://github.com/Kotlin/kotlinx.coroutines)
+[![Kotlin Atomicfu](https://img.shields.io/badge/atomicfu-0.17.3-blue.svg?logo=kotlin)](https://github.com/Kotlin/kotlinx.atomicfu)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)  
 
 ![android](https://camo.githubusercontent.com/b1d9ad56ab51c4ad1417e9a5ad2a8fe63bcc4755e584ec7defef83755c23f923/687474703a2f2f696d672e736869656c64732e696f2f62616467652f706c6174666f726d2d616e64726f69642d3645444238442e7376673f7374796c653d666c6174)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dependencies {
      - [Configuring Manifest](https://github.com/05nelsonm/kmp-tor/blob/master/samples/kotlin/android/src/main/AndroidManifest.xml)
 
 <!-- TODO: Add sample code for retrieving TorManager -->
- - See the [Sample App](https://github.com/05nelsonm/kmp-tor/tree/master/samples/kotlin/android/src/main/java/io/matthewnelson/kmp/tor/sample/android) 
+ - See the [Sample App](https://github.com/05nelsonm/kmp-tor/tree/master/samples/kotlin/android/src/main/java/io/matthewnelson/kmp/tor/sample/kotlin/android) 
    for a basic setup of `TorManager` and your `TorConfig`.  
 
 </details>
@@ -52,9 +52,9 @@ dependencies {
     <summary>Configuring a Java Project</summary>
 
 
- - See the [JavaFX Sample App Gradle Configuration](https://github.com/05nelsonm/kmp-tor/tree/master/samples/kotlin/javafx/build.gradle.kts) 
+ - See the [JavaFX Sample App Gradle Configuration](https://github.com/05nelsonm/kmp-tor/blob/master/samples/kotlin/javafx/build.gradle.kts) 
    for a basic gradle/dependency configuration.  
- - See the [JavaFx Sample App](https://github.com/05nelsonm/kmp-tor/tree/master/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/javafx/SampleApp.kt) 
+ - See the [JavaFx Sample App](https://github.com/05nelsonm/kmp-tor/blob/master/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/kotlin/javafx/SampleApp.kt) 
    for a basic setup example.  
  - Run the JavaFx Sample via `./gradlew :samples:kotlin:javafx:run -PKMP_TARGETS=JVM` from terminal 
    or cmd prompt.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ allprojects {
 }
 
 plugins {
-    id("kmp-publish")
+    id(pluginId.kmp.publish)
 }
 
 kmpPublish {

--- a/library/controller/kmp-tor-controller-common/build.gradle.kts
+++ b/library/controller/kmp-tor-controller-common/build.gradle.kts
@@ -19,8 +19,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {

--- a/library/controller/kmp-tor-controller/build.gradle.kts
+++ b/library/controller/kmp-tor-controller/build.gradle.kts
@@ -22,8 +22,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {
@@ -38,35 +38,33 @@ kmpConfiguration {
 //                node = KmpTarget.NonJvm.JS.Node(),
 //            ),
 //
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Linux.X64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
-        commonPluginIds = setOf("kotlinx-atomicfu"),
+        commonPluginIds = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
                 implementation(deps.components.encoding.base16)
-                implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.coroutines.core.core)
-                implementation(deps.kotlin.reflect)
                 api(project(":library:controller:kmp-tor-controller-common"))
             }
         },

--- a/library/extensions/kmp-tor-ext-callback-common/build.gradle.kts
+++ b/library/extensions/kmp-tor-ext-callback-common/build.gradle.kts
@@ -18,8 +18,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {

--- a/library/extensions/kmp-tor-ext-callback-controller-common/build.gradle.kts
+++ b/library/extensions/kmp-tor-ext-callback-controller-common/build.gradle.kts
@@ -18,8 +18,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {

--- a/library/extensions/kmp-tor-ext-callback-controller/build.gradle.kts
+++ b/library/extensions/kmp-tor-ext-callback-controller/build.gradle.kts
@@ -19,8 +19,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {

--- a/library/extensions/kmp-tor-ext-callback-manager-common/build.gradle.kts
+++ b/library/extensions/kmp-tor-ext-callback-manager-common/build.gradle.kts
@@ -18,8 +18,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {

--- a/library/extensions/kmp-tor-ext-callback-manager/build.gradle.kts
+++ b/library/extensions/kmp-tor-ext-callback-manager/build.gradle.kts
@@ -16,13 +16,12 @@
 import io.matthewnelson.kotlin.components.dependencies.deps
 import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.Jvm.Android.Companion.SOURCE_SET_MAIN_NAME as KmpAndroidMain
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {
@@ -46,23 +45,23 @@ kmpConfiguration {
 //                node = KmpTarget.NonJvm.JS.Node(),
 //            ),
 //
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Linux.X64.DEFAULT,
 //

--- a/library/kmp-tor-common/build.gradle.kts
+++ b/library/kmp-tor-common/build.gradle.kts
@@ -19,8 +19,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {

--- a/library/kmp-tor-internal/build.gradle.kts
+++ b/library/kmp-tor-internal/build.gradle.kts
@@ -17,8 +17,8 @@ import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import kmp.tor.env
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 /**

--- a/library/kmp-tor/build.gradle.kts
+++ b/library/kmp-tor/build.gradle.kts
@@ -19,13 +19,12 @@ import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import io.matthewnelson.kotlin.components.kmp.publish.kmpPublishRootProjectConfiguration
 import io.matthewnelson.kotlin.components.kmp.util.*
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.Jvm.Android.Companion.SOURCE_SET_MAIN_NAME as KmpAndroidMain
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 val pConfig = kmpPublishRootProjectConfiguration!!
@@ -39,10 +38,6 @@ kmpConfiguration {
                 mainSourceSet = {
                     dependencies {
                         implementation(project(":library:kmp-tor-internal"))
-
-                        // TODO: Remove once js, macosx64, linuxx64, mingwx64 binary targets are published
-                        implementation("${pConfig.group}:kmp-tor-binary-geoip:${env.kmpTorBinaries.version.name}")
-                        implementation("${pConfig.group}:kmp-tor-binary-extract:${env.kmpTorBinaries.version.name}")
                     }
                 },
                 testSourceSet = {
@@ -67,10 +62,6 @@ kmpConfiguration {
                 mainSourceSet = {
                     dependencies {
                         implementation("${pConfig.group}:kmp-tor-binary-android:${env.kmpTorBinaries.version.name}")
-
-                        // TODO: Remove once js, macosx64, linuxx64, mingwx64 binary targets are published
-                        implementation("${pConfig.group}:kmp-tor-binary-geoip:${env.kmpTorBinaries.version.name}")
-                        implementation("${pConfig.group}:kmp-tor-binary-extract:${env.kmpTorBinaries.version.name}")
                     }
                 },
             ),
@@ -81,36 +72,36 @@ kmpConfiguration {
 //                node = KmpTarget.NonJvm.JS.Node(),
 //            ),
 //
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64(
 //                mainSourceSet = {
 //                    dependencies {
 //                        // TODO: Uncomment once macosx64 binary target is published
-////                        implementation("${pConfig.group}:kmp-tor-binary-macosx64:${env.kmpTorBinaries.version.name}")
+//                        implementation("${pConfig.group}:kmp-tor-binary-macosx64:${env.kmpTorBinaries.version.name}")
 //                    }
 //                },
 //            ),
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Linux.X64(
 //                mainSourceSet = {
 //                    dependencies {
 //                        // TODO: Uncomment once linuxx64 binary target is published
-////                        implementation("${pConfig.group}:kmp-tor-binary-linuxx64:${env.kmpTorBinaries.version.name}")
+//                        implementation("${pConfig.group}:kmp-tor-binary-linuxx64:${env.kmpTorBinaries.version.name}")
 //                    }
 //                },
 //            ),
@@ -119,7 +110,7 @@ kmpConfiguration {
 //                mainSourceSet = {
 //                    dependencies {
 //                        // TODO: Uncomment once mingwx64 binary target is published
-////                        implementation("${pConfig.group}:kmp-tor-binary-mingwx64:${env.kmpTorBinaries.version.name}")
+//                        implementation("${pConfig.group}:kmp-tor-binary-mingwx64:${env.kmpTorBinaries.version.name}")
 //                    }
 //                },
 //            ),
@@ -128,9 +119,8 @@ kmpConfiguration {
             dependencies {
                 implementation(deps.kotlin.coroutines.core.core)
 
-                // TODO: Uncomment once js, macosx64, linuxx64, mingwx64 binary targets are published
-//                implementation("${pConfig.group}:kmp-tor-binary-geoip:${env.kmpTorBinaries.version.name}")
-//                implementation("${pConfig.group}:kmp-tor-binary-extract:${env.kmpTorBinaries.version.name}")
+                implementation("${pConfig.group}:kmp-tor-binary-geoip:${env.kmpTorBinaries.version.name}")
+                implementation("${pConfig.group}:kmp-tor-binary-extract:${env.kmpTorBinaries.version.name}")
 
                 api(project(":library:manager:kmp-tor-manager"))
             }

--- a/library/manager/kmp-tor-manager-common/build.gradle.kts
+++ b/library/manager/kmp-tor-manager-common/build.gradle.kts
@@ -19,8 +19,8 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {
@@ -59,7 +59,6 @@ kmpConfiguration {
         ),
         commonMainSourceSet = {
             dependencies {
-                implementation(deps.kotlin.reflect)
                 api(project(":library:controller:kmp-tor-controller-common"))
             }
         },

--- a/library/manager/kmp-tor-manager/build.gradle.kts
+++ b/library/manager/kmp-tor-manager/build.gradle.kts
@@ -17,14 +17,13 @@ import io.matthewnelson.kotlin.components.dependencies.deps
 import io.matthewnelson.kotlin.components.dependencies.depsTest
 import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
-import io.matthewnelson.kotlin.components.kmp.KmpTarget.Jvm.Android.Companion.SOURCE_SET_MAIN_NAME as KmpAndroidMain
 import io.matthewnelson.kotlin.components.kmp.publish.kmpPublishRootProjectConfiguration
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
-    id("kmp-publish")
+    id(pluginId.kmp.configuration)
+    id(pluginId.kmp.publish)
 }
 
 kmpConfiguration {
@@ -48,34 +47,32 @@ kmpConfiguration {
 //                node = KmpTarget.NonJvm.JS.Node(),
 //            ),
 //
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.X64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Macos.Arm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Tvos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm32.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.Arm64.DEFAULT,
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X64.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
-////            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.X86.DEFAULT,
+//            KmpTarget.NonJvm.Native.Unix.Darwin.Watchos.SimulatorArm64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Unix.Linux.X64.DEFAULT,
 //
 //            KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
-        commonPluginIds = setOf("kotlinx-atomicfu"),
+        commonPluginIds = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
-                implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.coroutines.core.core)
-                implementation(deps.kotlin.reflect)
                 implementation(project(":library:controller:kmp-tor-controller")) {
                     exclude(kmpPublishRootProjectConfiguration!!.group, "kmp-tor-common")
                     exclude(kmpPublishRootProjectConfiguration!!.group, "kmp-tor-controller-common")

--- a/samples/kotlin/android/build.gradle.kts
+++ b/samples/kotlin/android/build.gradle.kts
@@ -20,8 +20,8 @@ import io.matthewnelson.kotlin.components.kmp.util.includeStagingRepoIfTrue
 import kmp.tor.env
 
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
+    id(pluginId.android.application)
+    id(pluginId.kotlin.android)
 }
 
 // disregard. this is for playing with newly published binaries prior to release

--- a/samples/kotlin/javafx/build.gradle.kts
+++ b/samples/kotlin/javafx/build.gradle.kts
@@ -23,7 +23,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>() {
 }
 
 plugins {
-    kotlin("multiplatform")
+    id(pluginId.kotlin.multiplatform)
     application
     id("org.openjfx.javafxplugin") version("0.0.11")
 }

--- a/tools/check-publication/build.gradle.kts
+++ b/tools/check-publication/build.gradle.kts
@@ -23,7 +23,7 @@ import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
-    id("kmp-configuration")
+    id(pluginId.kmp.configuration)
 }
 
 val pConfig = kmpPublishRootProjectConfiguration!!


### PR DESCRIPTION
Bumps `kotlin-components` to latest stable version:
 - dependency `atomicfu` from `0.17.2` -> `0.17.3`
 - dependency `coroutines` from `1.6.1` -> `1.6.2`
 - adds `pluginId` shortcuts