### PR TITLE
Rename class ControllerUtils -> PlatformUtil

### DIFF
--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -25,7 +25,7 @@ import io.matthewnelson.kmp.tor.common.util.TorStrings.SP
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.TorF.False
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.TorF.True
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.controller.common.internal.appendTo
 import io.matthewnelson.kmp.tor.controller.common.internal.isUnixPath
 import kotlinx.atomicfu.AtomicBoolean
@@ -104,7 +104,7 @@ class TorConfig private constructor(
         init {
             // Reference so that localhostAddress for JVM can have its initial
             // value set immediately from BG thread.
-            ControllerUtils
+            PlatformUtil
         }
 
         private val settings: MutableSet<TorConfig.Setting<*>> = mutableSetOf()
@@ -663,7 +663,7 @@ class TorConfig private constructor(
                         val filtered = ports.filter { instance ->
                             when (instance) {
                                 is UnixSocket -> {
-                                    if (!ControllerUtils.isLinux) {
+                                    if (!PlatformUtil.isLinux) {
                                         false
                                     } else {
                                         instance.targetUnixSocket.isUnixPath
@@ -770,7 +770,7 @@ class TorConfig private constructor(
              * android). All [UnixSocket]s will be removed when [setPorts] is
              * called, so it is safe to call this from common code.
              *
-             * You can check [ControllerUtils.isLinux] when setting up your hidden
+             * You can check [PlatformUtil.isLinux] when setting up your hidden
              * service if you need to implement a fallback to use TCP.
              *
              * EX:
@@ -1069,7 +1069,7 @@ class TorConfig private constructor(
                 val isolationFlags: Set<IsolationFlag>? get() = _isolationFlags.value
 
                 override fun set(value: Option.AorDorPort): Setting<Option.AorDorPort> {
-                    return if (ControllerUtils.isLinux) {
+                    return if (PlatformUtil.isLinux) {
                         super.set(value)
                     } else {
                         this
@@ -1139,9 +1139,9 @@ class TorConfig private constructor(
 
             final override fun set(value: Option.FileSystemFile?): Setting<Option.FileSystemFile?> {
                 // Do not set if platform is something other than linux
-                if (!ControllerUtils.isLinux) return this
+                if (!PlatformUtil.isLinux) return this
                 // Do not set if unix domain sockets are not supported for control port
-                if (this is Control && !ControllerUtils.hasControlUnixDomainSocketSupport) return this
+                if (this is Control && !PlatformUtil.hasControlUnixDomainSocketSupport) return this
                 // First character of the path must be / (Unix FileSystem) root dir char
                 if (value?.path?.isUnixPath != true) return this
 

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -16,16 +16,29 @@
 package io.matthewnelson.kmp.tor.controller.common.internal
 
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
+import kotlin.jvm.JvmStatic
 
-// TODO: Fill out
-actual object ControllerUtils {
+expect object PlatformUtil {
+
+    /**
+     * Returns the resolved IP address for localhost (typically 127.0.0.1).
+     *
+     * @throws [RuntimeException] if being called for the first time and is
+     *   called from Android's Main Thread
+     * */
+    @JvmStatic
     @InternalTorApi
-    actual fun localhostAddress(): String = "127.0.0.1"
+    @Throws(RuntimeException::class)
+    fun localhostAddress(): String
 
-    actual val isDarwin: Boolean = false
-    actual val isLinux: Boolean = false
-    actual val isMingw: Boolean = true
+    @JvmStatic
+    val isDarwin: Boolean
+    @JvmStatic
+    val isLinux: Boolean
+    @JvmStatic
+    val isMingw: Boolean
 
+    @JvmStatic
     @InternalTorApi
-    actual val hasControlUnixDomainSocketSupport: Boolean = false
+    val hasControlUnixDomainSocketSupport: Boolean
 }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/SettingExt.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/SettingExt.kt
@@ -209,7 +209,7 @@ fun TorConfig.Setting<*>.appendTo(
             sb.quoteIfTrue(!isWriteTorConfig)
 
             val localhostIp: String = try {
-                ControllerUtils.localhostAddress()
+                PlatformUtil.localhostAddress()
             } catch (_: Exception) {
                 "127.0.0.1"
             }

--- a/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfigUnitTest.kt
@@ -21,7 +21,7 @@ import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import kotlin.test.*
 
 @OptIn(InternalTorApi::class)
@@ -342,7 +342,7 @@ class TorConfigUnitTest {
     @Test
     fun givenUnixSocket_whenPathsSame_equalsEachOther() {
         // Only run if support for domain sockets is had
-        if (!ControllerUtils.hasControlUnixDomainSocketSupport) return
+        if (!PlatformUtil.hasControlUnixDomainSocketSupport) return
 
         val path = Path("/some/path")
 
@@ -368,7 +368,7 @@ class TorConfigUnitTest {
     @Test
     fun givenUnixSocketControl_whenPathDoseNotStartWithUnixFileSeparator_valueNotSet() {
         // Only run if support for domain sockets is had
-        if (!ControllerUtils.hasControlUnixDomainSocketSupport) return
+        if (!PlatformUtil.hasControlUnixDomainSocketSupport) return
 
         val control = UnixSockets.Control()
         control.set(FileSystemFile(Path("0")))
@@ -384,7 +384,7 @@ class TorConfigUnitTest {
     @Test
     fun givenUnixSocketControl_whenCloned_matchesOriginal() {
         // Only run if support for domain sockets is had
-        if (!ControllerUtils.hasControlUnixDomainSocketSupport) return
+        if (!PlatformUtil.hasControlUnixDomainSocketSupport) return
 
         val control = UnixSockets.Control()
         control.set(FileSystemFile(Path("/some/path")))
@@ -405,7 +405,7 @@ class TorConfigUnitTest {
     @Test
     fun givenUnixSocketSocks_whenPathDoseNotStartWithUnixFileSeparator_valueNotSet() {
         // Only run if support for domain sockets is had
-        if (!ControllerUtils.hasControlUnixDomainSocketSupport) return
+        if (!PlatformUtil.hasControlUnixDomainSocketSupport) return
 
         val socks = UnixSockets.Socks()
         socks.set(FileSystemFile(Path("0")))
@@ -421,7 +421,7 @@ class TorConfigUnitTest {
     @Test
     fun givenUnixSocketSocks_whenCloned_matchesOriginal() {
         // Only run if support for domain sockets is had
-        if (!ControllerUtils.hasControlUnixDomainSocketSupport) return
+        if (!PlatformUtil.hasControlUnixDomainSocketSupport) return
 
         val socks = UnixSockets.Socks()
         socks.set(FileSystemFile(Path("/some/path")))

--- a/library/controller/kmp-tor-controller-common/src/darwinMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/darwinMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -18,45 +18,14 @@ package io.matthewnelson.kmp.tor.controller.common.internal
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 
 // TODO: Fill out
-actual object ControllerUtils {
+actual object PlatformUtil {
     @InternalTorApi
     actual fun localhostAddress(): String = "127.0.0.1"
 
-    actual val isDarwin: Boolean by lazy {
-        platform == "darwin"
-    }
-    actual val isLinux: Boolean by lazy {
-        platform == "linux" || platform == "android"
-    }
-    actual val isMingw: Boolean by lazy {
-        platform == "win32"
-    }
+    actual val isDarwin: Boolean = true
+    actual val isLinux: Boolean = false
+    actual val isMingw: Boolean = false
 
     @InternalTorApi
     actual val hasControlUnixDomainSocketSupport: Boolean = false
 }
-
-/**
- * Returns:
- *  - aix
- *  - android
- *  - darwin
- *  - freebsd
- *  - linux
- *  - openbsd
- *  - sunos
- *  - win32
- * */
-private val platform: String
-    get() {
-        return os?.platform() as? String ?: "linux"
-    }
-
-private val os: dynamic
-    get() {
-        return try {
-            js("require('os')")
-        } catch (_: Throwable) {
-            null
-        }
-    }

--- a/library/controller/kmp-tor-controller-common/src/jsMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/jsMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -18,14 +18,45 @@ package io.matthewnelson.kmp.tor.controller.common.internal
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 
 // TODO: Fill out
-actual object ControllerUtils {
+actual object PlatformUtil {
     @InternalTorApi
     actual fun localhostAddress(): String = "127.0.0.1"
 
-    actual val isDarwin: Boolean = false
-    actual val isLinux: Boolean = true
-    actual val isMingw: Boolean = false
+    actual val isDarwin: Boolean by lazy {
+        platform == "darwin"
+    }
+    actual val isLinux: Boolean by lazy {
+        platform == "linux" || platform == "android"
+    }
+    actual val isMingw: Boolean by lazy {
+        platform == "win32"
+    }
 
     @InternalTorApi
-    actual val hasControlUnixDomainSocketSupport: Boolean = true
+    actual val hasControlUnixDomainSocketSupport: Boolean = false
 }
+
+/**
+ * Returns:
+ *  - aix
+ *  - android
+ *  - darwin
+ *  - freebsd
+ *  - linux
+ *  - openbsd
+ *  - sunos
+ *  - win32
+ * */
+private val platform: String
+    get() {
+        return os?.platform() as? String ?: "linux"
+    }
+
+private val os: dynamic
+    get() {
+        return try {
+            js("require('os')")
+        } catch (_: Throwable) {
+            null
+        }
+    }

--- a/library/controller/kmp-tor-controller-common/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -18,7 +18,7 @@ package io.matthewnelson.kmp.tor.controller.common.internal
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import java.net.InetAddress
 
-actual object ControllerUtils {
+actual object PlatformUtil {
 
     @InternalTorApi
     const val ANDROID_NET_MAIN_THREAD_EXCEPTION = "android.os.NetworkOnMainThreadException"

--- a/library/controller/kmp-tor-controller-common/src/linuxMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/linuxMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -16,29 +16,16 @@
 package io.matthewnelson.kmp.tor.controller.common.internal
 
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
-import kotlin.jvm.JvmStatic
 
-expect object ControllerUtils {
-
-    /**
-     * Returns the resolved IP address for localhost (typically 127.0.0.1).
-     *
-     * @throws [RuntimeException] if being called for the first time and is
-     *   called from Android's Main Thread
-     * */
-    @JvmStatic
+// TODO: Fill out
+actual object PlatformUtil {
     @InternalTorApi
-    @Throws(RuntimeException::class)
-    fun localhostAddress(): String
+    actual fun localhostAddress(): String = "127.0.0.1"
 
-    @JvmStatic
-    val isDarwin: Boolean
-    @JvmStatic
-    val isLinux: Boolean
-    @JvmStatic
-    val isMingw: Boolean
+    actual val isDarwin: Boolean = false
+    actual val isLinux: Boolean = true
+    actual val isMingw: Boolean = false
 
-    @JvmStatic
     @InternalTorApi
-    val hasControlUnixDomainSocketSupport: Boolean
+    actual val hasControlUnixDomainSocketSupport: Boolean = true
 }

--- a/library/controller/kmp-tor-controller-common/src/mingwMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/mingwMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -18,13 +18,13 @@ package io.matthewnelson.kmp.tor.controller.common.internal
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 
 // TODO: Fill out
-actual object ControllerUtils {
+actual object PlatformUtil {
     @InternalTorApi
     actual fun localhostAddress(): String = "127.0.0.1"
 
-    actual val isDarwin: Boolean = true
+    actual val isDarwin: Boolean = false
     actual val isLinux: Boolean = false
-    actual val isMingw: Boolean = false
+    actual val isMingw: Boolean = true
 
     @InternalTorApi
     actual val hasControlUnixDomainSocketSupport: Boolean = false

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -36,7 +36,7 @@ import io.matthewnelson.kmp.tor.common.util.TorStrings.CLRF
 import io.matthewnelson.kmp.tor.common.util.TorStrings.MULTI_LINE_END
 import io.matthewnelson.kmp.tor.common.util.TorStrings.SP
 import io.matthewnelson.kmp.tor.controller.common.config.HiddenServiceEntry
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.controller.common.internal.appendTo
 import io.matthewnelson.kmp.tor.controller.internal.controller.ControlPortInteractor
 import io.matthewnelson.kmp.tor.controller.internal.controller.ReplyLine
@@ -487,10 +487,10 @@ private class RealTorControlProcessor(
 
                 if (hsPorts.isNotEmpty()) {
                     val localHostIp = try {
-                        ControllerUtils.localhostAddress()
+                        PlatformUtil.localhostAddress()
                     } catch (_: RuntimeException) {
                         withContext(Dispatchers.Default) {
-                            ControllerUtils.localhostAddress()
+                            PlatformUtil.localhostAddress()
                         }
                     }
 

--- a/library/controller/kmp-tor-controller/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
+++ b/library/controller/kmp-tor-controller/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
@@ -24,7 +24,7 @@ import io.matthewnelson.kmp.tor.controller.common.events.TorEvent
 import io.matthewnelson.kmp.tor.controller.common.events.TorEventProcessor
 import io.matthewnelson.kmp.tor.controller.common.exceptions.TorControllerException
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.controller.common.internal.isUnixPath
 import io.matthewnelson.kmp.tor.controller.internal.controller.getTorControllerDispatchers
 import io.matthewnelson.kmp.tor.controller.internal.util.toTorController
@@ -88,14 +88,14 @@ actual interface TorController: TorControlProcessor, TorEventProcessor<TorEvent.
             }
 
             @OptIn(InternalTorApi::class)
-            if (!ControllerUtils.hasControlUnixDomainSocketSupport) {
+            if (!PlatformUtil.hasControlUnixDomainSocketSupport) {
                 throw TorControllerException("UnixDomainSockets unsupported")
             }
 
             @OptIn(InternalTorApi::class)
             val clazz: Class<*> = try {
-                Class.forName(ControllerUtils.UNIX_DOMAIN_SOCKET_FACTORY_CLASS)
-                    ?: throw ClassNotFoundException(ControllerUtils.UNIX_DOMAIN_SOCKET_FACTORY_CLASS)
+                Class.forName(PlatformUtil.UNIX_DOMAIN_SOCKET_FACTORY_CLASS)
+                    ?: throw ClassNotFoundException(PlatformUtil.UNIX_DOMAIN_SOCKET_FACTORY_CLASS)
             } catch (e: ClassNotFoundException) {
                 throw TorControllerException("UnixDomainSockets unsupported. Add the kmp-tor-ext-unix-socket dependency", e)
             }

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
@@ -24,7 +24,7 @@ import io.matthewnelson.kmp.tor.controller.common.control.TorControlOnionClientA
 import io.matthewnelson.kmp.tor.controller.common.control.usecase.TorControlInfoGet.KeyWord
 import io.matthewnelson.kmp.tor.controller.common.control.usecase.TorControlOnionAdd
 import io.matthewnelson.kmp.tor.controller.common.events.TorEvent
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.controller.common.internal.appendTo
 import io.matthewnelson.kmp.tor.helper.TorTestHelper
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
@@ -521,7 +521,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
     @Test
     fun givenTorController_whenConfigResetSocksUnixSocketWithFlags_returnsSuccess() = runBlocking {
         // Only run if support for domain sockets is had
-        if (!ControllerUtils.isLinux) return@runBlocking
+        if (!PlatformUtil.isLinux) return@runBlocking
 
         val socks = TorConfig.Setting.UnixSockets.Socks()
             .setFlags(setOf(

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/helper/TorTestHelper.kt
@@ -26,7 +26,7 @@ import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
 import io.matthewnelson.kmp.tor.controller.common.events.TorEvent
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.manager.TorConfigProvider
 import io.matthewnelson.kmp.tor.manager.TorManager
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
@@ -188,15 +188,15 @@ abstract class TorTestHelper {
         val installOption: InstallOption = InstallOption.CleanInstallIfMissing
 
         val installer: PlatformInstaller = when {
-            ControllerUtils.isMingw -> {
+            PlatformUtil.isMingw -> {
                 println("\nRunning tests for Windows\n")
                 PlatformInstaller.mingwX64(installOption)
             }
-            ControllerUtils.isDarwin -> {
+            PlatformUtil.isDarwin -> {
                 println("\nRunning tests for Darwin\n")
                 PlatformInstaller.macosX64(installOption)
             }
-            ControllerUtils.isLinux -> {
+            PlatformUtil.isLinux -> {
                 println("\nRunning tests for Linux\n")
                 PlatformInstaller.linuxX64(installOption)
             }

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/manager/TorManagerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/manager/TorManagerIntegrationTest.kt
@@ -20,7 +20,7 @@ import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 import io.matthewnelson.kmp.tor.controller.common.control.usecase.TorControlInfoGet
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.helper.TorTestHelper
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 import io.matthewnelson.kmp.tor.manager.common.exceptions.InterruptedException
@@ -99,7 +99,7 @@ class TorManagerIntegrationTest: TorTestHelper() {
     @Test
     fun givenTorManager_whenUnixSocksPortOpenClose_addressInfoIsProperlyDispatched() = runBlocking {
         // Only run if support for domain sockets is had
-        if (!ControllerUtils.isLinux) return@runBlocking
+        if (!PlatformUtil.isLinux) return@runBlocking
 
         val initialSocksInstances = awaitLastValidatedTorConfig().torConfig.settings
             .filterIsInstance<UnixSockets.Socks>()

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidator.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidator.kt
@@ -22,7 +22,7 @@ import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.AorDor
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.Ports
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.UnixSockets
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 
 internal class PortValidator internal constructor(private val dataDir: Path) {
 
@@ -92,7 +92,7 @@ internal class PortValidator internal constructor(private val dataDir: Path) {
         if (!hasControl) {
             // Prefer using unix domain socket if it's supported.
             @OptIn(InternalTorApi::class)
-            val control = if (ControllerUtils.hasControlUnixDomainSocketSupport) {
+            val control = if (PlatformUtil.hasControlUnixDomainSocketSupport) {
                 UnixSockets.Control().set(
                     TorConfig.Option.FileSystemFile(
                         dataDir.builder {

--- a/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
+++ b/library/manager/kmp-tor-manager/src/commonTest/kotlin/io/matthewnelson/kmp/tor/manager/internal/util/PortValidatorUnitTest.kt
@@ -22,7 +22,7 @@ import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.Ports
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.UnixSockets
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.AorDorPort
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import kotlin.test.*
 
 @OptIn(InternalTorApi::class)
@@ -77,7 +77,7 @@ class PortValidatorUnitTest {
         val controlSocket = validated.filterIsInstance<UnixSockets.Control>()
         assertEquals(1, controlPort.size + controlSocket.size)
 
-        if (ControllerUtils.hasControlUnixDomainSocketSupport) {
+        if (PlatformUtil.hasControlUnixDomainSocketSupport) {
             val expected = UnixSockets.Control()
             expected.set(TorConfig.Option.FileSystemFile(Path(DATA_DIR).builder {
                 addSegment(UnixSockets.Control.DEFAULT_NAME)

--- a/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -24,7 +24,7 @@ import io.matthewnelson.kmp.tor.controller.common.control.usecase.TorControlSign
 import io.matthewnelson.kmp.tor.controller.common.exceptions.TorControllerException
 import io.matthewnelson.kmp.tor.controller.common.file.Path
 import io.matthewnelson.kmp.tor.controller.common.file.toFile
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.manager.common.event.TorManagerEvent
 import io.matthewnelson.kmp.tor.manager.common.exceptions.InterruptedException
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
@@ -446,6 +446,6 @@ actual abstract class KmpTorLoader(protected val provider: TorConfigProvider) {
     init {
         // Reference so that localhostAddress for JVM can have it's initial
         // value set immediately from BG thread.
-        ControllerUtils
+        PlatformUtil
     }
 }

--- a/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
+++ b/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/util/PortUtil.kt
@@ -17,7 +17,7 @@ package io.matthewnelson.kmp.tor.manager.util
 
 import io.matthewnelson.kmp.tor.common.address.Port
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils.ANDROID_NET_MAIN_THREAD_EXCEPTION
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil.ANDROID_NET_MAIN_THREAD_EXCEPTION
 import java.net.InetAddress
 import javax.net.ServerSocketFactory
 

--- a/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/kotlin/javafx/SampleApp.kt
+++ b/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/kotlin/javafx/SampleApp.kt
@@ -26,7 +26,7 @@ import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
 import io.matthewnelson.kmp.tor.controller.common.control.usecase.TorControlInfoGet
 import io.matthewnelson.kmp.tor.controller.common.events.TorEvent
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.controller.common.internal.ControllerUtils
+import io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil
 import io.matthewnelson.kmp.tor.manager.TorManager
 import io.matthewnelson.kmp.tor.manager.common.TorControlManager
 import io.matthewnelson.kmp.tor.manager.common.TorOperationManager
@@ -48,13 +48,13 @@ class SampleApp: App(SampleView::class) {
 
     private val platformInstaller: PlatformInstaller by lazy {
         val installer = when {
-            ControllerUtils.isMingw -> {
+            PlatformUtil.isMingw -> {
                 PlatformInstaller.mingwX64(InstallOption.CleanInstallIfMissing)
             }
-            ControllerUtils.isDarwin -> {
+            PlatformUtil.isDarwin -> {
                 PlatformInstaller.macosX64(InstallOption.CleanInstallIfMissing)
             }
-            ControllerUtils.isLinux -> {
+            PlatformUtil.isLinux -> {
                 PlatformInstaller.linuxX64(InstallOption.CleanInstallIfMissing)
             }
             else -> {


### PR DESCRIPTION
Closes #174 

**BREAKING CHANGE**:
 - Class `ControllerUtils` was renamed to `PlatformUtil`