### PR TITLE
Ensure `Destroyable.destroy` `onCompletion` lambda is always invoked

### DIFF
--- a/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/-RealTorManagerAndroid.kt
+++ b/library/manager/kmp-tor-manager/src/androidMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/-RealTorManagerAndroid.kt
@@ -92,7 +92,10 @@ internal class RealTorManagerAndroid(
 
     override fun destroy(stopCleanly: Boolean, onCompletion: (() -> Unit)?) {
         synchronized(this) {
-            if (isDestroyed) return@synchronized
+            if (isDestroyed) {
+                onCompletion?.invoke()
+                return@synchronized
+            }
             _isDestroyed = true
 
             val lce = TorManagerEvent.Lifecycle(this, TorManagerEvent.Lifecycle.ON_DESTROY)

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/Destroyable.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/Destroyable.kt
@@ -27,12 +27,15 @@ interface Destroyable {
      * threads, etc.
      *
      * Tf [stopCleanly] is true, [RealTorManager.destroy] launches a coroutine
-     * in order to stop Tor via it's control port so it can clean up properly.
+     * in order to stop Tor via it's control port, so it can clean up properly.
      * This takes approximately 500ms (if Tor is running).
      *
      * By passing a lambda via [onCompletion] you can perform other necessary
      * post destruction tasks and cleanup after Tor has been shutdown (or killed
      * if [stopCleanly] is set to false).
+     *
+     * [onCompletion] is **always** invoked, whether [TorManager] was already
+     * destroyed or not.
      * */
     fun destroy(stopCleanly: Boolean = true, onCompletion: (() -> Unit)? = null)
 }

--- a/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/-RealTorManager.kt
+++ b/library/manager/kmp-tor-manager/src/commonMain/kotlin/io/matthewnelson/kmp/tor/manager/internal/-RealTorManager.kt
@@ -171,7 +171,10 @@ internal class RealTorManager(
 
     override fun destroy(stopCleanly: Boolean, onCompletion: (() -> Unit)?) {
         kotlinx.atomicfu.locks.synchronized(this) {
-            if (isDestroyed) return@synchronized
+            if (isDestroyed) {
+                onCompletion?.invoke()
+                return@synchronized
+            }
             _isDestroyed.value = true
             networkObserver?.detach(instanceId)
 

--- a/samples/java/javafx/src/main/java/io/matthewnelson/kmp/tor/sample/java/javafx/App.java
+++ b/samples/java/javafx/src/main/java/io/matthewnelson/kmp/tor/sample/java/javafx/App.java
@@ -80,12 +80,7 @@ public class App extends Application {
 
     @Override
     public void stop() throws Exception {
-
-        // just in case setupOnCloseIntercept fails.
-        torManager.destroy(/* stopCleanly = */ false, whenComplete -> {
-            // will not be invoked if TorManager has already been destroyed
-            Log.d("App", "onCloseRequest intercept failed. Tor did not stop cleanly.");
-        });
+        torManager.destroy(/* stopCleanly = */ false, null);
         super.stop();
     }
 

--- a/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/kotlin/javafx/SampleApp.kt
+++ b/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/kotlin/javafx/SampleApp.kt
@@ -290,12 +290,7 @@ class SampleApp: App(SampleView::class) {
     override fun stop() {
         super.stop()
         Log.d(this.javaClass.simpleName, "stop")
-
-        // just in case setupOnCloseIntercept fails.
-        managerInstance1.destroy(stopCleanly = false) {
-            // will not be invoked if TorManager has already been destroyed
-            Log.w(this.javaClass.simpleName, "onCloseRequest intercept failed. Tor did not stop cleanly.")
-        }
+        managerInstance1.destroy(stopCleanly = false)
     }
 
     private val appScope by lazy {


### PR DESCRIPTION
Closes #268 

This PR ensures that any lambda passed to `Destroyealbe.destroy` for invocation after `TorManager` is shutdown **always** gets invoked, even if the instance is already destroyed.