### PR TITLE
Remove default overloads from `TorControl` usecases

### DIFF
--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlConfigSave.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlConfigSave.kt
@@ -26,6 +26,6 @@ import io.matthewnelson.kmp.tor.controller.common.control.TorControlConfig
  * */
 interface TorControlConfigSave {
 
-    suspend fun configSave(force: Boolean = false): Result<Any?>
+    suspend fun configSave(force: Boolean): Result<Any?>
 
 }

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlOnionAdd.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlOnionAdd.kt
@@ -74,8 +74,8 @@ interface TorControlOnionAdd {
     suspend fun onionAdd(
         privateKey: OnionAddress.PrivateKey,
         hsPorts: Set<TorConfig.Setting.HiddenService.Ports>,
-        flags: Set<Flag>? = null,
-        maxStreams: TorConfig.Setting.HiddenService.MaxStreams? = null,
+        flags: Set<Flag>?,
+        maxStreams: TorConfig.Setting.HiddenService.MaxStreams?,
     ): Result<HiddenServiceEntry>
 
     /**
@@ -85,8 +85,8 @@ interface TorControlOnionAdd {
     suspend fun onionAddNew(
         type: OnionAddress.PrivateKey.Type,
         hsPorts: Set<TorConfig.Setting.HiddenService.Ports>,
-        flags: Set<Flag>? = null,
-        maxStreams: TorConfig.Setting.HiddenService.MaxStreams? = null
+        flags: Set<Flag>?,
+        maxStreams: TorConfig.Setting.HiddenService.MaxStreams?
     ): Result<HiddenServiceEntry>
 
     enum class Flag {

--- a/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlSetEvents.kt
+++ b/library/controller/kmp-tor-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/common/control/usecase/TorControlSetEvents.kt
@@ -27,6 +27,6 @@ import io.matthewnelson.kmp.tor.controller.common.events.TorEvent
  * */
 interface TorControlSetEvents {
 
-    suspend fun setEvents(events: Set<TorEvent>, extended: Boolean = false): Result<Any?>
+    suspend fun setEvents(events: Set<TorEvent>): Result<Any?>
 
 }

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorControlProcessor.kt
@@ -728,14 +728,10 @@ private class RealTorControlProcessor(
 //        }
 //    }
 
-    override suspend fun setEvents(events: Set<TorEvent>, extended: Boolean): Result<Any?> {
+    override suspend fun setEvents(events: Set<TorEvent>): Result<Any?> {
         return lock.withLock {
             try {
                 val command = StringBuilder("SETEVENTS").apply {
-                    if (extended) {
-                        append(SP)
-                        append("EXTENDED")
-                    }
                     if (events.isNotEmpty()) {
                         events.joinTo(this, separator = SP, prefix = SP)
                     }

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
@@ -579,8 +579,8 @@ private class RealTorController(
 //        return processorDelegate.resolve()
 //    }
 
-    override suspend fun setEvents(events: Set<TorEvent>, extended: Boolean): Result<Any?> {
-        return processorDelegate.setEvents(events, extended)
+    override suspend fun setEvents(events: Set<TorEvent>): Result<Any?> {
+        return processorDelegate.setEvents(events)
     }
 
     override suspend fun signal(signal: TorControlSignal.Signal): Result<Any?> {

--- a/library/extensions/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlConfigSave.kt
+++ b/library/extensions/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlConfigSave.kt
@@ -29,7 +29,7 @@ import io.matthewnelson.kmp.tor.ext.callback.controller.common.control.CallbackT
 interface CallbackTorControlConfigSave {
 
     fun configSave(
-        force: Boolean = false,
+        force: Boolean,
         failure: TorCallback<Throwable>?,
         success: TorCallback<Any?>,
     ): Task

--- a/library/extensions/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlOnionAdd.kt
+++ b/library/extensions/kmp-tor-ext-callback-controller-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/ext/callback/controller/common/control/usecase/CallbackTorControlOnionAdd.kt
@@ -77,8 +77,8 @@ interface CallbackTorControlOnionAdd {
     fun onionAdd(
         privateKey: OnionAddress.PrivateKey,
         hsPorts: Set<TorConfig.Setting.HiddenService.Ports>,
-        flags: Set<Flag>? = null,
-        maxStreams: TorConfig.Setting.HiddenService.MaxStreams? = null,
+        flags: Set<Flag>?,
+        maxStreams: TorConfig.Setting.HiddenService.MaxStreams?,
         failure: TorCallback<Throwable>?,
         success: TorCallback<HiddenServiceEntry>,
     ): Task
@@ -90,8 +90,8 @@ interface CallbackTorControlOnionAdd {
     fun onionAddNew(
         type: OnionAddress.PrivateKey.Type,
         hsPorts: Set<TorConfig.Setting.HiddenService.Ports>,
-        flags: Set<Flag>? = null,
-        maxStreams: TorConfig.Setting.HiddenService.MaxStreams? = null,
+        flags: Set<Flag>?,
+        maxStreams: TorConfig.Setting.HiddenService.MaxStreams?,
         failure: TorCallback<Throwable>?,
         success: TorCallback<HiddenServiceEntry>,
     ): Task

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/controller/TorControllerIntegrationTest.kt
@@ -205,6 +205,7 @@ class TorControllerIntegrationTest: TorTestHelper() {
             flags = setOf(
                 TorControlOnionAdd.Flag.DiscardPK,
             ),
+            maxStreams = null,
         ).getOrThrow()
 
         manager.onionDel(expectedAddress)
@@ -225,6 +226,8 @@ class TorControllerIntegrationTest: TorTestHelper() {
             hsPorts = setOf(
                 TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8770), targetPort = Port(8770)),
             ),
+            flags = null,
+            maxStreams = null,
         ).getOrThrow()
 
         manager.onionDel(expectedAddress)
@@ -239,14 +242,18 @@ class TorControllerIntegrationTest: TorTestHelper() {
     fun givenHiddenService_whenNoPortsProvided_returnsFailure() = runBlocking {
         val resultNew = manager.onionAddNew(
             type = OnionAddress.PrivateKey.Type.ED25519_V3,
-            hsPorts = emptySet()
+            hsPorts = emptySet(),
+            flags = null,
+            maxStreams = null,
         )
 
         assertTrue(resultNew.isFailure)
 
         val resultExisting = manager.onionAdd(
             privateKey = OnionAddressV3PrivateKey_ED25519("gGNRsNtSKe38fPr/J1UW2nOCNetZNl3qNySlPs9M5Fait1VVruWEBOoNU7fuPRkC4yrS1G7f/VjohBdzKTIQ6Q"),
-            hsPorts = emptySet()
+            hsPorts = emptySet(),
+            flags = null,
+            maxStreams = null,
         )
 
         assertTrue(resultExisting.isFailure)
@@ -261,6 +268,8 @@ class TorControllerIntegrationTest: TorTestHelper() {
             hsPorts = setOf(
                 TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8771), targetPort = Port(8770)),
             ),
+            flags = null,
+            maxStreams = null,
         ).getOrThrow()
 
         val result = manager.onionAdd(
@@ -268,6 +277,8 @@ class TorControllerIntegrationTest: TorTestHelper() {
             hsPorts = setOf(
                 TorConfig.Setting.HiddenService.Ports(virtualPort = Port(8772), targetPort = Port(8770)),
             ),
+            flags = null,
+            maxStreams = null,
         )
 
         manager.onionDel(entry.address)

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/TorManager.kt
@@ -506,9 +506,9 @@ private class RealTorManager(
         }
     }
 
-    override suspend fun setEvents(events: Set<TorEvent>, extended: Boolean): Result<Any?> {
+    override suspend fun setEvents(events: Set<TorEvent>): Result<Any?> {
         return provide<TorControlSetEvents, Any?> {
-            setEvents(events.toMutableSet().apply { addAll(requiredEvents) }, extended)
+            setEvents(events.toMutableSet().apply { addAll(requiredEvents) })
         }
     }
 

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/BaseTorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/BaseTorManager.kt
@@ -226,9 +226,9 @@ internal abstract class BaseTorManager: SynchronizedObject(), TorControlManager 
 //        }
 //    }
 
-    override suspend fun setEvents(events: Set<TorEvent>, extended: Boolean): Result<Any?> {
+    override suspend fun setEvents(events: Set<TorEvent>): Result<Any?> {
         return provide<TorControlSetEvents, Any?> {
-            setEvents(events, extended)
+            setEvents(events)
         }
     }
 


### PR DESCRIPTION
Closes #194 

**BREAKING CHANGES**:
 - `TorControlConfigSave.configSave` overload was removed
 - `TorControlOnionAdd.onionAdd` overloads were removed
 - `TorControlOnionAdd.onionAddNew` overloads were removed
 - `TorControlSetEvents.setEvents` argument `extended` was removed (obsoleted by Tor)
 - `CallbackTorControlConfigSave.configSave` overload was removed
 - `CallbackTorControlOnionAdd.onionAdd` overloads were removed
 - `CallbackTorControlOnionAdd.onionAddNew` overloads were removed