### PR TITLE
Update terminology to use `canonical*` for wrapper class methods

### DIFF
--- a/library/kmp-tor-common/api/android/kmp-tor-common.api
+++ b/library/kmp-tor-common/api/android/kmp-tor-common.api
@@ -7,6 +7,7 @@ public final class io/matthewnelson/kmp/tor/common/BuildConfig {
 
 public abstract interface class io/matthewnelson/kmp/tor/common/address/OnionAddress : android/os/Parcelable {
 	public static final field Companion Lio/matthewnelson/kmp/tor/common/address/OnionAddress$Companion;
+	public abstract fun canonicalHostname ()Ljava/lang/String;
 	public abstract fun decode ()[B
 	public static fun fromString (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
 	public static fun fromStringOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
@@ -416,6 +417,7 @@ public final class io/matthewnelson/kmp/tor/common/server/Server {
 public abstract interface class io/matthewnelson/kmp/tor/common/server/Server$Fingerprint : android/os/Parcelable {
 	public static final field Companion Lio/matthewnelson/kmp/tor/common/server/Server$Fingerprint$Companion;
 	public static final field PREFIX C
+	public abstract fun canonicalName ()Ljava/lang/String;
 	public abstract fun decode ()[B
 	public static fun fromStringOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/server/Server$Fingerprint;
 	public static fun getREGEX ()Lkotlin/text/Regex;

--- a/library/kmp-tor-common/api/jvm/kmp-tor-common.api
+++ b/library/kmp-tor-common/api/jvm/kmp-tor-common.api
@@ -1,5 +1,6 @@
 public abstract interface class io/matthewnelson/kmp/tor/common/address/OnionAddress : io/matthewnelson/component/parcelize/Parcelable {
 	public static final field Companion Lio/matthewnelson/kmp/tor/common/address/OnionAddress$Companion;
+	public abstract fun canonicalHostname ()Ljava/lang/String;
 	public abstract fun decode ()[B
 	public static fun fromString (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
 	public static fun fromStringOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/address/OnionAddress;
@@ -293,6 +294,7 @@ public final class io/matthewnelson/kmp/tor/common/server/Server {
 public abstract interface class io/matthewnelson/kmp/tor/common/server/Server$Fingerprint : io/matthewnelson/component/parcelize/Parcelable {
 	public static final field Companion Lio/matthewnelson/kmp/tor/common/server/Server$Fingerprint$Companion;
 	public static final field PREFIX C
+	public abstract fun canonicalName ()Ljava/lang/String;
 	public abstract fun decode ()[B
 	public static fun fromStringOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/common/server/Server$Fingerprint;
 	public static fun getREGEX ()Lkotlin/text/Regex;

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddress.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddress.kt
@@ -28,13 +28,24 @@ import kotlin.jvm.JvmStatic
  * @see [OnionAddressV3]
  * */
 sealed interface OnionAddress: Parcelable {
+
     val value: String
+
+    @Deprecated(
+        message = "Replaced by canonicalHostname method",
+        replaceWith = ReplaceWith("canonicalHostname()"),
+        level = DeprecationLevel.WARNING,
+    )
+    val valueDotOnion: String
 
     /**
      * Appends .onion to the given [value]
      * */
-    val valueDotOnion: String
+    fun canonicalHostname(): String
 
+    /**
+     * Returns the raw bytes for the given [value]
+     * */
     fun decode(): ByteArray
 
     companion object {

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3.kt
@@ -90,13 +90,16 @@ private value class RealOnionAddressV3(override val value: String): OnionAddress
         }
     }
 
+    @Deprecated(
+        message = "Replaced by canonicalHostname method",
+        replaceWith = ReplaceWith("canonicalHostname()"),
+        level = DeprecationLevel.WARNING
+    )
     override val valueDotOnion: String get() = "$value.onion"
 
-    override fun decode(): ByteArray {
-        return value.uppercase().decodeBase32ToArray(Base32.Default)!!
-    }
+    override fun canonicalHostname(): String = "$value.onion"
 
-    override fun toString(): String {
-        return "OnionAddressV3(value=$value)"
-    }
+    override fun decode(): ByteArray = value.uppercase().decodeBase32ToArray(Base32.Default)!!
+
+    override fun toString(): String = "OnionAddressV3(value=$value)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3PrivateKey_ED25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3PrivateKey_ED25519.kt
@@ -81,13 +81,9 @@ private value class RealOnionAddressV3PrivateKey_ED25519(
         }
     }
 
-    override fun decode(): ByteArray {
-        return value.decodeBase64ToArray()!!
-    }
+    override fun decode(): ByteArray = value.decodeBase64ToArray()!!
 
     override val keyType: OnionAddress.PrivateKey.Type get() = OnionAddress.PrivateKey.Type.ED25519_V3
 
-    override fun toString(): String {
-        return "OnionAddressV3PrivateKey_ED25519(value=$REDACTED)"
-    }
+    override fun toString(): String = "OnionAddressV3PrivateKey_ED25519(value=$REDACTED)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionUrl.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionUrl.kt
@@ -73,7 +73,7 @@ data class OnionUrl(
     override fun toString(): String {
         return StringBuilder().let { sb ->
             sb.append(scheme)
-            sb.append(address.valueDotOnion)
+            sb.append(address.canonicalHostname())
             if (port != null) {
                 sb.append(':').append(port.value)
             }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/Port.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/Port.kt
@@ -58,13 +58,12 @@ sealed interface Port: Parcelable {
 @JvmInline
 @Parcelize
 private value class RealPort(override val value: Int): Port {
+
     init {
         require(value in Port.MIN..Port.MAX) {
             "Invalid port range. Must be between ${Port.MIN} and ${Port.MAX}"
         }
     }
 
-    override fun toString(): String {
-        return "Port(value=$value)"
-    }
+    override fun toString(): String = "Port(value=$value)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/PortProxy.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/PortProxy.kt
@@ -55,13 +55,12 @@ sealed interface PortProxy: Port {
 @JvmInline
 @Parcelize
 private value class RealPortProxy(override val value: Int): PortProxy {
+
     init {
         require(value in PortProxy.MIN..PortProxy.MAX) {
             "Invalid port range. Must be between ${PortProxy.MIN} and ${PortProxy.MAX}"
         }
     }
 
-    override fun toString(): String {
-        return "PortProxy(value=$value)"
-    }
+    override fun toString(): String = "PortProxy(value=$value)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/ClientName.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/ClientName.kt
@@ -80,7 +80,5 @@ private value class RealClientName(override val value: String): ClientName {
         }
     }
 
-    override fun toString(): String {
-        return "ClientName(value=$value)"
-    }
+    override fun toString(): String = "ClientName(value=$value)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuth.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuth.kt
@@ -186,9 +186,7 @@ class OnionClientAuth private constructor() {
             return result
         }
 
-        override fun toString(): String {
-            return "KeyPair(publicKey=$publicKey, privateKey=$privateKey)"
-        }
+        override fun toString(): String = "KeyPair(publicKey=$publicKey, privateKey=$privateKey)"
     }
 
 //    sealed interface KeyFactory: OnionClientAuth {

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B32_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B32_X25519.kt
@@ -85,17 +85,11 @@ private value class RealOnionClientAuthPrivateKey_B32_X25519(
         }
     }
 
-    override fun decode(): ByteArray {
-        return value.decodeBase32ToArray(Base32.Default)!!
-    }
+    override fun decode(): ByteArray = value.decodeBase32ToArray(Base32.Default)!!
 
-    override fun descriptor(address: OnionAddressV3): String {
-        return descriptorString(address)
-    }
+    override fun descriptor(address: OnionAddressV3): String = descriptorString(address)
 
     override val keyType: OnionClientAuth.Key.Type get() = OnionClientAuth.Key.Type.x25519
 
-    override fun toString(): String {
-        return "OnionClientAuthPrivateKey_B32_X25519(value=$REDACTED)"
-    }
+    override fun toString(): String = "OnionClientAuthPrivateKey_B32_X25519(value=$REDACTED)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B64_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B64_X25519.kt
@@ -84,17 +84,11 @@ private value class RealOnionClientAuthPrivateKey_B64_X25519(
         }
     }
 
-    override fun decode(): ByteArray {
-        return value.decodeBase64ToArray()!!
-    }
+    override fun decode(): ByteArray = value.decodeBase64ToArray()!!
 
-    override fun descriptor(address: OnionAddressV3): String {
-        return descriptorString(address)
-    }
+    override fun descriptor(address: OnionAddressV3): String = descriptorString(address)
 
     override val keyType: OnionClientAuth.Key.Type get() = OnionClientAuth.Key.Type.x25519
 
-    override fun toString(): String {
-        return "OnionClientAuthPrivateKey_B64_X25519(value=$REDACTED)"
-    }
+    override fun toString(): String = "OnionClientAuthPrivateKey_B64_X25519(value=$REDACTED)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B32_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B32_X25519.kt
@@ -78,17 +78,11 @@ private value class RealOnionClientAuthPublicKey_B32_X25519(
         }
     }
 
-    override fun decode(): ByteArray {
-        return value.decodeBase32ToArray(Base32.Default)!!
-    }
+    override fun decode(): ByteArray = value.decodeBase32ToArray(Base32.Default)!!
 
-    override fun descriptor(): String {
-        return descriptorString()
-    }
+    override fun descriptor(): String = descriptorString()
 
     override val keyType: OnionClientAuth.Key.Type get() = OnionClientAuth.Key.Type.x25519
 
-    override fun toString(): String {
-        return "OnionClientAuthPublicKey_B32_X25519(value=$value)"
-    }
+    override fun toString(): String = "OnionClientAuthPublicKey_B32_X25519(value=$value)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B64_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B64_X25519.kt
@@ -77,17 +77,11 @@ private value class RealOnionClientAuthPublicKey_B64_X25519(
         }
     }
 
-    override fun decode(): ByteArray {
-        return value.decodeBase64ToArray()!!
-    }
+    override fun decode(): ByteArray = value.decodeBase64ToArray()!!
 
-    override fun descriptor(): String {
-        return descriptorString()
-    }
+    override fun descriptor(): String = descriptorString()
 
     override val keyType: OnionClientAuth.Key.Type get() = OnionClientAuth.Key.Type.x25519
 
-    override fun toString(): String {
-        return "OnionClientAuthPublicKey_B64_X25519(value=$value)"
-    }
+    override fun toString(): String = "OnionClientAuthPublicKey_B64_X25519(value=$value)"
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/server/Server.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/server/Server.kt
@@ -38,9 +38,24 @@ class Server private constructor() {
     @SealedValueClass
     @OptIn(ExperimentalTorApi::class)
     sealed interface Fingerprint: Parcelable {
+
         val value: String
+
+        @Deprecated(
+            message = "Use canonicalName",
+            replaceWith = ReplaceWith("canonicalName()"),
+            level = DeprecationLevel.WARNING,
+        )
         val valueWithPrefix: String
 
+        /**
+         * Prepends [value] with the [PREFIX] expected by Tor.
+         * */
+        fun canonicalName(): String
+
+        /**
+         * Returns the raw bytes for the given [value]
+         * */
         fun decode(): ByteArray
 
         companion object {
@@ -80,15 +95,18 @@ class Server private constructor() {
             }
         }
 
+        @Deprecated(
+            message = "Use canonicalName",
+            replaceWith = ReplaceWith("canonicalName()"),
+            level = DeprecationLevel.WARNING
+        )
         override val valueWithPrefix: String get() = "${Fingerprint.PREFIX}$value"
 
-        override fun decode(): ByteArray {
-            return value.decodeBase16ToArray()!!
-        }
+        override fun canonicalName(): String = "${Fingerprint.PREFIX}$value"
 
-        override fun toString(): String {
-            return "Fingerprint(value=$value)"
-        }
+        override fun decode(): ByteArray = value.decodeBase16ToArray()!!
+
+        override fun toString(): String = "Fingerprint(value=$value)"
     }
 
     /**
@@ -100,6 +118,7 @@ class Server private constructor() {
     @SealedValueClass
     @OptIn(ExperimentalTorApi::class)
     sealed interface Nickname: Parcelable {
+
         val value: String
 
         companion object {
@@ -133,9 +152,7 @@ class Server private constructor() {
             }
         }
 
-        override fun toString(): String {
-            return "Nickname(value=$value)"
-        }
+        override fun toString(): String = "Nickname(value=$value)"
     }
 
     @Parcelize
@@ -148,9 +165,9 @@ class Server private constructor() {
 
         override fun toString(): String {
             return if (nickname != null) {
-                "${fingerprint.valueWithPrefix}$DELIMITER${nickname.value}"
+                "${fingerprint.canonicalName()}$DELIMITER${nickname.value}"
             } else {
-                fingerprint.valueWithPrefix
+                fingerprint.canonicalName()
             }
         }
 

--- a/samples/kotlin/android/src/main/java/io/matthewnelson/kmp/tor/sample/kotlin/android/SampleApp.kt
+++ b/samples/kotlin/android/src/main/java/io/matthewnelson/kmp/tor/sample/kotlin/android/SampleApp.kt
@@ -273,7 +273,7 @@ class SampleApp: Application() {
                 ).onSuccess { hsEntry ->
                     addLine(
                         "New HiddenService: " +
-                        "\n - Address: ${OnionUrl(hsEntry.address, scheme = Scheme.HTTPS)}" +
+                        "\n - Address: https://${hsEntry.address}" +
                         "\n - PrivateKey: ${hsEntry.privateKey}"
                     )
 


### PR DESCRIPTION
Closes #236 

Deprecates:
 - `OnionAddress.valueDotOnion` in favor of `OnionAddress.canonicalHostname()`
 - `Server.Fingerprint.valueWithPrefix` in favor of `Server.Fingerprint.canonicalName()`