### PR TITLE
Fix publication for JS targets where atomicfu classes were not being found (missing dependency)

### DIFF
--- a/library/controller/kmp-tor-controller-common/build.gradle.kts
+++ b/library/controller/kmp-tor-controller-common/build.gradle.kts
@@ -39,6 +39,12 @@ kmpConfiguration {
                 compilerType = KotlinJsCompilerType.BOTH,
                 browser = null,
                 node = KmpTarget.NonJvm.JS.Node(),
+                mainSourceSet = {
+                    dependencies {
+                        // https://github.com/05nelsonm/kmp-tor/issues/205
+                        implementation(deps.kotlin.atomicfu.js)
+                    }
+                },
             ),
 
             KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,

--- a/library/controller/kmp-tor-controller/build.gradle.kts
+++ b/library/controller/kmp-tor-controller/build.gradle.kts
@@ -50,6 +50,12 @@ kmpConfiguration {
 //                compilerType = KotlinJsCompilerType.BOTH,
 //                browser = null,
 //                node = KmpTarget.NonJvm.JS.Node(),
+//                mainSourceSet = {
+//                    dependencies {
+//                        // https://github.com/05nelsonm/kmp-tor/issues/205
+//                        implementation(deps.kotlin.atomicfu.js)
+//                    }
+//                },
 //            ),
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,

--- a/library/manager/kmp-tor-manager-common/build.gradle.kts
+++ b/library/manager/kmp-tor-manager-common/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+import io.matthewnelson.kotlin.components.dependencies.deps
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import kmp.tor.env
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
@@ -32,6 +33,12 @@ kmpConfiguration {
                 compilerType = KotlinJsCompilerType.BOTH,
                 browser = null,
                 node = KmpTarget.NonJvm.JS.Node(),
+                mainSourceSet = {
+                    dependencies {
+                        // https://github.com/05nelsonm/kmp-tor/issues/205
+                        implementation(deps.kotlin.atomicfu.js)
+                    }
+                },
             ),
 
             KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,

--- a/library/manager/kmp-tor-manager/build.gradle.kts
+++ b/library/manager/kmp-tor-manager/build.gradle.kts
@@ -51,6 +51,12 @@ kmpConfiguration {
 //                compilerType = KotlinJsCompilerType.BOTH,
 //                browser = null,
 //                node = KmpTarget.NonJvm.JS.Node(),
+//                mainSourceSet = {
+//                    dependencies {
+//                        // https://github.com/05nelsonm/kmp-tor/issues/205
+//                        implementation(deps.kotlin.atomicfu.js)
+//                    }
+//                },
 //            ),
 //
 //            KmpTarget.NonJvm.Native.Unix.Darwin.Ios.Arm32.DEFAULT,


### PR DESCRIPTION
Closes #205 