### PR TITLE
Decouple `TorConfig` KeyWords from Setting classes

### DIFF
--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -248,7 +248,7 @@ class TorConfig private constructor(
     @Suppress("PropertyName", "CanBePrimaryConstructorProperty")
     sealed class Setting<T: Option?>(
         @JvmField
-        val keyword: KeyWord,
+        val keyword: TorConfig.KeyWord,
         @JvmField
         val default: T,
         isStartArgument: Boolean,

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -41,6 +41,7 @@ import kotlin.reflect.KClass
  * @see [Builder]
  * @see [Setting]
  * @see [Option]
+ * @see [KeyWord]
  * */
 @OptIn(ExperimentalTorApi::class, InternalTorApi::class)
 @Suppress("RemoveRedundantQualifierName", "SpellCheckingInspection")
@@ -159,7 +160,7 @@ class TorConfig private constructor(
         fun build(): TorConfig {
             val sb = StringBuilder()
 
-            val disabledPorts = mutableSetOf<String>()
+            val disabledPorts = mutableSetOf<KeyWord>()
             val sorted = settings.sortedBy { setting ->
                 when (setting) {
                     // Ports must come before UnixSocket to ensure
@@ -174,12 +175,12 @@ class TorConfig private constructor(
                         "AAA${setting.keyword}"
                     }
                     else -> {
-                        setting.keyword
+                        setting.keyword.toString()
                     }
                 }
             }
 
-            val writtenDisabledPorts: MutableSet<String> = LinkedHashSet(disabledPorts.size)
+            val writtenDisabledPorts: MutableSet<KeyWord> = LinkedHashSet(disabledPorts.size)
 
             val newSettings = mutableSetOf<Setting<*>>()
             for (setting in sorted) {
@@ -247,7 +248,7 @@ class TorConfig private constructor(
     @Suppress("PropertyName", "CanBePrimaryConstructorProperty")
     sealed class Setting<T: Option?>(
         @JvmField
-        val keyword: String,
+        val keyword: KeyWord,
         @JvmField
         val default: T,
         isStartArgument: Boolean,
@@ -308,7 +309,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#AutomapHostsOnResolve
          * */
         class AutomapHostsOnResolve                 : Setting<Option.TorF>(
-            keyword = "AutomapHostsOnResolve",
+            keyword = KeyWord.AutomapHostsOnResolve,
             default = Option.TorF.True,
             isStartArgument = false,
         ) {
@@ -322,7 +323,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#CacheDirectory
          * */
         class CacheDirectory                        : Setting<Option.FileSystemDir?>(
-            keyword = "CacheDirectory",
+            keyword = KeyWord.CacheDirectory,
             default = null,
             isStartArgument = true,
         ) {
@@ -340,7 +341,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ClientOnionAuthDir
          * */
         class ClientOnionAuthDir                    : Setting<Option.FileSystemDir?>(
-            keyword = "ClientOnionAuthDir",
+            keyword = KeyWord.ClientOnionAuthDir,
             default = null,
             isStartArgument = true,
         ) {
@@ -362,7 +363,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ConnectionPadding
          * */
         class ConnectionPadding                     : Setting<Option.AorTorF>(
-            keyword = "ConnectionPadding",
+            keyword = KeyWord.ConnectionPadding,
             default = Option.AorTorF.Auto,
             isStartArgument = false,
         ) {
@@ -376,7 +377,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ConnectionPaddingReduced
          * */
         class ConnectionPaddingReduced              : Setting<Option.TorF>(
-            keyword = "ReducedConnectionPadding",
+            keyword = KeyWord.ReducedConnectionPadding,
             default = Option.TorF.False,
             isStartArgument = false,
         ) {
@@ -390,7 +391,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#ControlPortWriteToFile
          * */
         class ControlPortWriteToFile                : Setting<Option.FileSystemFile?>(
-            keyword = "ControlPortWriteToFile",
+            keyword = KeyWord.ControlPortWriteToFile,
             default = null,
             isStartArgument = true,
         ) {
@@ -412,7 +413,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#CookieAuthentication
          * */
         class CookieAuthentication                  : Setting<Option.TorF>(
-            keyword = "CookieAuthentication",
+            keyword = KeyWord.CookieAuthentication,
             default = Option.TorF.True,
             isStartArgument = true,
         ) {
@@ -426,7 +427,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#CookieAuthFile
          * */
         class CookieAuthFile                        : Setting<Option.FileSystemFile?>(
-            keyword = "CookieAuthFile",
+            keyword = KeyWord.CookieAuthFile,
             default = null,
             isStartArgument = true,
         ) {
@@ -448,7 +449,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DataDirectory
          * */
         class DataDirectory                         : Setting<Option.FileSystemDir?>(
-            keyword = "DataDirectory",
+            keyword = KeyWord.DataDirectory,
             default = null,
             isStartArgument = true,
         ) {
@@ -470,7 +471,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DisableNetwork
          * */
         class DisableNetwork                        : Setting<Option.TorF>(
-            keyword = "DisableNetwork",
+            keyword = KeyWord.DisableNetwork,
             default = Option.TorF.False,
             isStartArgument = true,
         ) {
@@ -484,7 +485,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DormantCanceledByStartup
          * */
         class DormantCanceledByStartup              : Setting<Option.TorF>(
-            keyword = "DormantCanceledByStartup",
+            keyword = KeyWord.DormantCanceledByStartup,
             default = Option.TorF.False,
             isStartArgument = true,
         ) {
@@ -498,7 +499,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DormantClientTimeout
          * */
         class DormantClientTimeout                  : Setting<Option.Time>(
-            keyword = "DormantClientTimeout",
+            keyword = KeyWord.DormantClientTimeout,
             default = Option.Time.Hours(24),
             isStartArgument = false,
         ) {
@@ -520,7 +521,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DormantOnFirstStartup
          * */
         class DormantOnFirstStartup                 : Setting<Option.TorF>(
-            keyword = "DormantOnFirstStartup",
+            keyword = KeyWord.DormantOnFirstStartup,
             default = Option.TorF.False,
             isStartArgument = true,
         ) {
@@ -534,7 +535,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#DormantTimeoutDisabledByIdleStreams
          * */
         class DormantTimeoutDisabledByIdleStreams   : Setting<Option.TorF>(
-            keyword = "DormantTimeoutDisabledByIdleStreams",
+            keyword = KeyWord.DormantTimeoutDisabledByIdleStreams,
             default = Option.TorF.True,
             isStartArgument = false,
         ) {
@@ -548,7 +549,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#GeoIPExcludeUnknown
          * */
         class GeoIPExcludeUnknown                   : Setting<Option.AorTorF>(
-            keyword = "GeoIPExcludeUnknown",
+            keyword = KeyWord.GeoIPExcludeUnknown,
             default = Option.AorTorF.Auto,
             isStartArgument = false,
         ) {
@@ -562,7 +563,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#GeoIPFile
          * */
         class GeoIpV4File                           : Setting<Option.FileSystemFile?>(
-            keyword = "GeoIPFile",
+            keyword = KeyWord.GeoIpV4File,
             default = null,
             isStartArgument = true,
         ) {
@@ -580,7 +581,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#GeoIPv6File
          * */
         class GeoIpV6File                           : Setting<Option.FileSystemFile?>(
-            keyword = "GeoIPv6File",
+            keyword = KeyWord.GeoIPv6File,
             default = null,
             isStartArgument = true,
         ) {
@@ -621,7 +622,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#HiddenServiceMaxStreamsCloseCircuit
          * */
         class HiddenService                         : Setting<Option.FileSystemDir?>(
-            keyword = "HiddenServiceDir",
+            keyword = KeyWord.HiddenServiceDir,
             default = null,
             isStartArgument = false,
         ) {
@@ -838,7 +839,7 @@ class TorConfig private constructor(
          * https://torproject.gitlab.io/torspec/control-spec/#takeownership
          * */
         class OwningControllerProcess               : Setting<Option.ProcessId?>(
-            keyword = "__OwningControllerProcess",
+            keyword = KeyWord.OwningControllerProcess,
             default = null,
             isStartArgument = true,
         ) {
@@ -849,7 +850,7 @@ class TorConfig private constructor(
         }
 
         sealed class Ports(
-            keyword: String,
+            keyword: TorConfig.KeyWord,
             default: Option.AorDorPort,
             isStartArgument: Boolean,
         ) : Setting<Option.AorDorPort>(
@@ -903,7 +904,7 @@ class TorConfig private constructor(
              * @see [UnixSockets.Control]
              * */
             class Control                               : Ports(
-                keyword = "ControlPort",
+                keyword = KeyWord.PortControl,
                 default = Option.AorDorPort.Auto,
                 isStartArgument = true,
             ) {
@@ -925,7 +926,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#DNSPort
              * */
             class Dns                                   : Ports(
-                keyword = "DNSPort",
+                keyword = KeyWord.PortDns,
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
             ) {
@@ -958,7 +959,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#HTTPTunnelPort
              * */
             class HttpTunnel                            : Ports(
-                keyword = "HTTPTunnelPort",
+                keyword = KeyWord.PortHttpTunnel,
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
             ) {
@@ -991,7 +992,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
              * */
             class Socks                                 : Ports(
-                keyword = "SocksPort",
+                keyword = KeyWord.PortSocks,
                 default = Option.AorDorPort.Value(PortProxy(9050)),
                 isStartArgument = false,
             ) {
@@ -1059,7 +1060,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#TransPort
              * */
             class Trans                                 : Ports(
-                keyword = "TransPort",
+                keyword = KeyWord.PortTrans,
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
             ) {
@@ -1129,7 +1130,7 @@ class TorConfig private constructor(
         }
 
         sealed class UnixSockets(
-            keyword: String,
+            keyword: TorConfig.KeyWord,
             isStartArgument: Boolean,
         ) : Setting<Option.FileSystemFile?>(
             keyword,
@@ -1162,7 +1163,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#ControlPort
              * */
             class Control                               : UnixSockets(
-                keyword = "ControlPort",
+                keyword = KeyWord.PortControl,
                 isStartArgument = true,
             ) {
 
@@ -1213,7 +1214,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
              * */
             class Socks                             : UnixSockets(
-                keyword = "SocksPort",
+                keyword = KeyWord.PortSocks,
                 isStartArgument = false,
             ) {
 
@@ -1283,7 +1284,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#RunAsDaemon
          * */
         class RunAsDaemon                           : Setting<Option.TorF>(
-            keyword = "RunAsDaemon",
+            keyword = KeyWord.RunAsDaemon,
             default = Option.TorF.False,
             isStartArgument = true,
         ) {
@@ -1297,7 +1298,7 @@ class TorConfig private constructor(
          * https://2019.www.torproject.org/docs/tor-manual.html.en#SyslogIdentityTag
          * */
         class SyslogIdentityTag                     : Setting<Option.FieldId?>(
-            keyword = "SyslogIdentityTag",
+            keyword = KeyWord.SyslogIdentityTag,
             default = null,
             isStartArgument = true,
         ) {
@@ -1543,5 +1544,50 @@ class TorConfig private constructor(
                 override fun toString(): String = value
             }
         }
+    }
+
+    sealed class KeyWord: Comparable<String>, CharSequence {
+
+        object AutomapHostsOnResolve: KeyWord() { override fun toString(): String = "AutomapHostsOnResolve" }
+        object CacheDirectory: KeyWord() { override fun toString(): String = "CacheDirectory" }
+        object ClientOnionAuthDir: KeyWord() { override fun toString(): String = "ClientOnionAuthDir" }
+        object ConnectionPadding: KeyWord() { override fun toString(): String = "ConnectionPadding" }
+        object ReducedConnectionPadding: KeyWord() { override fun toString(): String = "ReducedConnectionPadding" }
+        object ControlPortWriteToFile: KeyWord() { override fun toString(): String = "ControlPortWriteToFile" }
+        object CookieAuthentication: KeyWord() { override fun toString(): String = "CookieAuthentication" }
+        object CookieAuthFile: KeyWord() { override fun toString(): String = "CookieAuthFile" }
+        object DataDirectory: KeyWord() { override fun toString(): String = "DataDirectory" }
+        object DisableNetwork: KeyWord() { override fun toString(): String = "DisableNetwork" }
+        object DormantCanceledByStartup: KeyWord() { override fun toString(): String = "DormantCanceledByStartup" }
+        object DormantClientTimeout: KeyWord() { override fun toString(): String = "DormantClientTimeout" }
+        object DormantOnFirstStartup: KeyWord() { override fun toString(): String = "DormantOnFirstStartup" }
+        object DormantTimeoutDisabledByIdleStreams: KeyWord() { override fun toString(): String = "DormantTimeoutDisabledByIdleStreams" }
+        object GeoIPExcludeUnknown: KeyWord() { override fun toString(): String = "GeoIPExcludeUnknown" }
+        object GeoIpV4File: KeyWord() { override fun toString(): String = "GeoIPFile" }
+        object GeoIPv6File: KeyWord() { override fun toString(): String = "GeoIPv6File" }
+        object HiddenServiceDir: KeyWord() { override fun toString(): String = "HiddenServiceDir" }
+        object HiddenServicePort: KeyWord() { override fun toString(): String = "HiddenServicePort" }
+        object HiddenServiceMaxStreams: KeyWord() { override fun toString(): String = "HiddenServiceMaxStreams" }
+        object HiddenServiceMaxStreamsCloseCircuit: KeyWord() { override fun toString(): String = "HiddenServiceMaxStreamsCloseCircuit" }
+        object OwningControllerProcess: KeyWord() { override fun toString(): String = "__OwningControllerProcess" }
+        object PortControl: KeyWord() { override fun toString(): String = "ControlPort" }
+        object PortDns: KeyWord() { override fun toString(): String = "DNSPort" }
+        object PortHttpTunnel: KeyWord() { override fun toString(): String = "HTTPTunnelPort" }
+        object PortSocks: KeyWord() { override fun toString(): String = "SocksPort" }
+        object PortTrans: KeyWord() { override fun toString(): String = "TransPort" }
+        object RunAsDaemon: KeyWord() { override fun toString(): String = "RunAsDaemon" }
+        object SyslogIdentityTag: KeyWord() { override fun toString(): String = "SyslogIdentityTag" }
+
+        final override val length: Int get() = toString().length
+        final override fun get(index: Int): Char = toString()[index]
+        final override fun subSequence(startIndex: Int, endIndex: Int): CharSequence {
+            return toString().subSequence(startIndex, endIndex)
+        }
+
+        final override fun compareTo(other: String): Int = toString().compareTo(other)
+        operator fun plus(other: Any?): String = toString() + other
+
+        final override fun equals(other: Any?): Boolean = other is KeyWord && other.toString() == toString()
+        final override fun hashCode(): Int = 21 * 31 + toString().hashCode()
     }
 }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -904,7 +904,7 @@ class TorConfig private constructor(
              * @see [UnixSockets.Control]
              * */
             class Control                               : Ports(
-                keyword = KeyWord.PortControl,
+                keyword = KeyWord.ControlPort,
                 default = Option.AorDorPort.Auto,
                 isStartArgument = true,
             ) {
@@ -926,7 +926,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#DNSPort
              * */
             class Dns                                   : Ports(
-                keyword = KeyWord.PortDns,
+                keyword = KeyWord.DnsPort,
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
             ) {
@@ -959,7 +959,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#HTTPTunnelPort
              * */
             class HttpTunnel                            : Ports(
-                keyword = KeyWord.PortHttpTunnel,
+                keyword = KeyWord.HttpTunnelPort,
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
             ) {
@@ -992,7 +992,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
              * */
             class Socks                                 : Ports(
-                keyword = KeyWord.PortSocks,
+                keyword = KeyWord.SocksPort,
                 default = Option.AorDorPort.Value(PortProxy(9050)),
                 isStartArgument = false,
             ) {
@@ -1060,7 +1060,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#TransPort
              * */
             class Trans                                 : Ports(
-                keyword = KeyWord.PortTrans,
+                keyword = KeyWord.TransPort,
                 default = Option.AorDorPort.Disable,
                 isStartArgument = false,
             ) {
@@ -1163,7 +1163,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#ControlPort
              * */
             class Control                               : UnixSockets(
-                keyword = KeyWord.PortControl,
+                keyword = KeyWord.ControlPort,
                 isStartArgument = true,
             ) {
 
@@ -1214,7 +1214,7 @@ class TorConfig private constructor(
              * https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
              * */
             class Socks                             : UnixSockets(
-                keyword = KeyWord.PortSocks,
+                keyword = KeyWord.SocksPort,
                 isStartArgument = false,
             ) {
 
@@ -1570,11 +1570,13 @@ class TorConfig private constructor(
         object HiddenServiceMaxStreams: KeyWord() { override fun toString(): String = "HiddenServiceMaxStreams" }
         object HiddenServiceMaxStreamsCloseCircuit: KeyWord() { override fun toString(): String = "HiddenServiceMaxStreamsCloseCircuit" }
         object OwningControllerProcess: KeyWord() { override fun toString(): String = "__OwningControllerProcess" }
-        object PortControl: KeyWord() { override fun toString(): String = "ControlPort" }
-        object PortDns: KeyWord() { override fun toString(): String = "DNSPort" }
-        object PortHttpTunnel: KeyWord() { override fun toString(): String = "HTTPTunnelPort" }
-        object PortSocks: KeyWord() { override fun toString(): String = "SocksPort" }
-        object PortTrans: KeyWord() { override fun toString(): String = "TransPort" }
+
+        object ControlPort: KeyWord() { override fun toString(): String = "ControlPort" }
+        object DnsPort: KeyWord() { override fun toString(): String = "DNSPort" }
+        object HttpTunnelPort: KeyWord() { override fun toString(): String = "HTTPTunnelPort" }
+        object SocksPort: KeyWord() { override fun toString(): String = "SocksPort" }
+        object TransPort: KeyWord() { override fun toString(): String = "TransPort" }
+
         object RunAsDaemon: KeyWord() { override fun toString(): String = "RunAsDaemon" }
         object SyslogIdentityTag: KeyWord() { override fun toString(): String = "SyslogIdentityTag" }
 

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/config/TorConfig.kt
@@ -203,15 +203,15 @@ class TorConfig private constructor(
                             continue
                         }
 
-                        setting.appendTo(sb, appendValue = true, isWriteTorConfig = true)
+                        setting.appendTo(sb, isWriteTorConfig = true)
                     }
                     is Setting.UnixSockets -> {
                         if (disabledPorts.contains(setting.keyword)) continue
 
-                        setting.appendTo(sb, appendValue = true, isWriteTorConfig = true)
+                        setting.appendTo(sb, isWriteTorConfig = true)
                     }
                     else -> {
-                        setting.appendTo(sb, appendValue = true, isWriteTorConfig = true)
+                        setting.appendTo(sb, isWriteTorConfig = true)
                     }
                 }
 

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlConfigGet.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlConfigGet.kt
@@ -28,8 +28,8 @@ import io.matthewnelson.kmp.tor.controller.common.control.TorControlConfig
  * */
 interface TorControlConfigGet {
 
-    suspend fun configGet(setting: TorConfig.Setting<*>) : Result<List<ConfigEntry>>
+    suspend fun configGet(keyword: TorConfig.KeyWord) : Result<List<ConfigEntry>>
 
-    suspend fun configGet(settings: Set<TorConfig.Setting<*>>) : Result<List<ConfigEntry>>
+    suspend fun configGet(keywords: Set<TorConfig.KeyWord>) : Result<List<ConfigEntry>>
 
 }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlConfigReset.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlConfigReset.kt
@@ -23,18 +23,18 @@ import io.matthewnelson.kmp.tor.controller.common.control.TorControlConfig
  *
  * https://torproject.gitlab.io/torspec/control-spec/#resetconf
  *
+ * Functionality does not follow spec, and _only_ sets the config
+ * to its default setting for the given [TorConfig.KeyWord]. If you
+ * need to modify a config value to a non-default setting, use
+ * [TorControlConfigSet.configSet].
+ *
  * @see [TorControlConfig]
+ * @see [TorControlConfigSet]
  * */
 interface TorControlConfigReset {
 
-    suspend fun configReset(
-        setting: TorConfig.Setting<*>,
-        setDefault: Boolean = true
-    ): Result<Any?>
+    suspend fun configReset(keyword: TorConfig.KeyWord): Result<Any?>
 
-    suspend fun configReset(
-        settings: Set<TorConfig.Setting<*>>,
-        setDefault: Boolean = true
-    ): Result<Any?>
+    suspend fun configReset(keywords: Set<TorConfig.KeyWord>): Result<Any?>
 
 }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/SettingExt.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/SettingExt.kt
@@ -27,14 +27,8 @@ import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
  * and true if something was.
  * */
 @InternalTorApi
-fun TorConfig.Setting<*>.appendTo(
-    sb: StringBuilder,
-    appendValue: Boolean,
-    isWriteTorConfig: Boolean,
-): Boolean {
-    if (appendValue && this.value == null) {
-        return false
-    }
+fun TorConfig.Setting<*>.appendTo(sb: StringBuilder, isWriteTorConfig: Boolean): Boolean {
+    val value = value ?: return false
 
     val delimiter = if (isWriteTorConfig) {
         ' '
@@ -64,11 +58,6 @@ fun TorConfig.Setting<*>.appendTo(
         is RunAsDaemon,
         is SyslogIdentityTag -> {
             sb.append(keyword)
-
-            if (!appendValue) {
-                return true
-            }
-
             sb.append(delimiter)
             sb.quoteIfTrue(!isWriteTorConfig)
             sb.append(value)
@@ -78,17 +67,12 @@ fun TorConfig.Setting<*>.appendTo(
 
         is UnixSockets -> {
             sb.append(keyword)
-
-            if (!appendValue) {
-                return true
-            }
-
             sb.append(delimiter)
             sb.quoteIfTrue(!isWriteTorConfig)
             sb.append("unix:")
             sb.escapeIfTrue(!isWriteTorConfig)
             sb.quote()
-            sb.append(value?.value)
+            sb.append(value.value)
             sb.escapeIfTrue(!isWriteTorConfig)
             sb.quote()
 
@@ -129,11 +113,6 @@ fun TorConfig.Setting<*>.appendTo(
 
         is Ports -> {
             sb.append(keyword)
-
-            if (!appendValue) {
-                return true
-            }
-
             sb.append(delimiter)
             sb.quoteIfTrue(!isWriteTorConfig)
             sb.append(value)
@@ -185,18 +164,6 @@ fun TorConfig.Setting<*>.appendTo(
         }
 
         is HiddenService -> {
-            if (!appendValue) {
-                sb.append(keyword)
-                sb.append(SP)
-                sb.append(KeyWord.HiddenServicePort)
-                sb.append(SP)
-                sb.append(KeyWord.HiddenServiceMaxStreams)
-                sb.append(SP)
-                sb.append(KeyWord.HiddenServiceMaxStreamsCloseCircuit)
-                return true
-            }
-
-            val hsDirPath = value ?: return false
             val hsPorts = ports
 
             if (hsPorts == null || hsPorts.isEmpty()) {
@@ -207,7 +174,7 @@ fun TorConfig.Setting<*>.appendTo(
             sb.append(keyword)
             sb.append(delimiter)
             sb.quoteIfTrue(!isWriteTorConfig)
-            sb.append(hsDirPath.value)
+            sb.append(value.value)
             sb.quoteIfTrue(!isWriteTorConfig)
 
             val localhostIp: String = try {

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/SettingExt.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/SettingExt.kt
@@ -18,7 +18,9 @@ package io.matthewnelson.kmp.tor.controller.common.internal
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.util.TorStrings.SP
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
-import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.HiddenService
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.KeyWord
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Option.*
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig.Setting.*
 
 /**
  * Returns false if nothing was appended to the StringBuilder,
@@ -41,26 +43,26 @@ fun TorConfig.Setting<*>.appendTo(
     }
 
     when (this) {
-        is TorConfig.Setting.AutomapHostsOnResolve,
-        is TorConfig.Setting.CacheDirectory,
-        is TorConfig.Setting.ClientOnionAuthDir,
-        is TorConfig.Setting.ConnectionPadding,
-        is TorConfig.Setting.ConnectionPaddingReduced,
-        is TorConfig.Setting.ControlPortWriteToFile,
-        is TorConfig.Setting.CookieAuthFile,
-        is TorConfig.Setting.CookieAuthentication,
-        is TorConfig.Setting.DataDirectory,
-        is TorConfig.Setting.DisableNetwork,
-        is TorConfig.Setting.DormantCanceledByStartup,
-        is TorConfig.Setting.DormantClientTimeout,
-        is TorConfig.Setting.DormantOnFirstStartup,
-        is TorConfig.Setting.DormantTimeoutDisabledByIdleStreams,
-        is TorConfig.Setting.GeoIPExcludeUnknown,
-        is TorConfig.Setting.GeoIpV4File,
-        is TorConfig.Setting.GeoIpV6File,
-        is TorConfig.Setting.OwningControllerProcess,
-        is TorConfig.Setting.RunAsDaemon,
-        is TorConfig.Setting.SyslogIdentityTag -> {
+        is AutomapHostsOnResolve,
+        is CacheDirectory,
+        is ClientOnionAuthDir,
+        is ConnectionPadding,
+        is ConnectionPaddingReduced,
+        is ControlPortWriteToFile,
+        is CookieAuthFile,
+        is CookieAuthentication,
+        is DataDirectory,
+        is DisableNetwork,
+        is DormantCanceledByStartup,
+        is DormantClientTimeout,
+        is DormantOnFirstStartup,
+        is DormantTimeoutDisabledByIdleStreams,
+        is GeoIPExcludeUnknown,
+        is GeoIpV4File,
+        is GeoIpV6File,
+        is OwningControllerProcess,
+        is RunAsDaemon,
+        is SyslogIdentityTag -> {
             sb.append(keyword)
 
             if (!appendValue) {
@@ -74,7 +76,7 @@ fun TorConfig.Setting<*>.appendTo(
             return true
         }
 
-        is TorConfig.Setting.UnixSockets -> {
+        is UnixSockets -> {
             sb.append(keyword)
 
             if (!appendValue) {
@@ -91,7 +93,7 @@ fun TorConfig.Setting<*>.appendTo(
             sb.quote()
 
             when (this) {
-                is TorConfig.Setting.UnixSockets.Control -> {
+                is UnixSockets.Control -> {
                     unixFlags?.let { flags ->
                         for (flag in flags) {
                             sb.append(SP)
@@ -99,7 +101,7 @@ fun TorConfig.Setting<*>.appendTo(
                         }
                     }
                 }
-                is TorConfig.Setting.UnixSockets.Socks -> {
+                is UnixSockets.Socks -> {
                     flags?.let { flags ->
                         for (flag in flags) {
                             sb.append(SP)
@@ -125,7 +127,7 @@ fun TorConfig.Setting<*>.appendTo(
             return true
         }
 
-        is TorConfig.Setting.Ports -> {
+        is Ports -> {
             sb.append(keyword)
 
             if (!appendValue) {
@@ -137,8 +139,8 @@ fun TorConfig.Setting<*>.appendTo(
             sb.append(value)
 
             when (this) {
-                is TorConfig.Setting.Ports.Control -> {}
-                is TorConfig.Setting.Ports.Dns -> {
+                is Ports.Control -> {}
+                is Ports.Dns -> {
                     isolationFlags?.let { flags ->
                         for (flag in flags) {
                             sb.append(SP)
@@ -146,7 +148,7 @@ fun TorConfig.Setting<*>.appendTo(
                         }
                     }
                 }
-                is TorConfig.Setting.Ports.HttpTunnel -> {
+                is Ports.HttpTunnel -> {
                     isolationFlags?.let { flags ->
                         for (flag in flags) {
                             sb.append(SP)
@@ -154,7 +156,7 @@ fun TorConfig.Setting<*>.appendTo(
                         }
                     }
                 }
-                is TorConfig.Setting.Ports.Socks -> {
+                is Ports.Socks -> {
                     flags?.let { flags ->
                         for (flag in flags) {
                             sb.append(SP)
@@ -168,7 +170,7 @@ fun TorConfig.Setting<*>.appendTo(
                         }
                     }
                 }
-                is TorConfig.Setting.Ports.Trans -> {
+                is Ports.Trans -> {
                     isolationFlags?.let { flags ->
                         for (flag in flags) {
                             sb.append(SP)
@@ -186,11 +188,11 @@ fun TorConfig.Setting<*>.appendTo(
             if (!appendValue) {
                 sb.append(keyword)
                 sb.append(SP)
-                sb.append("HiddenServicePort")
+                sb.append(KeyWord.HiddenServicePort)
                 sb.append(SP)
-                sb.append("HiddenServiceMaxStreams")
+                sb.append(KeyWord.HiddenServiceMaxStreams)
                 sb.append(SP)
-                sb.append("HiddenServiceMaxStreamsCloseCircuit")
+                sb.append(KeyWord.HiddenServiceMaxStreamsCloseCircuit)
                 return true
             }
 
@@ -220,7 +222,7 @@ fun TorConfig.Setting<*>.appendTo(
                     append(SP)
                 }
 
-                sb.append("HiddenServicePort")
+                sb.append(KeyWord.HiddenServicePort)
                 sb.append(delimiter)
                 sb.quoteIfTrue(!isWriteTorConfig)
 
@@ -252,10 +254,10 @@ fun TorConfig.Setting<*>.appendTo(
                 append(SP)
             }
 
-            sb.append("HiddenServiceMaxStreams")
+            sb.append(KeyWord.HiddenServiceMaxStreams)
             sb.append(delimiter)
             sb.quoteIfTrue(!isWriteTorConfig)
-            sb.append(maxStreams?.value ?: "0")
+            sb.append(maxStreams?.value ?: AorDorPort.Disable)
             sb.quoteIfTrue(!isWriteTorConfig)
 
             sb.newLineIfTrue(isWriteTorConfig) {
@@ -263,10 +265,10 @@ fun TorConfig.Setting<*>.appendTo(
                 append(SP)
             }
 
-            sb.append("HiddenServiceMaxStreamsCloseCircuit")
+            sb.append(KeyWord.HiddenServiceMaxStreamsCloseCircuit)
             sb.append(delimiter)
             sb.quoteIfTrue(!isWriteTorConfig)
-            sb.append(maxStreamsCloseCircuit?.value ?: "0")
+            sb.append(maxStreamsCloseCircuit?.value ?: TorF.False)
             sb.newLineIfTrue(isWriteTorConfig) {
                 // if false
                 quote()

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -151,17 +151,17 @@ private class RealTorControlProcessor(
 //        }
 //    }
 
-    override suspend fun configGet(setting: TorConfig.Setting<*>): Result<List<ConfigEntry>> {
-        return configGet(setOf(setting))
+    override suspend fun configGet(keyword: TorConfig.KeyWord): Result<List<ConfigEntry>> {
+        return configGet(setOf(keyword))
     }
 
-    override suspend fun configGet(settings: Set<TorConfig.Setting<*>>): Result<List<ConfigEntry>> {
+    override suspend fun configGet(keywords: Set<TorConfig.KeyWord>): Result<List<ConfigEntry>> {
         return lock.withLock {
             try {
                 val command = StringBuilder("GETCONF").apply {
-                    for (setting in settings) {
+                    for (keyword in keywords) {
                         append(SP)
-                        setting.appendTo(this, appendValue = false, isWriteTorConfig = false)
+                        append(keyword)
                     }
                     append(CLRF)
                 }.toString()
@@ -203,41 +203,32 @@ private class RealTorControlProcessor(
         }
     }
 
-    override suspend fun configReset(
-        setting: TorConfig.Setting<*>,
-        setDefault: Boolean
-    ): Result<Any?> {
-        return configReset(setOf(setting), setDefault)
+    override suspend fun configReset(keyword: TorConfig.KeyWord): Result<Any?> {
+        return configReset(setOf(keyword))
     }
 
-    override suspend fun configReset(
-        settings: Set<TorConfig.Setting<*>>,
-        setDefault: Boolean
-    ): Result<Any?> {
+    override suspend fun configReset(keywords: Set<TorConfig.KeyWord>): Result<Any?> {
         return lock.withLock {
             try {
                 val command = StringBuilder("RESETCONF").apply {
-                    for (setting in settings) {
-                        when (setting) {
+                    for (keyword in keywords) {
+                        when (keyword) {
                             // ControlPort can only be set upon startup
-                            is TorConfig.Setting.Ports.Control,
-                            is TorConfig.Setting.UnixSockets.Control,
+                            is TorConfig.KeyWord.ControlPort,
 
                             // Cookie authentication can only be set upon startup
-                            is TorConfig.Setting.CookieAuthFile,
-                            is TorConfig.Setting.CookieAuthentication,
+                            is TorConfig.KeyWord.CookieAuthFile,
+                            is TorConfig.KeyWord.CookieAuthentication,
 
                             // ControlPortWriteToFile can only be set upon startup
-                            is TorConfig.Setting.ControlPortWriteToFile -> {
-                                throw TorControllerException("${setting.keyword} cannot be modified via RESETCONF")
+                            is TorConfig.KeyWord.ControlPortWriteToFile -> {
+                                throw TorControllerException("$keyword cannot be modified via RESETCONF")
                             }
                             else -> { /* no-op */ }
                         }
 
                         append(SP)
-                        if (!setting.appendTo(this, appendValue = !setDefault, isWriteTorConfig = false)) {
-                            throw TorControllerException("Failed to add ${setting.keyword} to RESETCONF command")
-                        }
+                        append(keyword)
                     }
 
                     append(CLRF)
@@ -278,17 +269,16 @@ private class RealTorControlProcessor(
                 val command = StringBuilder("SETCONF").apply {
 
                     for (setting in settings) {
-                        when (setting) {
+                        when (setting.keyword) {
                             // ControlPort can only be set upon startup
-                            is TorConfig.Setting.Ports.Control,
-                            is TorConfig.Setting.UnixSockets.Control,
+                            is TorConfig.KeyWord.ControlPort,
 
                             // Cookie authentication can only be set upon startup
-                            is TorConfig.Setting.CookieAuthFile,
-                            is TorConfig.Setting.CookieAuthentication,
+                            is TorConfig.KeyWord.CookieAuthFile,
+                            is TorConfig.KeyWord.CookieAuthentication,
 
                             // ControlPortWriteToFile can only be set upon startup
-                            is TorConfig.Setting.ControlPortWriteToFile -> {
+                            is TorConfig.KeyWord.ControlPortWriteToFile -> {
                                 throw TorControllerException("${setting.keyword} cannot be modified via SETCONF")
                             }
                             else -> { /* no-op */ }

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -285,7 +285,7 @@ private class RealTorControlProcessor(
                         }
 
                         append(SP)
-                        if (!setting.appendTo(this, appendValue = true, isWriteTorConfig = false)) {
+                        if (!setting.appendTo(this, isWriteTorConfig = false)) {
                             throw TorControllerException("Failed to add ${setting.keyword} to SETCONF command")
                         }
                     }

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
@@ -452,30 +452,24 @@ private class RealTorController(
 //        return processorDelegate.circuitSetPurpose()
 //    }
 
-    override suspend fun configGet(setting: TorConfig.Setting<*>): Result<List<ConfigEntry>> {
-        return processorDelegate.configGet(setting)
+    override suspend fun configGet(keyword: TorConfig.KeyWord): Result<List<ConfigEntry>> {
+        return processorDelegate.configGet(keyword)
     }
 
-    override suspend fun configGet(settings: Set<TorConfig.Setting<*>>): Result<List<ConfigEntry>> {
-        return processorDelegate.configGet(settings)
+    override suspend fun configGet(keywords: Set<TorConfig.KeyWord>): Result<List<ConfigEntry>> {
+        return processorDelegate.configGet(keywords)
     }
 
     override suspend fun configLoad(config: TorConfig): Result<Any?> {
         return processorDelegate.configLoad(config)
     }
 
-    override suspend fun configReset(
-        setting: TorConfig.Setting<*>,
-        setDefault: Boolean
-    ): Result<Any?> {
-        return processorDelegate.configReset(setting, setDefault)
+    override suspend fun configReset(keyword: TorConfig.KeyWord): Result<Any?> {
+        return processorDelegate.configReset(keyword)
     }
 
-    override suspend fun configReset(
-        settings: Set<TorConfig.Setting<*>>,
-        setDefault: Boolean
-    ): Result<Any?> {
-        return processorDelegate.configReset(settings, setDefault)
+    override suspend fun configReset(keywords: Set<TorConfig.KeyWord>): Result<Any?> {
+        return processorDelegate.configReset(keywords)
     }
 
     override suspend fun configSave(force: Boolean): Result<Any?> {

--- a/library/extensions/callback/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlConfigGet.kt
+++ b/library/extensions/callback/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlConfigGet.kt
@@ -31,15 +31,14 @@ import io.matthewnelson.kmp.tor.ext.callback.controller.common.control.CallbackT
 interface CallbackTorControlConfigGet {
 
     fun configGet(
-        setting: TorConfig.Setting<*>,
+        keyword: TorConfig.KeyWord,
         failure: TorCallback<Throwable>?,
         success: TorCallback<List<ConfigEntry>>,
     ): Task
 
     fun configGet(
-        settings: Set<TorConfig.Setting<*>>,
+        keywords: Set<TorConfig.KeyWord>,
         failure: TorCallback<Throwable>?,
         success: TorCallback<List<ConfigEntry>>,
     ): Task
-
 }

--- a/library/extensions/callback/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlConfigReset.kt
+++ b/library/extensions/callback/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlConfigReset.kt
@@ -25,22 +25,25 @@ import io.matthewnelson.kmp.tor.ext.callback.controller.common.control.CallbackT
  *
  * https://torproject.gitlab.io/torspec/control-spec/#resetconf
  *
+ * Functionality does not follow spec, and _only_ sets the config
+ * to its default setting for the given [TorConfig.KeyWord]. If you
+ * need to modify a config value to a non-default setting, use
+ * [CallbackTorControlConfigSet.configSet].
+ *
  * @see [CallbackTorControlConfig]
+ * @see [CallbackTorControlConfigSet]
  * */
 interface CallbackTorControlConfigReset {
 
     fun configReset(
-        setting: TorConfig.Setting<*>,
-        setDefault: Boolean = true,
+        keyword: TorConfig.KeyWord,
         failure: TorCallback<Throwable>?,
         success: TorCallback<Any?>,
     ): Task
 
     fun configReset(
-        settings: Set<TorConfig.Setting<*>>,
-        setDefault: Boolean = true,
+        keywords: Set<TorConfig.KeyWord>,
         failure: TorCallback<Throwable>?,
         success: TorCallback<Any?>,
     ): Task
-
 }

--- a/library/extensions/callback/kmp-tor-ext-callback-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/CallbackTorController.kt
+++ b/library/extensions/callback/kmp-tor-ext-callback-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/CallbackTorController.kt
@@ -112,22 +112,22 @@ class CallbackTorController(
     }
 
     override fun configGet(
-        setting: TorConfig.Setting<*>,
+        keyword: TorConfig.KeyWord,
         failure: TorCallback<Throwable>?,
         success: TorCallback<List<ConfigEntry>>
     ): Task {
         return provideOrFail(failure, success) {
-            configGet(setting)
+            configGet(keyword)
         }
     }
 
     override fun configGet(
-        settings: Set<TorConfig.Setting<*>>,
+        keywords: Set<TorConfig.KeyWord>,
         failure: TorCallback<Throwable>?,
         success: TorCallback<List<ConfigEntry>>
     ): Task {
         return provideOrFail(failure, success) {
-            configGet(settings)
+            configGet(keywords)
         }
     }
 
@@ -142,24 +142,22 @@ class CallbackTorController(
     }
 
     override fun configReset(
-        setting: TorConfig.Setting<*>,
-        setDefault: Boolean,
+        keyword: TorConfig.KeyWord,
         failure: TorCallback<Throwable>?,
         success: TorCallback<Any?>
     ): Task {
         return provideOrFail(failure, success) {
-            configReset(setting)
+            configReset(keyword)
         }
     }
 
     override fun configReset(
-        settings: Set<TorConfig.Setting<*>>,
-        setDefault: Boolean,
+        keywords: Set<TorConfig.KeyWord>,
         failure: TorCallback<Throwable>?,
         success: TorCallback<Any?>
     ): Task {
         return provideOrFail(failure, success) {
-            configReset(settings, setDefault)
+            configReset(keywords)
         }
     }
 

--- a/library/extensions/callback/kmp-tor-ext-callback-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/manager/CallbackTorManager.kt
+++ b/library/extensions/callback/kmp-tor-ext-callback-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/manager/CallbackTorManager.kt
@@ -155,22 +155,22 @@ class CallbackTorManager(
     }
 
     override fun configGet(
-        setting: TorConfig.Setting<*>,
+        keyword: TorConfig.KeyWord,
         failure: TorCallback<Throwable>?,
         success: TorCallback<List<ConfigEntry>>
     ): Task {
         return provideOrFail(failure, success) {
-            configGet(setting)
+            configGet(keyword)
         }
     }
 
     override fun configGet(
-        settings: Set<TorConfig.Setting<*>>,
+        keywords: Set<TorConfig.KeyWord>,
         failure: TorCallback<Throwable>?,
         success: TorCallback<List<ConfigEntry>>
     ): Task {
         return provideOrFail(failure, success) {
-            configGet(settings)
+            configGet(keywords)
         }
     }
 
@@ -185,24 +185,22 @@ class CallbackTorManager(
     }
 
     override fun configReset(
-        setting: TorConfig.Setting<*>,
-        setDefault: Boolean,
+        keyword: TorConfig.KeyWord,
         failure: TorCallback<Throwable>?,
         success: TorCallback<Any?>
     ): Task {
         return provideOrFail(failure, success) {
-            configReset(setting)
+            configReset(keyword)
         }
     }
 
     override fun configReset(
-        settings: Set<TorConfig.Setting<*>>,
-        setDefault: Boolean,
+        keywords: Set<TorConfig.KeyWord>,
         failure: TorCallback<Throwable>?,
         success: TorCallback<Any?>
     ): Task {
         return provideOrFail(failure, success) {
-            configReset(settings, setDefault)
+            configReset(keywords)
         }
     }
 

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
@@ -56,9 +56,9 @@ class TorControllerIntegrationTest: TorTestHelper() {
     @Test
     fun givenCommandConfigGet_whenTorQueried_returnsSuccess() = runBlocking {
         val getConfig = setOf(
-            TorConfig.Setting.CookieAuthentication(),
-            TorConfig.Setting.DisableNetwork(),
-            TorConfig.Setting.Ports.Control(),
+            TorConfig.KeyWord.CookieAuthentication,
+            TorConfig.KeyWord.DisableNetwork,
+            TorConfig.KeyWord.ControlPort,
         )
 
         manager.configGet(getConfig).getOrThrow()
@@ -105,7 +105,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
             manager.configSet(disableNetwork).getOrThrow()
 
             // Check it is enabled
-            val entry1 = manager.configGet(disableNetwork).getOrThrow().first()
+            val entry1 = manager.configGet(disableNetwork.keyword).getOrThrow().first()
             assertEquals(_false.value, entry1.value)
 
             // Now disable it
@@ -114,7 +114,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
             manager.configSet(disableNetwork).getOrThrow()
 
             // verify disabled
-            val entry2 = manager.configGet(disableNetwork).getOrThrow().first()
+            val entry2 = manager.configGet(disableNetwork.keyword).getOrThrow().first()
             assertEquals(_true.value, entry2.value)
         } catch (t: Throwable) {
             throwable = t
@@ -160,7 +160,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
             throwable = t
         } finally {
 
-            manager.configReset(setOf(dormancy, padding))
+            manager.configSet(setOf(dormancy, padding))
             manager.setEvents(setOf())
             manager.removeListener(listener)
 
@@ -389,7 +389,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
         assertTrue(hsConfigSettings.size > 1)
 
-        val entries = manager.configGet(hsConfigSettings.first())
+        val entries = manager.configGet(hsConfigSettings.first().keyword)
             .getOrThrow()
             .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
@@ -409,7 +409,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
         assertTrue(hsConfigSettings.size > 1)
 
-        val entries = manager.configGet(hsConfigSettings.first())
+        val entries = manager.configGet(hsConfigSettings.first().keyword)
             .getOrThrow()
             .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
@@ -417,9 +417,9 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
         var throwable: Throwable? = null
         try {
-            manager.configReset(hsConfigSettings.first(), setDefault = false).getOrThrow()
+            manager.configSet(hsConfigSettings.first()).getOrThrow()
 
-            val resetEntries = manager.configGet(hsConfigSettings.first())
+            val resetEntries = manager.configGet(hsConfigSettings.first().keyword)
                 .getOrThrow()
                 .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
@@ -448,7 +448,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
         assertTrue(hsConfigSettings.size > 1)
 
-        val entries = manager.configGet(hsConfigSettings.first())
+        val entries = manager.configGet(hsConfigSettings.first().keyword)
             .getOrThrow()
             .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
@@ -458,7 +458,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
         try {
             manager.configSet(hsConfigSettings.first()).getOrThrow()
 
-            val resetEntries = manager.configGet(hsConfigSettings.first())
+            val resetEntries = manager.configGet(hsConfigSettings.first().keyword)
                 .getOrThrow()
                 .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
@@ -495,7 +495,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
             manager.configSet(socks).getOrThrow()
 
-            val entry = manager.configGet(socks).getOrThrow().first()
+            val entry = manager.configGet(socks.keyword).getOrThrow().first()
 
             val sb = StringBuilder()
             socks.appendTo(sb, appendValue = true, isWriteTorConfig = true)
@@ -541,7 +541,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
             manager.configSet(socks).getOrThrow()
 
-            val entry = manager.configGet(socks).getOrThrow().first()
+            val entry = manager.configGet(socks.keyword).getOrThrow().first()
 
             val sb = StringBuilder()
             socks.appendTo(sb, appendValue = true, isWriteTorConfig = true)

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
@@ -391,7 +391,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
         val entries = manager.configGet(hsConfigSettings.first())
             .getOrThrow()
-            .filter { it.key == hsConfigSettings.first().keyword }
+            .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
         assertEquals(hsConfigSettings.size, entries.size)
 
@@ -411,7 +411,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
         val entries = manager.configGet(hsConfigSettings.first())
             .getOrThrow()
-            .filter { it.key == hsConfigSettings.first().keyword }
+            .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
         assertEquals(hsConfigSettings.size, entries.size)
 
@@ -421,7 +421,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
             val resetEntries = manager.configGet(hsConfigSettings.first())
                 .getOrThrow()
-                .filter { it.key == hsConfigSettings.first().keyword }
+                .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
             assertEquals(1, resetEntries.size)
         } catch (t: Throwable) {
@@ -450,7 +450,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
         val entries = manager.configGet(hsConfigSettings.first())
             .getOrThrow()
-            .filter { it.key == hsConfigSettings.first().keyword }
+            .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
         assertEquals(hsConfigSettings.size, entries.size)
 
@@ -460,7 +460,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
 
             val resetEntries = manager.configGet(hsConfigSettings.first())
                 .getOrThrow()
-                .filter { it.key == hsConfigSettings.first().keyword }
+                .filter { it.key == hsConfigSettings.first().keyword.toString() }
 
             assertEquals(1, resetEntries.size)
         } catch (t: Throwable) {

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
@@ -498,7 +498,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
             val entry = manager.configGet(socks.keyword).getOrThrow().first()
 
             val sb = StringBuilder()
-            socks.appendTo(sb, appendValue = true, isWriteTorConfig = true)
+            socks.appendTo(sb, isWriteTorConfig = true)
 
             // Remove Keyword (SocksPort)
             val expected = sb.toString().substringAfter(' ')
@@ -544,7 +544,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
             val entry = manager.configGet(socks.keyword).getOrThrow().first()
 
             val sb = StringBuilder()
-            socks.appendTo(sb, appendValue = true, isWriteTorConfig = true)
+            socks.appendTo(sb, isWriteTorConfig = true)
 
             // Remove Keyword (SocksPort)
             val expected = sb.toString().substringAfter(' ')

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/manager/TorManagerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/manager/TorManagerIntegrationTest.kt
@@ -136,7 +136,7 @@ class TorManagerIntegrationTest: TorTestHelper() {
         try {
             // Run 1: Set Socks1 and Socks2 ports
             manager.configSet(setOf(socks1, socks2)).getOrThrow()
-            val entries1 = manager.configGet(socks1).getOrThrow()
+            val entries1 = manager.configGet(socks1.keyword).getOrThrow()
 
             assertEquals(2, entries1.size)
             assertTrue(entries1[0].value.contains(socks1.value?.path?.value!!))
@@ -153,7 +153,7 @@ class TorManagerIntegrationTest: TorTestHelper() {
             // Run 2: Disable SocksPort
             manager.configSet(Ports.Socks().set(AorDorPort.Disable)).getOrThrow()
 
-            val entries2 = manager.configGet(socks1).getOrThrow()
+            val entries2 = manager.configGet(socks1.keyword).getOrThrow()
             assertEquals(1, entries2.size)
             assertEquals(AorDorPort.Disable.value, entries2.first().value)
 
@@ -165,7 +165,7 @@ class TorManagerIntegrationTest: TorTestHelper() {
             // Run 3: Set Socks1
             manager.configSet(socks1).getOrThrow()
 
-            val entries3 = manager.configGet(socks1).getOrThrow()
+            val entries3 = manager.configGet(socks1.keyword).getOrThrow()
             assertEquals(1, entries3.size)
             assertTrue(entries3.first().value.contains(socks1.value?.path?.value!!))
 

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -33,12 +33,10 @@ expect abstract class KmpTorLoader {
     }
 
     /**
-     * Calls [TorConfig.Builder.removeInstanceOf] for all present
-     * settings. This is to ensure platform specific settings are
-     * removed during the [TorConfigProvider.retrieve] process, prior
-     * to starting Tor.
+     * Will exclude settings for the given [TorConfig.KeyWord]
+     * when validating the provided config.
      * */
-    protected open val excludeSettings: Set<TorConfig.Setting<*>>
+    protected open val excludeSettings: Set<TorConfig.KeyWord>
 
     @Throws(TorManagerException::class, CancellationException::class)
     protected abstract suspend fun startTor(

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorConfigProvider.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorConfigProvider.kt
@@ -122,7 +122,7 @@ abstract class TorConfigProvider {
         // remove certain settings if present, for example,
         // anything to do with Unix Sockets for Android,
         // Jvm (windows), NodeJs (windows), Windows targets.
-        excludeSettings: Set<TorConfig.Setting<*>>,
+        excludeSettings: Set<TorConfig.KeyWord>,
         isPortAvailable: (Port) -> Boolean
     ): ValidatedTorConfig {
         val clientConfig = provide()
@@ -137,11 +137,10 @@ abstract class TorConfigProvider {
             ?: workDir.builder { addSegment(DataDirectory.DEFAULT_NAME) }
         dataDir.set(FileSystemDir(dataDirPath))
 
-        val excludedClasses = excludeSettings.map { it::class }
         val portValidator = PortValidator(dataDirPath)
         val builder: TorConfig.Builder = TorConfig.Builder {
             for (setting in clientConfig.settings) {
-                if (excludedClasses.contains(setting::class)) {
+                if (excludeSettings.contains(setting.keyword)) {
                     continue
                 }
 

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/BaseTorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/BaseTorManager.kt
@@ -51,15 +51,15 @@ internal abstract class BaseTorManager: SynchronizedObject(), TorControlManager 
 //        }
 //    }
 
-    override suspend fun configGet(setting: TorConfig.Setting<*>): Result<List<ConfigEntry>> {
+    override suspend fun configGet(keyword: TorConfig.KeyWord): Result<List<ConfigEntry>> {
         return provide<TorControlConfigGet, List<ConfigEntry>> {
-            configGet(setting)
+            configGet(keyword)
         }
     }
 
-    override suspend fun configGet(settings: Set<TorConfig.Setting<*>>): Result<List<ConfigEntry>> {
+    override suspend fun configGet(keywords: Set<TorConfig.KeyWord>): Result<List<ConfigEntry>> {
         return provide<TorControlConfigGet, List<ConfigEntry>> {
-            configGet(settings)
+            configGet(keywords)
         }
     }
 
@@ -69,21 +69,15 @@ internal abstract class BaseTorManager: SynchronizedObject(), TorControlManager 
         }
     }
 
-    override suspend fun configReset(
-        setting: TorConfig.Setting<*>,
-        setDefault: Boolean
-    ): Result<Any?> {
+    override suspend fun configReset(keyword: TorConfig.KeyWord): Result<Any?> {
         return provide<TorControlConfigReset, Any?> {
-            configReset(setting, setDefault)
+            configReset(keyword)
         }
     }
 
-    override suspend fun configReset(
-        settings: Set<TorConfig.Setting<*>>,
-        setDefault: Boolean
-    ): Result<Any?> {
+    override suspend fun configReset(keywords: Set<TorConfig.KeyWord>): Result<Any?> {
         return provide<TorControlConfigReset, Any?> {
-            configReset(settings, setDefault)
+            configReset(keywords)
         }
     }
 

--- a/library/manager/kmp-tor-manager/src/jsMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jsMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -30,12 +30,10 @@ actual abstract class KmpTorLoader(provider: TorConfigProvider) {
     }
 
     /**
-     * Calls [TorConfig.Builder.removeInstanceOf] for all present
-     * settings. This is to ensure platform specific settings are
-     * removed during the [TorConfigProvider.retrieve] process, prior
-     * to starting Tor.
+     * Will exclude settings for the given [TorConfig.KeyWord]
+     * when validating the provided config.
      * */
-    protected actual open val excludeSettings: Set<TorConfig.Setting<*>> = emptySet()
+    protected actual open val excludeSettings: Set<TorConfig.KeyWord> = emptySet()
     private val provider = provider
     internal actual open suspend fun load(
         instanceId: String,

--- a/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -59,12 +59,10 @@ actual abstract class KmpTorLoader(protected val provider: TorConfigProvider) {
     }
 
     /**
-     * Calls [TorConfig.Builder.removeInstanceOf] for all present
-     * settings. This is to ensure platform specific settings are
-     * removed during the [TorConfigProvider.retrieve] process, prior
-     * to starting Tor.
+     * Will exclude settings for the given [TorConfig.KeyWord]
+     * when validating the provided config.
      * */
-    protected actual open val excludeSettings: Set<TorConfig.Setting<*>> = emptySet()
+    protected actual open val excludeSettings: Set<TorConfig.KeyWord> = emptySet()
     private val torDispatcher = DispatcherHandler()
     private var torJob: Job? = null
 

--- a/library/manager/kmp-tor-manager/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -32,12 +32,10 @@ actual abstract class KmpTorLoader(provider: TorConfigProvider) {
     }
 
     /**
-     * Calls [TorConfig.Builder.removeInstanceOf] for all present
-     * settings. This is to ensure platform specific settings are
-     * removed during the [TorConfigProvider.retrieve] process, prior
-     * to starting Tor.
+     * Will exclude settings for the given [TorConfig.KeyWord]
+     * when validating the provided config.
      * */
-    protected actual open val excludeSettings: Set<TorConfig.Setting<*>> = emptySet()
+    protected actual open val excludeSettings: Set<TorConfig.KeyWord> = emptySet()
     private val provider = provider
     internal actual open suspend fun load(
         instanceId: String,


### PR DESCRIPTION
New subclass to `TorConfig`; `TorConfig.KeyWord.*`'s.

This will allow for adding more `KeyWord`s w/o having to implement the `TorConfig.Setting` for it, and still provides type safety with controller/manager usage (such as the changes made to `configGet` and `configReset`).

Closes #157 

**BREAKING CHANGES**:
 - `TorConfig.Setting.keyword` was changed from type `String` to `TorConfig.KeyWord`
 - `KmpTorLoader.excludeSettings` was changed from type `Set<TorConfig.Setting<*>>` to `Set<TorConfig.KeyWord>`
 - `TorControlConfigGet.configGet` was changed from accepting a `TorConfig.Setting<*>`, to accepting a `TorConfig.KeyWord`
 - `TorControlConfigReset.configReset` was changed from accepting a `TorConfig.Setting<*>` to accepting a `TorConfig.KeyWord`
 - `CallbackTorControlConfigGet.configGet` was changed from accepting a `TorConfig.Setting<*>`, to accepting a `TorConfig.KeyWord`
 - `CallbackTorControlConfigReset.configReset` was changed from accepting a `TorConfig.Setting<*>` to accepting a `TorConfig.KeyWord`