### PR TITLE
Fix parsing of urls that contain subdomains

### DIFF
--- a/library/kmp-tor-common/api/android/kmp-tor-common.api
+++ b/library/kmp-tor-common/api/android/kmp-tor-common.api
@@ -10,6 +10,7 @@ public abstract interface class io/matthewnelson/kmp/tor/common/address/OnionAdd
 	public abstract fun decode ()[B
 	public static fun fromString (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
 	public static fun fromStringOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
+	public abstract fun getHostname ()Ljava/lang/String;
 	public abstract fun getValue ()Ljava/lang/String;
 	public abstract fun getValueDotOnion ()Ljava/lang/String;
 }
@@ -84,14 +85,20 @@ public final class io/matthewnelson/kmp/tor/common/address/OnionUrl : android/os
 	public final field path Ljava/lang/String;
 	public final field port Lio/matthewnelson/kmp/tor/common/address/Port;
 	public final field scheme Lio/matthewnelson/kmp/tor/common/address/Scheme;
+	public final field subdomain Ljava/lang/String;
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;)V
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;)V
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;)V
 	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;)V
-	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lio/matthewnelson/kmp/tor/common/address/Port;
 	public final fun component4 ()Lio/matthewnelson/kmp/tor/common/address/Scheme;
-	public final fun copy (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
-	public static synthetic fun copy$default (Lio/matthewnelson/kmp/tor/common/address/OnionUrl;Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;ILjava/lang/Object;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
+	public static synthetic fun copy$default (Lio/matthewnelson/kmp/tor/common/address/OnionUrl;Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;ILjava/lang/Object;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromString (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;

--- a/library/kmp-tor-common/api/jvm/kmp-tor-common.api
+++ b/library/kmp-tor-common/api/jvm/kmp-tor-common.api
@@ -3,6 +3,7 @@ public abstract interface class io/matthewnelson/kmp/tor/common/address/OnionAdd
 	public abstract fun decode ()[B
 	public static fun fromString (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
 	public static fun fromStringOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
+	public abstract fun getHostname ()Ljava/lang/String;
 	public abstract fun getValue ()Ljava/lang/String;
 	public abstract fun getValueDotOnion ()Ljava/lang/String;
 }
@@ -76,14 +77,20 @@ public final class io/matthewnelson/kmp/tor/common/address/OnionUrl : io/matthew
 	public final field path Ljava/lang/String;
 	public final field port Lio/matthewnelson/kmp/tor/common/address/Port;
 	public final field scheme Lio/matthewnelson/kmp/tor/common/address/Scheme;
+	public final field subdomain Ljava/lang/String;
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;)V
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;)V
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;)V
 	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;)V
-	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lio/matthewnelson/kmp/tor/common/address/Port;
 	public final fun component4 ()Lio/matthewnelson/kmp/tor/common/address/Scheme;
-	public final fun copy (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
-	public static synthetic fun copy$default (Lio/matthewnelson/kmp/tor/common/address/OnionUrl;Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;ILjava/lang/Object;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
+	public static synthetic fun copy$default (Lio/matthewnelson/kmp/tor/common/address/OnionUrl;Lio/matthewnelson/kmp/tor/common/address/OnionAddress;Ljava/lang/String;Lio/matthewnelson/kmp/tor/common/address/Port;Lio/matthewnelson/kmp/tor/common/address/Scheme;Ljava/lang/String;ILjava/lang/Object;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromString (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;
 	public static final fun fromStringOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionUrl;

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddress.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddress.kt
@@ -16,7 +16,6 @@
 package io.matthewnelson.kmp.tor.common.address
 
 import io.matthewnelson.component.parcelize.Parcelable
-import io.matthewnelson.component.parcelize.Parcelize
 import io.matthewnelson.kmp.tor.common.internal.stripAddress
 import io.matthewnelson.kmp.tor.common.internal.stripString
 import kotlin.jvm.JvmStatic
@@ -32,7 +31,17 @@ sealed interface OnionAddress: Parcelable {
     /**
      * Appends .onion to the given [value]
      * */
+    @Deprecated(
+        message = "Use hostname",
+        replaceWith = ReplaceWith("hostname"),
+        level = DeprecationLevel.WARNING
+    )
     val valueDotOnion: String
+
+    /**
+     * Appends .onion to the given [value]
+     * */
+    val hostname: String
 
     fun decode(): ByteArray
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3.kt
@@ -74,7 +74,14 @@ private value class RealOnionAddressV3(override val value: String): OnionAddress
         }
     }
 
+    @Deprecated(
+        "Use hostname",
+        replaceWith = ReplaceWith("hostname"),
+        level = DeprecationLevel.WARNING
+    )
     override val valueDotOnion: String get() = "$value.onion"
+
+    override val hostname: String get() = "$value.onion"
 
     override fun decode(): ByteArray {
         return value.uppercase().decodeBase32ToArray(Base32.Default)!!

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/internal/-StringExt.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/internal/-StringExt.kt
@@ -35,7 +35,7 @@ internal inline fun String.stripString(): String {
 
 @Suppress("nothing_to_inline")
 internal inline fun String.separateSchemeFromAddress(): Pair<Scheme?, String> {
-    val trimmed = this.trim()
+    val trimmed = trim()
     val scheme: Scheme? = Scheme.fromString(trimmed, trim = false)
     return Pair(
         scheme,
@@ -51,5 +51,8 @@ internal inline fun String.separateSchemeFromAddress(): Pair<Scheme?, String> {
 internal inline fun String.stripAddress(): String {
     return separateSchemeFromAddress()
         .second
-        .substringBefore('.')
+        .substringBefore('/')
+        .substringBefore(':')
+        .substringBefore(".onion")
+        .substringAfterLast('.')
 }

--- a/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3UnitTest.kt
+++ b/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3UnitTest.kt
@@ -61,4 +61,11 @@ class OnionAddressV3UnitTest {
         assertNotNull(actual)
     }
 
+    @Test
+    fun givenUrlString_whenSubdomainPresent_returnsNotNull() {
+        val url = "some.subdomain.$VALID_ONION_ADDRESS.onion"
+        val actual = OnionAddressV3.fromStringOrNull(url)
+        assertNotNull(actual)
+    }
+
 }

--- a/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/address/OnionUrlUnitTest.kt
+++ b/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/address/OnionUrlUnitTest.kt
@@ -28,7 +28,6 @@ class OnionUrlUnitTest {
         val expectedUrl = "$expectedScheme$expectedAddress.onion:$expectedPort$expectedPath"
 
         val onionUrl = OnionUrl.fromString(expectedUrl)
-        assertNotNull(onionUrl)
         assertEquals(expectedScheme, onionUrl.scheme)
         assertEquals(expectedAddress, onionUrl.address.value)
         assertEquals(expectedPath, onionUrl.path)
@@ -44,7 +43,6 @@ class OnionUrlUnitTest {
 
         val onionUrl = OnionUrl.fromString(expectedAddress)
 
-        assertNotNull(onionUrl)
         assertEquals(expectedUrl, onionUrl.toString())
     }
 
@@ -76,9 +74,9 @@ class OnionUrlUnitTest {
 
         val onionUrl = OnionUrl.fromString(expectedUrl)
 
-        assertNotNull(onionUrl)
         assertEquals(expectedPath, onionUrl.path)
         assertEquals(expectedPort, onionUrl.port?.value)
+        assertTrue(onionUrl.subdomain.isEmpty())
         assertEquals(expectedUrl, onionUrl.toString())
     }
 
@@ -90,9 +88,9 @@ class OnionUrlUnitTest {
 
         val onionUrl = OnionUrl.fromString(expectedUrl)
 
-        assertNotNull(onionUrl)
         assertEquals(expectedPath, onionUrl.path)
         assertNull(onionUrl.port)
+        assertTrue(onionUrl.subdomain.isEmpty())
         assertEquals(expectedUrl, onionUrl.toString())
     }
 
@@ -105,9 +103,9 @@ class OnionUrlUnitTest {
 
         val onionUrl = OnionUrl.fromString(expectedUrl)
 
-        assertNotNull(onionUrl)
         assertEquals(expectedPath, onionUrl.path)
         assertEquals(expectedPort, onionUrl.port?.value)
+        assertTrue(onionUrl.subdomain.isEmpty())
         assertEquals(expectedUrl, onionUrl.toString())
     }
 
@@ -119,9 +117,9 @@ class OnionUrlUnitTest {
 
         val onionUrl = OnionUrl.fromString(expectedUrl)
 
-        assertNotNull(onionUrl)
         assertEquals(expectedPath, onionUrl.path)
         assertNull(onionUrl.port)
+        assertTrue(onionUrl.subdomain.isEmpty())
         assertEquals(expectedUrl, onionUrl.toString())
     }
 
@@ -135,9 +133,28 @@ class OnionUrlUnitTest {
 
         val onionUrl = OnionUrl.fromString(url)
 
-        assertNotNull(onionUrl)
         assertEquals(expectedPath, onionUrl.path)
         assertEquals(expectedPort, onionUrl.port?.value)
+        assertTrue(onionUrl.subdomain.isEmpty())
         assertEquals(expectedUrl, onionUrl.toString())
+    }
+
+    @Test
+    fun givenUrlString_whenSubdomainPresent_returnsOnionUrl() {
+        val expectedAddress = OnionAddressV3UnitTest.VALID_ONION_ADDRESS
+        val expectedSubdomain = "sub.domain"
+        val url = "$expectedSubdomain.$expectedAddress.onion"
+
+        val onionUrl = OnionUrl.fromString(url)
+
+        assertEquals(expectedSubdomain, onionUrl.subdomain)
+        assertEquals(expectedAddress, onionUrl.address.value)
+        assertEquals("${Scheme.HTTP}$url", onionUrl.toString())
+    }
+
+    @Test
+    fun givenUrlString_whenJustOnionAddress_returnsOnionUrl() {
+        val onionUrl = OnionUrl.fromStringOrNull(OnionAddressV3UnitTest.VALID_ONION_ADDRESS)
+        assertNotNull(onionUrl)
     }
 }


### PR DESCRIPTION
Closes #229 

Also deprecates `OnionAddress.valueDotOnion` and replaces it with `OnionAddress.hostname`