### PR TITLE
Remove dependency on `kmp-tor-internal` module

### DIFF
--- a/library/kmp-tor-internal/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessId.kt
+++ b/library/kmp-tor-internal/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/internal/ProcessId.kt
@@ -15,6 +15,14 @@
  **/
 package io.matthewnelson.kmp.tor.internal
 
+@Deprecated(
+    message = """
+        Functionality was moved to TorConfigProviderJvm.
+        This dependency will cease to be published in the
+        next major version release (2.0.0) and should be
+        removed.
+        """,
+)
 class ProcessId private constructor() {
     companion object {
         @JvmStatic

--- a/library/kmp-tor/build.gradle.kts
+++ b/library/kmp-tor/build.gradle.kts
@@ -44,15 +44,6 @@ kmpConfiguration {
         }
 
         jvm {
-            sourceSetMain {
-                dependencies {
-                    if (env.kmpTorAll.isBinaryRelease) {
-                        implementation("$group:kmp-tor-internal:${env.kmpTor.version.name}")
-                    } else {
-                        implementation(project(":library:kmp-tor-internal"))
-                    }
-                }
-            }
             sourceSetTest {
                 dependencies {
                     if (System.getProperty("java.version").substringBefore('.').toInt() < 16) {
@@ -72,7 +63,8 @@ kmpConfiguration {
                 }
             }
 
-            // Requires Java 11+ b/c of kmp-tor-internal module
+            // Requires Java 11+ b/c of java.lang.management.ManagementFactory
+            // to retrieve process id.
             kotlinJvmTarget = JavaVersion.VERSION_11
             compileSourceCompatibility = JavaVersion.VERSION_11
             compileTargetCompatibility = JavaVersion.VERSION_11

--- a/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/TorConfigProviderJvm.kt
+++ b/library/kmp-tor/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/TorConfigProviderJvm.kt
@@ -18,7 +18,6 @@ package io.matthewnelson.kmp.tor
 import io.matthewnelson.kmp.tor.binary.extract.*
 import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
 import io.matthewnelson.kmp.tor.controller.common.file.Path
-import io.matthewnelson.kmp.tor.internal.ProcessId
 import io.matthewnelson.kmp.tor.manager.TorConfigProvider
 import io.matthewnelson.kmp.tor.manager.common.exceptions.TorManagerException
 
@@ -46,7 +45,11 @@ abstract class TorConfigProviderJvm: TorConfigProvider() {
     override val geoIpV6File: Path? by lazy {
         workDir.builder { addSegment("geoip6") }
     }
-    override val processId: Int get() = ProcessId.get()
+    override val processId: Int get() = java.lang.management.ManagementFactory
+        .getRuntimeMXBean()
+        .name
+        .split('@')[0]
+        .toInt()
 
     @Throws(TorManagerException::class)
     override fun extractGeoIpV4File(toLocation: Path) {

--- a/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/TorConfigProviderJvmUnitTest.kt
+++ b/library/kmp-tor/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/TorConfigProviderJvmUnitTest.kt
@@ -1,0 +1,22 @@
+package io.matthewnelson.kmp.tor
+
+import io.matthewnelson.kmp.tor.controller.common.config.TorConfig
+import io.matthewnelson.kmp.tor.controller.common.file.Path
+import kotlin.test.Test
+
+class TorConfigProviderJvmUnitTest {
+
+    @Test
+    fun givenTorConfigProvider_whenGetProcessId_thenReturnsExpected() {
+        val config = object : TorConfigProviderJvm() {
+            override val workDir: Path get() = TODO("Not yet implemented")
+            override val cacheDir: Path get() = TODO("Not yet implemented")
+            override fun provide(): TorConfig { TODO("Not yet implemented") }
+
+        }
+
+        config.processId
+
+        // pass, does not throw.
+    }
+}


### PR DESCRIPTION
Closes #269 
Closes #287 

Moves functionality of `kmp-tor-internal` to call-site. This was possible w/o needing to use reflection b/c in `1.4.0` release fixed a lot of build issues switching to `gradle-kmp-configuration-plugin` usage instead of `kotlin-components`. :partying_face: 