### PR TITLE
Bump dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/kmp/tor/env.kt
+++ b/buildSrc/src/main/kotlin/kmp/tor/env.kt
@@ -20,7 +20,7 @@ object env {
     // Must be either "-SNAPSHOT" || ""
     private const val SNAPSHOT              = "-SNAPSHOT"
 
-    private const val MANAGER_VERSION_NAME  = "0.2.1"
+    private const val MANAGER_VERSION_NAME  = "1.0.0"
     //                           1.0.0-alpha1  == 01_00_00_11
     //                           1.0.0-alpha2  == 01_00_00_12
     //                           1.0.0-beta1   == 01_00_00_21
@@ -29,13 +29,13 @@ object env {
     //                           1.0.1         == 01_00_01_99
     //                           1.1.1         == 01_01_01_99
     //                           1.15.1        == 01_15_01_99
-    private const val MANAGER_VERSION_CODE  = /*00_0*/2_01_99
+    private const val MANAGER_VERSION_CODE  = /*0*/1_00_00_99
 
-    private const val BINARY_VERSION_NAME   = "0.4.7.7"
+    private const val BINARY_VERSION_NAME   = "0.4.7.8"
     //                           0.4.6.9       == 00_04_06_09_00
     //                           0.4.6.9a      == 00_04_06_09_01
     //                           0.4.6.9b      == 00_04_06_09_02
-    private const val BINARY_VERSION_CODE   = /*00_0*/4_07_07_00
+    private const val BINARY_VERSION_CODE   = /*00_0*/4_07_08_00
 
     /**
      * Binaries exist in a different repo. Building against the staged
@@ -55,6 +55,7 @@ object env {
      *  - :library:controller:kmp-tor-controller
      *  - :library:extensions:kmp-tor-ext-callback-controller
      *  - :library:extensions:kmp-tor-ext-callback-manager
+     *  - :library:extensions:kmp-tor-ext-unix-socket
      *  - :library:manager:kmp-tor-manager
      * */
     object kmpTor {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,7 +38,7 @@ if (CHECK_PUBLICATION != null) {
     }
 
     if (allTargets || targets?.contains("JVM") != false) {
-        include(":samples:java:javafx")
+//        include(":samples:java:javafx")
         include(":samples:kotlin:javafx")
     }
 }


### PR DESCRIPTION
 - `encoding` updated from `1.1.2` -> `1.1.3`
 - `kmp-tor-binary` updated from `0.4.7.7` -> `0.4.7.8`
 - Temporarily comments out `:samples:java:javafx` project, until a `1.0.0` release gets cut (today, hopefully)