### PR TITLE
Add typealias + deprecation notice

### DIFF
--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -18,6 +18,15 @@ package io.matthewnelson.kmp.tor.controller.common.internal
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import kotlin.jvm.JvmStatic
 
+@Deprecated(
+    message = "ControllerUtils name was changed to PlatformUtil",
+    replaceWith = ReplaceWith(
+        "PlatformUtil",
+        "io.matthewnelson.kmp.tor.controller.common.internal.PlatformUtil"
+    )
+)
+typealias ControllerUtils = PlatformUtil
+
 expect object PlatformUtil {
 
     /**


### PR DESCRIPTION
Adds typealias + deprecation notice to mitigate breaking name change of `ControllerUtils` introduced in #176 

Closes #177 