### PR TITLE
Bump kotlin-components (build tool improvements)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ android.enableJetifier=true
 
 kotlin.code.style=official
 kotlin.js.compiler=both
+kotlinx.atomicfu.enableIrTransformation=true
 
 kapt.use.worker.api=true
 

--- a/library/controller/kmp-tor-controller-common/build.gradle.kts
+++ b/library/controller/kmp-tor-controller-common/build.gradle.kts
@@ -63,10 +63,9 @@ kmpConfiguration {
 
             KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
-        commonPluginIds = setOf(pluginId.kotlin.atomicfu),
+        commonPluginIdsPostConfiguration = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
-                implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.reflect)
                 api(project(":library:kmp-tor-common"))
             }

--- a/library/controller/kmp-tor-controller/build.gradle.kts
+++ b/library/controller/kmp-tor-controller/build.gradle.kts
@@ -17,7 +17,6 @@ import io.matthewnelson.kotlin.components.dependencies.deps
 import io.matthewnelson.kotlin.components.dependencies.depsTest
 import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
-import io.matthewnelson.kotlin.components.kmp.util.sourceSetJvmAndroidMain
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -39,6 +38,12 @@ kmpConfiguration {
                 target = {
                     publishLibraryVariants("release")
                 },
+                mainSourceSet = {
+                    dependencies {
+                        // https://github.com/Kotlin/kotlinx.atomicfu/issues/145
+                        implementation(deps.kotlin.atomicfu.jvm)
+                    }
+                }
             ),
 
 //            KmpTarget.NonJvm.JS(
@@ -69,11 +74,10 @@ kmpConfiguration {
 //
 //            KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
-        commonPluginIds = setOf(pluginId.kotlin.atomicfu),
+        commonPluginIdsPostConfiguration = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
                 implementation(deps.components.encoding.base16)
-                implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.coroutines.core.core)
                 api(project(":library:controller:kmp-tor-controller-common"))
             }
@@ -84,13 +88,6 @@ kmpConfiguration {
                 implementation(kotlin("test"))
             }
         },
-        kotlin = {
-            sourceSetJvmAndroidMain {
-                dependencies {
-                    implementation(deps.kotlin.coroutines.core.jvm)
-                }
-            }
-        }
     )
 }
 

--- a/library/extensions/kmp-tor-ext-callback-controller-common/build.gradle.kts
+++ b/library/extensions/kmp-tor-ext-callback-controller-common/build.gradle.kts
@@ -56,6 +56,7 @@ kmpConfiguration {
 
             KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
+        commonPluginIdsPostConfiguration = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
                 implementation(project(":library:controller:kmp-tor-controller-common"))

--- a/library/extensions/kmp-tor-ext-callback-manager-common/build.gradle.kts
+++ b/library/extensions/kmp-tor-ext-callback-manager-common/build.gradle.kts
@@ -56,6 +56,7 @@ kmpConfiguration {
 
             KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
+        commonPluginIdsPostConfiguration = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
                 api(project(":library:extensions:kmp-tor-ext-callback-controller-common"))

--- a/library/manager/kmp-tor-manager-common/build.gradle.kts
+++ b/library/manager/kmp-tor-manager-common/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-import io.matthewnelson.kotlin.components.dependencies.deps
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
@@ -57,6 +56,7 @@ kmpConfiguration {
 
             KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
+        commonPluginIdsPostConfiguration = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
                 api(project(":library:controller:kmp-tor-controller-common"))

--- a/library/manager/kmp-tor-manager/build.gradle.kts
+++ b/library/manager/kmp-tor-manager/build.gradle.kts
@@ -18,7 +18,6 @@ import io.matthewnelson.kotlin.components.dependencies.depsTest
 import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import io.matthewnelson.kotlin.components.kmp.publish.kmpPublishRootProjectConfiguration
-import io.matthewnelson.kotlin.components.kmp.util.sourceSetJvmJsMain
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -40,6 +39,12 @@ kmpConfiguration {
                 target = {
                     publishLibraryVariants("release")
                 },
+                mainSourceSet = {
+                    dependencies {
+                        // https://github.com/Kotlin/kotlinx.atomicfu/issues/145
+                        implementation(deps.kotlin.atomicfu.jvm)
+                    }
+                }
             ),
 
 //            KmpTarget.NonJvm.JS(
@@ -70,10 +75,9 @@ kmpConfiguration {
 //
 //            KmpTarget.NonJvm.Native.Mingw.X64.DEFAULT,
         ),
-        commonPluginIds = setOf(pluginId.kotlin.atomicfu),
+        commonPluginIdsPostConfiguration = setOf(pluginId.kotlin.atomicfu),
         commonMainSourceSet = {
             dependencies {
-                implementation(deps.kotlin.atomicfu.atomicfu)
                 implementation(deps.kotlin.coroutines.core.core)
                 implementation(project(":library:controller:kmp-tor-controller")) {
                     exclude(kmpPublishRootProjectConfiguration!!.group, "kmp-tor-common")
@@ -88,13 +92,6 @@ kmpConfiguration {
                 implementation(kotlin("test"))
             }
         },
-        kotlin = {
-            sourceSetJvmJsMain {
-                dependencies {
-                    implementation(deps.kotlin.coroutines.core.core)
-                }
-            }
-        }
     )
 }
 


### PR DESCRIPTION
Fixes how `atomicfu` plugin was being applied by setting up source sets **before** applying the plugin
Fixes how commonMain dependencies were being applied by invoking `commonMainSourceSet` **after** intermediary source sets are setup (so the dependency can propagate to them properly)