### PR TITLE
Add atomics to `TorConfig.Setting.*`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kmp-tor
 [![Kotlin](https://img.shields.io/badge/kotlin-1.6.21-blue.svg?logo=kotlin)](http://kotlinlang.org)
-[![Kotlin Coroutines](https://img.shields.io/badge/coroutines-1.6.2-blue.svg?logo=kotlin)](https://github.com/Kotlin/kotlinx.coroutines)
+[![Kotlin Coroutines](https://img.shields.io/badge/coroutines-1.6.3-blue.svg?logo=kotlin)](https://github.com/Kotlin/kotlinx.coroutines)
 [![Kotlin Atomicfu](https://img.shields.io/badge/atomicfu-0.17.3-blue.svg?logo=kotlin)](https://github.com/Kotlin/kotlinx.atomicfu)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)  
 

--- a/library/controller/kmp-tor-controller-common/build.gradle.kts
+++ b/library/controller/kmp-tor-controller-common/build.gradle.kts
@@ -63,8 +63,10 @@ kmpConfiguration {
 
             KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
+        commonPluginIds = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
+                implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.reflect)
                 api(project(":library:kmp-tor-common"))
             }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -279,6 +279,7 @@ class TorConfig private constructor(
             }
             return this
         }
+
         open fun setDefault(): Setting<T> {
             if (isMutable) {
                 _value.value = default
@@ -299,14 +300,13 @@ class TorConfig private constructor(
         }
 
         override fun toString(): String {
-            val simpleName = this::class.simpleName?.let { ".$it" } ?: ""
-            return "TorConfig.Setting$simpleName(keyword=$keyword, value=$value, default=$default)"
+            return "${this::class.simpleName}(keyword=$keyword, value=$value, default=$default)"
         }
 
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#AutomapHostsOnResolve
          * */
-        class AutomapHostsOnResolve         : Setting<Option.TorF>(
+        class AutomapHostsOnResolve                 : Setting<Option.TorF>(
             keyword = "AutomapHostsOnResolve",
             default = Option.TorF.True,
             isStartArgument = false,
@@ -320,7 +320,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#CacheDirectory
          * */
-        class CacheDirectory                : Setting<Option.FileSystemDir?>(
+        class CacheDirectory                        : Setting<Option.FileSystemDir?>(
             keyword = "CacheDirectory",
             default = null,
             isStartArgument = true,
@@ -338,7 +338,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ClientOnionAuthDir
          * */
-        class ClientOnionAuthDir            : Setting<Option.FileSystemDir?>(
+        class ClientOnionAuthDir                    : Setting<Option.FileSystemDir?>(
             keyword = "ClientOnionAuthDir",
             default = null,
             isStartArgument = true,
@@ -360,7 +360,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ConnectionPadding
          * */
-        class ConnectionPadding             : Setting<Option.AorTorF>(
+        class ConnectionPadding                     : Setting<Option.AorTorF>(
             keyword = "ConnectionPadding",
             default = Option.AorTorF.Auto,
             isStartArgument = false,
@@ -374,7 +374,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ConnectionPaddingReduced
          * */
-        class ConnectionPaddingReduced      : Setting<Option.TorF>(
+        class ConnectionPaddingReduced              : Setting<Option.TorF>(
             keyword = "ReducedConnectionPadding",
             default = Option.TorF.False,
             isStartArgument = false,
@@ -388,7 +388,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ControlPortWriteToFile
          * */
-        class ControlPortWriteToFile        : Setting<Option.FileSystemFile?>(
+        class ControlPortWriteToFile                : Setting<Option.FileSystemFile?>(
             keyword = "ControlPortWriteToFile",
             default = null,
             isStartArgument = true,
@@ -410,7 +410,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#CookieAuthentication
          * */
-        class CookieAuthentication          : Setting<Option.TorF>(
+        class CookieAuthentication                  : Setting<Option.TorF>(
             keyword = "CookieAuthentication",
             default = Option.TorF.True,
             isStartArgument = true,
@@ -424,7 +424,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#CookieAuthFile
          * */
-        class CookieAuthFile                : Setting<Option.FileSystemFile?>(
+        class CookieAuthFile                        : Setting<Option.FileSystemFile?>(
             keyword = "CookieAuthFile",
             default = null,
             isStartArgument = true,
@@ -446,7 +446,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DataDirectory
          * */
-        class DataDirectory                 : Setting<Option.FileSystemDir?>(
+        class DataDirectory                         : Setting<Option.FileSystemDir?>(
             keyword = "DataDirectory",
             default = null,
             isStartArgument = true,
@@ -468,7 +468,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DisableNetwork
          * */
-        class DisableNetwork                : Setting<Option.TorF>(
+        class DisableNetwork                        : Setting<Option.TorF>(
             keyword = "DisableNetwork",
             default = Option.TorF.False,
             isStartArgument = true,
@@ -482,7 +482,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DormantCanceledByStartup
          * */
-        class DormantCanceledByStartup      : Setting<Option.TorF>(
+        class DormantCanceledByStartup              : Setting<Option.TorF>(
             keyword = "DormantCanceledByStartup",
             default = Option.TorF.False,
             isStartArgument = true,
@@ -496,7 +496,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DormantClientTimeout
          * */
-        class DormantClientTimeout          : Setting<Option.Time>(
+        class DormantClientTimeout                  : Setting<Option.Time>(
             keyword = "DormantClientTimeout",
             default = Option.Time.Hours(24),
             isStartArgument = false,
@@ -518,7 +518,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DormantOnFirstStartup
          * */
-        class DormantOnFirstStartup         : Setting<Option.TorF>(
+        class DormantOnFirstStartup                 : Setting<Option.TorF>(
             keyword = "DormantOnFirstStartup",
             default = Option.TorF.False,
             isStartArgument = true,
@@ -546,7 +546,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#GeoIPExcludeUnknown
          * */
-        class GeoIPExcludeUnknown           : Setting<Option.AorTorF>(
+        class GeoIPExcludeUnknown                   : Setting<Option.AorTorF>(
             keyword = "GeoIPExcludeUnknown",
             default = Option.AorTorF.Auto,
             isStartArgument = false,
@@ -560,7 +560,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#GeoIPFile
          * */
-        class GeoIpV4File                   : Setting<Option.FileSystemFile?>(
+        class GeoIpV4File                           : Setting<Option.FileSystemFile?>(
             keyword = "GeoIPFile",
             default = null,
             isStartArgument = true,
@@ -578,7 +578,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#GeoIPv6File
          * */
-        class GeoIpV6File                   : Setting<Option.FileSystemFile?>(
+        class GeoIpV6File                           : Setting<Option.FileSystemFile?>(
             keyword = "GeoIPv6File",
             default = null,
             isStartArgument = true,
@@ -619,7 +619,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#HiddenServiceMaxStreams
          * https://2019.www.torproject.org/docs/tor-manual.html.en#HiddenServiceMaxStreamsCloseCircuit
          * */
-        class HiddenService                 : Setting<Option.FileSystemDir?>(
+        class HiddenService                         : Setting<Option.FileSystemDir?>(
             keyword = "HiddenServiceDir",
             default = null,
             isStartArgument = false,
@@ -877,7 +877,7 @@ class TorConfig private constructor(
         /**
          * https://torproject.gitlab.io/torspec/control-spec/#takeownership
          * */
-        class OwningControllerProcess       : Setting<Option.ProcessId?>(
+        class OwningControllerProcess               : Setting<Option.ProcessId?>(
             keyword = "__OwningControllerProcess",
             default = null,
             isStartArgument = true,
@@ -942,7 +942,7 @@ class TorConfig private constructor(
              *
              * @see [UnixSockets.Control]
              * */
-            class Control                       : Ports(
+            class Control                               : Ports(
                 keyword = "ControlPort",
                 default = Option.AorDorPort.Auto,
                 isStartArgument = true,
@@ -964,7 +964,7 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#DNSPort
              * */
-            class Dns                           : Ports(
+            class Dns                                   : Ports(
                 keyword = "DNSPort",
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
@@ -996,7 +996,7 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#HTTPTunnelPort
              * */
-            class HttpTunnel                    : Ports(
+            class HttpTunnel                            : Ports(
                 keyword = "HTTPTunnelPort",
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
@@ -1028,7 +1028,7 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
              * */
-            class Socks                         : Ports(
+            class Socks                                 : Ports(
                 keyword = "SocksPort",
                 default = Option.AorDorPort.Value(PortProxy(9050)),
                 isStartArgument = false,
@@ -1093,7 +1093,7 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#TransPort
              * */
-            class Trans                         : Ports(
+            class Trans                                 : Ports(
                 keyword = "TransPort",
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
@@ -1187,7 +1187,7 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#ControlPort
              * */
-            class Control                       : UnixSockets(
+            class Control                               : UnixSockets(
                 keyword = "ControlPort",
                 isStartArgument = true,
             ) {
@@ -1237,7 +1237,7 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
              * */
-            class Socks                       : UnixSockets(
+            class Socks                             : UnixSockets(
                 keyword = "SocksPort",
                 isStartArgument = false,
             ) {
@@ -1302,7 +1302,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#RunAsDaemon
          * */
-        class RunAsDaemon                   : Setting<Option.TorF>(
+        class RunAsDaemon                           : Setting<Option.TorF>(
             keyword = "RunAsDaemon",
             default = Option.TorF.False,
             isStartArgument = true,
@@ -1316,7 +1316,7 @@ class TorConfig private constructor(
         /**
          * https://2019.www.torproject.org/docs/tor-manual.html.en#SyslogIdentityTag
          * */
-        class SyslogIdentityTag             : Setting<Option.FieldId?>(
+        class SyslogIdentityTag                     : Setting<Option.FieldId?>(
             keyword = "SyslogIdentityTag",
             default = null,
             isStartArgument = true,

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -31,6 +31,7 @@ import io.matthewnelson.kmp.tor.controller.common.internal.isUnixPath
 import kotlinx.atomicfu.AtomicBoolean
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
 import kotlin.jvm.*
 import kotlin.reflect.KClass
 
@@ -269,20 +270,20 @@ class TorConfig private constructor(
 
         @JvmSynthetic
         internal fun setImmutable(): Setting<T> {
-            _isMutable.value = false
+            _isMutable.update { false }
             return this
         }
 
         open fun set(value: T): Setting<T> {
             if (isMutable) {
-                _value.value = value
+                _value.update { value }
             }
             return this
         }
 
         open fun setDefault(): Setting<T> {
             if (isMutable) {
-                _value.value = default
+                _value.update { default }
             }
             return this
         }
@@ -657,7 +658,7 @@ class TorConfig private constructor(
             fun setPorts(ports: Set<VirtualPort>?): HiddenService {
                 if (isMutable) {
                     if (ports.isNullOrEmpty()) {
-                        _ports.value = null
+                        _ports.update { null }
                     } else {
                         val filtered = ports.filter { instance ->
                             when (instance) {
@@ -672,10 +673,12 @@ class TorConfig private constructor(
                             }
                         }
 
-                        _ports.value = if (filtered.isNotEmpty()) {
-                            filtered.toSet()
-                        } else {
-                            null
+                        _ports.update {
+                            if (filtered.isNotEmpty()) {
+                                filtered.toSet()
+                            } else {
+                                null
+                            }
                         }
                     }
                 }
@@ -685,14 +688,14 @@ class TorConfig private constructor(
 
             fun setMaxStreams(maxStreams: MaxStreams?): HiddenService {
                 if (isMutable) {
-                    _maxStreams.value = maxStreams
+                    _maxStreams.update { maxStreams }
                 }
                 return this
             }
 
             fun setMaxStreamsCloseCircuit(value: Option.TorF?): HiddenService {
                 if (isMutable) {
-                    _maxStreamsCloseCircuit.value = value
+                    _maxStreamsCloseCircuit.update { value }
                 }
                 return this
             }
@@ -700,9 +703,9 @@ class TorConfig private constructor(
             override fun setDefault(): HiddenService {
                 if (isMutable) {
                     super.setDefault()
-                    _ports.value = null
-                    _maxStreams.value = null
-                    _maxStreamsCloseCircuit.value = null
+                    _ports.update {  null }
+                    _maxStreams.update {  null }
+                    _maxStreamsCloseCircuit.update {  null }
                 }
                 return this
             }
@@ -980,14 +983,14 @@ class TorConfig private constructor(
                 override fun setDefault(): Dns {
                     if (isMutable) {
                         super.setDefault()
-                        _isolationFlags.value = null
+                        _isolationFlags.update { null }
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): Dns {
                     if (isMutable) {
-                        _isolationFlags.value = flags?.toSet()
+                        _isolationFlags.update { flags?.toSet() }
                     }
                     return this
                 }
@@ -1013,14 +1016,14 @@ class TorConfig private constructor(
                 override fun setDefault(): HttpTunnel {
                     if (isMutable) {
                         super.setDefault()
-                        _isolationFlags.value = null
+                        _isolationFlags.update { null }
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): HttpTunnel {
                     if (isMutable) {
-                        _isolationFlags.value = flags?.toSet()
+                        _isolationFlags.update { flags?.toSet() }
                     }
                     return this
                 }
@@ -1050,22 +1053,22 @@ class TorConfig private constructor(
                 override fun setDefault(): Socks {
                     if (isMutable) {
                         super.setDefault()
-                        _flags.value = null
-                        _isolationFlags.value = null
+                        _flags.update { null }
+                        _isolationFlags.update { null }
                     }
                     return this
                 }
 
                 fun setFlags(flags: Set<Flag>?): Socks {
                     if (isMutable) {
-                        _flags.value = flags?.toSet()
+                        _flags.update { flags?.toSet() }
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): Socks {
                     if (isMutable) {
-                        _isolationFlags.value = flags?.toSet()
+                        _isolationFlags.update { flags?.toSet() }
                     }
                     return this
                 }
@@ -1114,14 +1117,14 @@ class TorConfig private constructor(
                 override fun setDefault(): Trans {
                     if (isMutable) {
                         super.setDefault()
-                        _isolationFlags.value = null
+                        _isolationFlags.update { null }
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): Trans {
                     if (isMutable) {
-                        _isolationFlags.value = flags?.toSet()
+                        _isolationFlags.update { flags?.toSet() }
                     }
                     return this
                 }
@@ -1208,14 +1211,14 @@ class TorConfig private constructor(
                 override fun setDefault(): Control {
                     if (isMutable) {
                         super.setDefault()
-                        _unixFlags.value = null
+                        _unixFlags.update { null }
                     }
                     return this
                 }
 
                 fun setUnixFlags(flags: Set<UnixSockets.Control.Flag>?): Control {
                     if (isMutable) {
-                        _unixFlags.value = flags?.toSet()
+                        _unixFlags.update { flags?.toSet() }
                     }
                     return this
                 }
@@ -1267,30 +1270,30 @@ class TorConfig private constructor(
                 override fun setDefault(): Socks {
                     if (isMutable) {
                         super.setDefault()
-                        _flags.value = null
-                        _unixFlags.value = null
-                        _isolationFlags.value = null
+                        _flags.update { null }
+                        _unixFlags.update { null }
+                        _isolationFlags.update { null }
                     }
                     return this
                 }
 
                 fun setFlags(flags: Set<Ports.Socks.Flag>?): Socks {
                     if (isMutable) {
-                        _flags.value = flags?.toSet()
+                        _flags.update { flags?.toSet() }
                     }
                     return this
                 }
 
                 fun setUnixFlags(flags: Set<UnixSockets.Flag>?): Socks {
                     if (isMutable) {
-                        _unixFlags.value = flags?.toSet()
+                        _unixFlags.update { flags?.toSet() }
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<Ports.IsolationFlag>?): Socks {
                     if (isMutable) {
-                        _isolationFlags.value = flags?.toSet()
+                        _isolationFlags.update { flags?.toSet() }
                     }
                     return this
                 }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -243,8 +243,14 @@ class TorConfig private constructor(
      *
      * https://2019.www.torproject.org/docs/tor-manual.html.en
      * */
-    @Suppress("PropertyName")
-    sealed class Setting<T: Option?>(@JvmField val keyword: String, @JvmField val default: T) {
+    @Suppress("PropertyName", "CanBePrimaryConstructorProperty")
+    sealed class Setting<T: Option?>(
+        @JvmField
+        val keyword: String,
+        @JvmField
+        val default: T,
+        isStartArgument: Boolean,
+    ) {
 
         private val _value: AtomicRef<T> = atomic(default)
         @get:JvmName("value")
@@ -257,8 +263,9 @@ class TorConfig private constructor(
         @get:JvmName("isMutable")
         val isMutable: Boolean get() = _isMutable.value
 
+        @JvmField
         @InternalTorApi
-        abstract val isStartArgument: Boolean
+        val isStartArgument: Boolean = isStartArgument
 
         @JvmSynthetic
         internal fun setImmutable(): Setting<T> {
@@ -302,10 +309,8 @@ class TorConfig private constructor(
         class AutomapHostsOnResolve         : Setting<Option.TorF>(
             keyword = "AutomapHostsOnResolve",
             default = Option.TorF.True,
+            isStartArgument = false,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = false
 
             override fun clone(): AutomapHostsOnResolve {
                 return AutomapHostsOnResolve().set(value) as AutomapHostsOnResolve
@@ -318,10 +323,8 @@ class TorConfig private constructor(
         class CacheDirectory                : Setting<Option.FileSystemDir?>(
             keyword = "CacheDirectory",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FileSystemDir?): Setting<Option.FileSystemDir?> {
                 return super.set(value?.nullIfEmpty)
@@ -338,10 +341,8 @@ class TorConfig private constructor(
         class ClientOnionAuthDir            : Setting<Option.FileSystemDir?>(
             keyword = "ClientOnionAuthDir",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FileSystemDir?): Setting<Option.FileSystemDir?> {
                 return super.set(value?.nullIfEmpty)
@@ -362,10 +363,8 @@ class TorConfig private constructor(
         class ConnectionPadding             : Setting<Option.AorTorF>(
             keyword = "ConnectionPadding",
             default = Option.AorTorF.Auto,
+            isStartArgument = false,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = false
 
             override fun clone(): ConnectionPadding {
                 return ConnectionPadding().set(value) as ConnectionPadding
@@ -378,10 +377,8 @@ class TorConfig private constructor(
         class ConnectionPaddingReduced      : Setting<Option.TorF>(
             keyword = "ReducedConnectionPadding",
             default = Option.TorF.False,
+            isStartArgument = false,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = false
 
             override fun clone(): ConnectionPaddingReduced {
                 return ConnectionPaddingReduced().set(value) as ConnectionPaddingReduced
@@ -394,10 +391,8 @@ class TorConfig private constructor(
         class ControlPortWriteToFile        : Setting<Option.FileSystemFile?>(
             keyword = "ControlPortWriteToFile",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FileSystemFile?): Setting<Option.FileSystemFile?> {
                 return super.set(value?.nullIfEmpty)
@@ -418,10 +413,8 @@ class TorConfig private constructor(
         class CookieAuthentication          : Setting<Option.TorF>(
             keyword = "CookieAuthentication",
             default = Option.TorF.True,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun clone(): CookieAuthentication {
                 return CookieAuthentication().set(value) as CookieAuthentication
@@ -434,10 +427,8 @@ class TorConfig private constructor(
         class CookieAuthFile                : Setting<Option.FileSystemFile?>(
             keyword = "CookieAuthFile",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FileSystemFile?): Setting<Option.FileSystemFile?> {
                 return super.set(value?.nullIfEmpty)
@@ -458,10 +449,8 @@ class TorConfig private constructor(
         class DataDirectory                 : Setting<Option.FileSystemDir?>(
             keyword = "DataDirectory",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FileSystemDir?): Setting<Option.FileSystemDir?> {
                 return super.set(value?.nullIfEmpty)
@@ -482,10 +471,8 @@ class TorConfig private constructor(
         class DisableNetwork                : Setting<Option.TorF>(
             keyword = "DisableNetwork",
             default = Option.TorF.False,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun clone(): DisableNetwork {
                 return DisableNetwork().set(value) as DisableNetwork
@@ -498,10 +485,8 @@ class TorConfig private constructor(
         class DormantCanceledByStartup      : Setting<Option.TorF>(
             keyword = "DormantCanceledByStartup",
             default = Option.TorF.False,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun clone(): DormantCanceledByStartup {
                 return DormantCanceledByStartup().set(value) as DormantCanceledByStartup
@@ -514,10 +499,8 @@ class TorConfig private constructor(
         class DormantClientTimeout          : Setting<Option.Time>(
             keyword = "DormantClientTimeout",
             default = Option.Time.Hours(24),
+            isStartArgument = false,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = false
 
             override fun set(value: Option.Time): Setting<Option.Time> {
                 return if (value is Option.Time.Minutes && value.time < 10) {
@@ -538,10 +521,8 @@ class TorConfig private constructor(
         class DormantOnFirstStartup         : Setting<Option.TorF>(
             keyword = "DormantOnFirstStartup",
             default = Option.TorF.False,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun clone(): DormantOnFirstStartup {
                 return DormantOnFirstStartup().set(value) as DormantOnFirstStartup
@@ -554,10 +535,8 @@ class TorConfig private constructor(
         class DormantTimeoutDisabledByIdleStreams   : Setting<Option.TorF>(
             keyword = "DormantTimeoutDisabledByIdleStreams",
             default = Option.TorF.True,
+            isStartArgument = false,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = false
 
             override fun clone(): DormantTimeoutDisabledByIdleStreams {
                 return DormantTimeoutDisabledByIdleStreams().set(value) as DormantTimeoutDisabledByIdleStreams
@@ -570,10 +549,8 @@ class TorConfig private constructor(
         class GeoIPExcludeUnknown           : Setting<Option.AorTorF>(
             keyword = "GeoIPExcludeUnknown",
             default = Option.AorTorF.Auto,
+            isStartArgument = false,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = false
 
             override fun clone(): GeoIPExcludeUnknown {
                 return GeoIPExcludeUnknown().set(value) as GeoIPExcludeUnknown
@@ -586,10 +563,8 @@ class TorConfig private constructor(
         class GeoIpV4File                   : Setting<Option.FileSystemFile?>(
             keyword = "GeoIPFile",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FileSystemFile?): Setting<Option.FileSystemFile?> {
                 return super.set(value?.nullIfEmpty)
@@ -606,10 +581,8 @@ class TorConfig private constructor(
         class GeoIpV6File                   : Setting<Option.FileSystemFile?>(
             keyword = "GeoIPv6File",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FileSystemFile?): Setting<Option.FileSystemFile?> {
                 return super.set(value?.nullIfEmpty)
@@ -649,10 +622,8 @@ class TorConfig private constructor(
         class HiddenService                 : Setting<Option.FileSystemDir?>(
             keyword = "HiddenServiceDir",
             default = null,
+            isStartArgument = false,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = false
 
             /**
              * See [HiddenService.VirtualPort]
@@ -908,18 +879,24 @@ class TorConfig private constructor(
          * */
         class OwningControllerProcess       : Setting<Option.ProcessId?>(
             keyword = "__OwningControllerProcess",
-            default = null
+            default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun clone(): OwningControllerProcess {
                 return OwningControllerProcess().set(value) as OwningControllerProcess
             }
         }
 
-        sealed class Ports(keyword: String, default: Option.AorDorPort) : Setting<Option.AorDorPort>(keyword, default) {
+        sealed class Ports(
+            keyword: String,
+            default: Option.AorDorPort,
+            isStartArgument: Boolean,
+        ) : Setting<Option.AorDorPort>(
+            keyword,
+            default,
+            isStartArgument
+        ) {
 
             override fun equals(other: Any?): Boolean {
                 if (other == null) {
@@ -968,10 +945,8 @@ class TorConfig private constructor(
             class Control                       : Ports(
                 keyword = "ControlPort",
                 default = Option.AorDorPort.Auto,
+                isStartArgument = true,
             ) {
-
-                @InternalTorApi
-                override val isStartArgument: Boolean get() = true
 
                 override fun set(value: Option.AorDorPort): Setting<Option.AorDorPort> {
                     return if (value !is Option.AorDorPort.Disable) {
@@ -992,13 +967,11 @@ class TorConfig private constructor(
             class Dns                           : Ports(
                 keyword = "DNSPort",
                 default = Option.AorDorPort.Disable,
+                isStartArgument = false,
             ) {
 
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
-
-                @InternalTorApi
-                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): Dns {
                     if (isMutable) {
@@ -1026,13 +999,11 @@ class TorConfig private constructor(
             class HttpTunnel                    : Ports(
                 keyword = "HTTPTunnelPort",
                 default = Option.AorDorPort.Disable,
+                isStartArgument = false,
             ) {
 
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
-
-                @InternalTorApi
-                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): HttpTunnel {
                     if (isMutable) {
@@ -1060,15 +1031,13 @@ class TorConfig private constructor(
             class Socks                         : Ports(
                 keyword = "SocksPort",
                 default = Option.AorDorPort.Value(PortProxy(9050)),
+                isStartArgument = false,
             ) {
 
                 var flags: Set<Flag>? = null
                     private set
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
-
-                @InternalTorApi
-                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): Socks {
                     if (isMutable) {
@@ -1127,13 +1096,11 @@ class TorConfig private constructor(
             class Trans                         : Ports(
                 keyword = "TransPort",
                 default = Option.AorDorPort.Disable,
+                isStartArgument = false,
             ) {
 
                 var isolationFlags: Set<IsolationFlag>? = null
                     private set
-
-                @InternalTorApi
-                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): Trans {
                     if (isMutable) {
@@ -1187,7 +1154,14 @@ class TorConfig private constructor(
             }
         }
 
-        sealed class UnixSockets(keyword: String) : Setting<Option.FileSystemFile?>(keyword, null) {
+        sealed class UnixSockets(
+            keyword: String,
+            isStartArgument: Boolean,
+        ) : Setting<Option.FileSystemFile?>(
+            keyword,
+            null,
+            isStartArgument
+        ) {
 
             final override fun set(value: Option.FileSystemFile?): Setting<Option.FileSystemFile?> {
                 // Do not set if platform is something other than linux
@@ -1213,13 +1187,13 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#ControlPort
              * */
-            class Control                       : UnixSockets(keyword = "ControlPort") {
+            class Control                       : UnixSockets(
+                keyword = "ControlPort",
+                isStartArgument = true,
+            ) {
 
                 var unixFlags: Set<UnixSockets.Control.Flag>? = null
                     private set
-
-                @InternalTorApi
-                override val isStartArgument: Boolean get() = true
 
                 override fun setDefault(): Control {
                     if (isMutable) {
@@ -1263,7 +1237,10 @@ class TorConfig private constructor(
             /**
              * https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
              * */
-            class Socks                       : UnixSockets(keyword = "SocksPort") {
+            class Socks                       : UnixSockets(
+                keyword = "SocksPort",
+                isStartArgument = false,
+            ) {
 
                 var flags: Set<Ports.Socks.Flag>? = null
                     private set
@@ -1271,9 +1248,6 @@ class TorConfig private constructor(
                     private set
                 var isolationFlags: Set<Ports.IsolationFlag>? = null
                     private set
-
-                @InternalTorApi
-                override val isStartArgument: Boolean get() = false
 
                 override fun setDefault(): Socks {
                     if (isMutable) {
@@ -1331,10 +1305,8 @@ class TorConfig private constructor(
         class RunAsDaemon                   : Setting<Option.TorF>(
             keyword = "RunAsDaemon",
             default = Option.TorF.False,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun clone(): RunAsDaemon {
                 return RunAsDaemon().set(value) as RunAsDaemon
@@ -1347,10 +1319,8 @@ class TorConfig private constructor(
         class SyslogIdentityTag             : Setting<Option.FieldId?>(
             keyword = "SyslogIdentityTag",
             default = null,
+            isStartArgument = true,
         ) {
-
-            @InternalTorApi
-            override val isStartArgument: Boolean get() = true
 
             override fun set(value: Option.FieldId?): Setting<Option.FieldId?> {
                 return super.set(value?.nullIfEmpty)

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -628,8 +628,9 @@ class TorConfig private constructor(
             /**
              * See [HiddenService.VirtualPort]
              * */
-            var ports: Set<HiddenService.VirtualPort>? = null
-                private set
+            private val _ports: AtomicRef<Set<HiddenService.VirtualPort>?> = atomic(null)
+            @get:JvmName("ports")
+            val ports: Set<HiddenService.VirtualPort>? get() = _ports.value
 
             /**
              * A value of `null` means it will not be written to the config and falls
@@ -637,15 +638,17 @@ class TorConfig private constructor(
              *
              * @see [MaxStreams]
              * */
-            var maxStreams: MaxStreams? = null
-                private set
+            private val _maxStreams: AtomicRef<MaxStreams?> = atomic(null)
+            @get:JvmName("maxStreams")
+            val maxStreams: MaxStreams? get() = _maxStreams.value
 
             /**
              * A value of `null` means it will not be written to the config and falls
              * back to Tor's default setting of [Option.TorF.False]
              * */
-            var maxStreamsCloseCircuit: Option.TorF? = null
-                private set
+            private val _maxStreamsCloseCircuit: AtomicRef<Option.TorF?> = atomic(null)
+            @get:JvmName("maxStreamsCloseCircuit")
+            val maxStreamsCloseCircuit: Option.TorF? get() = _maxStreamsCloseCircuit.value
 
             override fun set(value: Option.FileSystemDir?): Setting<Option.FileSystemDir?> {
                 return super.set(value?.nullIfEmpty)
@@ -654,7 +657,7 @@ class TorConfig private constructor(
             fun setPorts(ports: Set<VirtualPort>?): HiddenService {
                 if (isMutable) {
                     if (ports.isNullOrEmpty()) {
-                        this.ports = null
+                        _ports.value = null
                     } else {
                         val filtered = ports.filter { instance ->
                             when (instance) {
@@ -669,7 +672,7 @@ class TorConfig private constructor(
                             }
                         }
 
-                        this.ports = if (filtered.isNotEmpty()) {
+                        _ports.value = if (filtered.isNotEmpty()) {
                             filtered.toSet()
                         } else {
                             null
@@ -682,14 +685,14 @@ class TorConfig private constructor(
 
             fun setMaxStreams(maxStreams: MaxStreams?): HiddenService {
                 if (isMutable) {
-                    this.maxStreams = maxStreams
+                    _maxStreams.value = maxStreams
                 }
                 return this
             }
 
             fun setMaxStreamsCloseCircuit(value: Option.TorF?): HiddenService {
                 if (isMutable) {
-                    maxStreamsCloseCircuit = value
+                    _maxStreamsCloseCircuit.value = value
                 }
                 return this
             }
@@ -697,9 +700,9 @@ class TorConfig private constructor(
             override fun setDefault(): HiddenService {
                 if (isMutable) {
                     super.setDefault()
-                    ports = null
-                    maxStreams = null
-                    maxStreamsCloseCircuit = null
+                    _ports.value = null
+                    _maxStreams.value = null
+                    _maxStreamsCloseCircuit.value = null
                 }
                 return this
             }
@@ -970,20 +973,21 @@ class TorConfig private constructor(
                 isStartArgument = false,
             ) {
 
-                var isolationFlags: Set<IsolationFlag>? = null
-                    private set
+                private val _isolationFlags: AtomicRef<Set<IsolationFlag>?> = atomic(null)
+                @get:JvmName("isolationFlags")
+                val isolationFlags: Set<IsolationFlag>? get() = _isolationFlags.value
 
                 override fun setDefault(): Dns {
                     if (isMutable) {
                         super.setDefault()
-                        isolationFlags = null
+                        _isolationFlags.value = null
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): Dns {
                     if (isMutable) {
-                        isolationFlags = flags?.toSet()
+                        _isolationFlags.value = flags?.toSet()
                     }
                     return this
                 }
@@ -1002,20 +1006,21 @@ class TorConfig private constructor(
                 isStartArgument = false,
             ) {
 
-                var isolationFlags: Set<IsolationFlag>? = null
-                    private set
+                private val _isolationFlags: AtomicRef<Set<IsolationFlag>?> = atomic(null)
+                @get:JvmName("isolationFlags")
+                val isolationFlags: Set<IsolationFlag>? get() = _isolationFlags.value
 
                 override fun setDefault(): HttpTunnel {
                     if (isMutable) {
                         super.setDefault()
-                        isolationFlags = null
+                        _isolationFlags.value = null
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): HttpTunnel {
                     if (isMutable) {
-                        isolationFlags = flags?.toSet()
+                        _isolationFlags.value = flags?.toSet()
                     }
                     return this
                 }
@@ -1034,30 +1039,33 @@ class TorConfig private constructor(
                 isStartArgument = false,
             ) {
 
-                var flags: Set<Flag>? = null
-                    private set
-                var isolationFlags: Set<IsolationFlag>? = null
-                    private set
+                private val _flags: AtomicRef<Set<Flag>?> = atomic(null)
+                @get:JvmName("flags")
+                val flags: Set<Flag>? get() = _flags.value
+
+                private val _isolationFlags: AtomicRef<Set<IsolationFlag>?> = atomic(null)
+                @get:JvmName("isolationFlags")
+                val isolationFlags: Set<IsolationFlag>? get() = _isolationFlags.value
 
                 override fun setDefault(): Socks {
                     if (isMutable) {
                         super.setDefault()
-                        flags = null
-                        isolationFlags = null
+                        _flags.value = null
+                        _isolationFlags.value = null
                     }
                     return this
                 }
 
                 fun setFlags(flags: Set<Flag>?): Socks {
                     if (isMutable) {
-                        this.flags = flags?.toSet()
+                        _flags.value = flags?.toSet()
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): Socks {
                     if (isMutable) {
-                        isolationFlags = flags?.toSet()
+                        _isolationFlags.value = flags?.toSet()
                     }
                     return this
                 }
@@ -1099,20 +1107,21 @@ class TorConfig private constructor(
                 isStartArgument = false,
             ) {
 
-                var isolationFlags: Set<IsolationFlag>? = null
-                    private set
+                private val _isolationFlags: AtomicRef<Set<IsolationFlag>?> = atomic(null)
+                @get:JvmName("isolationFlags")
+                val isolationFlags: Set<IsolationFlag>? get() = _isolationFlags.value
 
                 override fun setDefault(): Trans {
                     if (isMutable) {
                         super.setDefault()
-                        isolationFlags = null
+                        _isolationFlags.value = null
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<IsolationFlag>?): Trans {
                     if (isMutable) {
-                        isolationFlags = flags?.toSet()
+                        _isolationFlags.value = flags?.toSet()
                     }
                     return this
                 }
@@ -1192,20 +1201,21 @@ class TorConfig private constructor(
                 isStartArgument = true,
             ) {
 
-                var unixFlags: Set<UnixSockets.Control.Flag>? = null
-                    private set
+                private val _unixFlags: AtomicRef<Set<UnixSockets.Control.Flag>?> = atomic(null)
+                @get:JvmName("unixFlags")
+                val unixFlags: Set<UnixSockets.Control.Flag>? get() = _unixFlags.value
 
                 override fun setDefault(): Control {
                     if (isMutable) {
                         super.setDefault()
-                        unixFlags = null
+                        _unixFlags.value = null
                     }
                     return this
                 }
 
                 fun setUnixFlags(flags: Set<UnixSockets.Control.Flag>?): Control {
                     if (isMutable) {
-                        unixFlags = flags?.toSet()
+                        _unixFlags.value = flags?.toSet()
                     }
                     return this
                 }
@@ -1242,40 +1252,45 @@ class TorConfig private constructor(
                 isStartArgument = false,
             ) {
 
-                var flags: Set<Ports.Socks.Flag>? = null
-                    private set
-                var unixFlags: Set<UnixSockets.Flag>? = null
-                    private set
-                var isolationFlags: Set<Ports.IsolationFlag>? = null
-                    private set
+                private val _flags: AtomicRef<Set<Ports.Socks.Flag>?> = atomic(null)
+                @get:JvmName("flags")
+                val flags: Set<Ports.Socks.Flag>? get() = _flags.value
+
+                private val _unixFlags: AtomicRef<Set<UnixSockets.Flag>?> = atomic(null)
+                @get:JvmName("unixFlags")
+                val unixFlags: Set<UnixSockets.Flag>? get() = _unixFlags.value
+
+                private val _isolationFlags: AtomicRef<Set<Ports.IsolationFlag>?> = atomic(null)
+                @get:JvmName("isolationFlags")
+                val isolationFlags: Set<Ports.IsolationFlag>? get() = _isolationFlags.value
 
                 override fun setDefault(): Socks {
                     if (isMutable) {
                         super.setDefault()
-                        flags = null
-                        unixFlags = null
-                        isolationFlags = null
+                        _flags.value = null
+                        _unixFlags.value = null
+                        _isolationFlags.value = null
                     }
                     return this
                 }
 
                 fun setFlags(flags: Set<Ports.Socks.Flag>?): Socks {
                     if (isMutable) {
-                        this.flags = flags?.toSet()
+                        _flags.value = flags?.toSet()
                     }
                     return this
                 }
 
                 fun setUnixFlags(flags: Set<UnixSockets.Flag>?): Socks {
                     if (isMutable) {
-                        unixFlags = flags?.toSet()
+                        _unixFlags.value = flags?.toSet()
                     }
                     return this
                 }
 
                 fun setIsolationFlags(flags: Set<Ports.IsolationFlag>?): Socks {
                     if (isMutable) {
-                        isolationFlags = flags?.toSet()
+                        _isolationFlags.value = flags?.toSet()
                     }
                     return this
                 }


### PR DESCRIPTION
Closes #155 

- Bumps coroutines from `1.6.2` -> `1.6.3`
- Converts `TorConfig.Setting.*` classes to utilize atomic values.

**Breaking Changes due to `@Jvm*` annotations (Java users only)**:
- `Setting.value` Java method changed from `getValue()` -> `value()`
- `Setting.isMutable` Java method changed from `getIsMutable()` -> `isMutable()`
- `Setting.default` Java method changed from `getDefault()` -> property `default`
- `Setting.default` Java method changed from `getIsDefault()` -> `isDefault()`
- `Setting.HiddenService.ports` Java method changed from `getPorts()` -> `ports()`
- `Setting.HiddenService.maxStreams` Java method changed from `getMaxStreams()` -> `maxStreams()`
- `Setting.HiddenService.maxStreamsCloseCircuit` Java method changed from `getMaxStreamsCloseCircuit()` -> `maxStreamsCloseCircuit()`
- `Setting.Ports.Dns.isolationFlags` Java method changed from `getIsolationFlags()` -> `isolationFlags()`
- `Setting.Ports.HttpTunnel.isolationFlags` Java method changed from `getIsolationFlags()` -> `isolationFlags()`
- `Setting.Ports.Socks.flags` Java method changed from `getFlags()` -> `flags()`
- `Setting.Ports.Socks.isolationFlags` Java method changed from `getIsolationFlags()` -> `isolationFlags()`
- `Setting.Ports.Trans.isolationFlags` Java method changed from `getIsolationFlags()` -> `isolationFlags()`
