### PR TITLE
Sets all `Thread`s utilized to run as daemons

### DIFF
--- a/build-environment/src/main/kotlin/kmp/tor/env.kt
+++ b/build-environment/src/main/kotlin/kmp/tor/env.kt
@@ -31,11 +31,11 @@ object env {
     //                       1.15.1        ==     01_15_01_99
     private const val MANAGER_VERSION_CODE  = /*0*/1_04_02_99
 
-    private const val BINARY_VERSION_NAME   = "4.7.13-3"
+    private const val BINARY_VERSION_NAME   = "4.7.13-4"
     //                       4.6.9-0       ==     00_04_06_09_00
     //                       4.6.9-1       ==     00_04_06_09_01
     //                       4.6.9-2       ==     00_04_06_09_02
-    private const val BINARY_VERSION_CODE   = /*00_0*/4_07_13_03
+    private const val BINARY_VERSION_CODE   = /*00_0*/4_07_13_04
 
     /**
      * Binaries exist in a different repo. Building against the staged

--- a/library/controller/kmp-tor-controller-common/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
+++ b/library/controller/kmp-tor-controller-common/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/common/internal/PlatformUtil.kt
@@ -67,7 +67,7 @@ actual object PlatformUtil {
         Thread {
             @OptIn(InternalTorApi::class)
             localhostAddress()
-        }.start()
+        }.apply { isDaemon = true }.start()
     }
 
     @JvmStatic

--- a/library/controller/kmp-tor-controller/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/-JvmAndroidPlatform.kt
+++ b/library/controller/kmp-tor-controller/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/-JvmAndroidPlatform.kt
@@ -18,8 +18,11 @@ package io.matthewnelson.kmp.tor.controller.internal
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 
 @Suppress("nothing_to_inline")
 internal actual inline fun getTorControllerDispatcher(): ExecutorCoroutineDispatcher {
-    return Executors.newFixedThreadPool(2).asCoroutineDispatcher()
+    return Executors.newFixedThreadPool(2) { runnable ->
+        Thread(runnable).apply { isDaemon = true }
+    }.asCoroutineDispatcher()
 }

--- a/library/kmp-tor/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/internal/-ProcessStreamEater.kt
+++ b/library/kmp-tor/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/internal/-ProcessStreamEater.kt
@@ -31,7 +31,9 @@ internal class ProcessStreamEater(
 ) {
 
     private val supervisor = SupervisorJob(parentJob)
-    private val dispatcher = Executors.newFixedThreadPool(2).asCoroutineDispatcher()
+    private val dispatcher = Executors.newFixedThreadPool(2) { runnable ->
+        Thread(runnable).apply { isDaemon = true }
+    }.asCoroutineDispatcher()
     private val scope = CoroutineScope(supervisor + dispatcher)
 
     init {

--- a/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
+++ b/library/manager/kmp-tor-manager/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/manager/KmpTorLoader.kt
@@ -72,8 +72,9 @@ actual abstract class KmpTorLoader(protected val provider: TorConfigProvider) {
 
         fun getOrCreate(): ExecutorCoroutineDispatcher =
             synchronized(this) {
-                dispatcher ?: Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-                    .also { dispatcher = it }
+                dispatcher ?: Executors.newSingleThreadExecutor { runnable ->
+                    Thread(runnable).apply { isDaemon = true }
+                }.asCoroutineDispatcher().also { dispatcher = it }
             }
 
         fun close() {


### PR DESCRIPTION
Closes #293 

Also updated `kmp-tor-binary` to `4.7.13-4` with fixes for resource extraction in projects that utilize Java9 modules.