### PR TITLE
Update dependencies

### DIFF
--- a/.kotlin-js-store/yarn.lock
+++ b/.kotlin-js-store/yarn.lock
@@ -2,10 +2,150 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.10.4":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
+  integrity sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==
+  dependencies:
+    "@babel/highlight" "^7.22.5"
+
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
+
+"@babel/highlight@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
+  integrity sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.5"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@jridgewell/gen-mapping@^0.3.0":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
+  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/resolve-uri@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.3.tgz#8108265659d4c33e72ffe14e33d6cc5eb59f2fda"
+  integrity sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/sourcemap-codec@1.4.14":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@rollup/plugin-commonjs@^21.0.1":
+  version "21.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.1.0.tgz#45576d7b47609af2db87f55a6d4b46e44fc3a553"
+  integrity sha512-6ZtHx3VHIp2ReNNDxHjuUml6ur+WcQ28N1yHgCQwsbNkQg2suhxGMDQGJOn/KuDxKtd1xuZP5xSTwBA4GQ8hbA==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-node-resolve@^13.1.3":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz#da1c5c5ce8316cef96a2f823d111c1e4e498801c"
+  integrity sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    deepmerge "^4.2.2"
+    is-builtin-module "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/plugin-typescript@^8.3.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz#7ea11599a15b0a30fa7ea69ce3b791d41b862515"
+  integrity sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    resolve "^1.17.0"
+
+"@rollup/pluginutils@^3.0.9", "@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
+"@types/estree@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/node@*":
+  version "20.3.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.1.tgz#e8a83f1aa8b649377bb1fb5d7bac5cb90e784dfe"
+  integrity sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==
+
+"@types/node@^12.12.14":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
+
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
+acorn@^8.8.2:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
+  integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
 
 ansi-colors@4.1.1:
   version "4.1.1"
@@ -16,6 +156,13 @@ ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
@@ -36,6 +183,11 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+atob@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -79,10 +231,24 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
 camelcase@^6.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
+chalk@^2.0.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chalk@^4.1.0:
   version "4.1.2"
@@ -116,6 +282,13 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -123,10 +296,25 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -144,6 +332,16 @@ decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+decode-uri-component@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 diff@5.0.0:
   version "5.0.0"
@@ -165,6 +363,21 @@ escape-string-regexp@4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -185,7 +398,7 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-format-util@1.0.5:
+format-util@1.0.5, format-util@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
   integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
@@ -199,6 +412,11 @@ fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -224,10 +442,34 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3, glob@^7.1.6:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 he@1.2.0:
   version "1.2.0"
@@ -254,6 +496,25 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-builtin-module@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
+  dependencies:
+    builtin-modules "^3.3.0"
+
+is-core-module@^2.11.0:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.1.tgz#0c0b6885b6f80011c71541ce15c8d66cf5a4f9fd"
+  integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
+  dependencies:
+    has "^1.0.3"
+
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -271,6 +532,11 @@ is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -281,10 +547,38 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
+
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
+
+jest-worker@^26.2.1:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
+  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@4.1.0:
   version "4.1.0"
@@ -308,6 +602,18 @@ log-symbols@4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
+magic-string@^0.25.7:
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
+  dependencies:
+    sourcemap-codec "^1.4.8"
+
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 minimatch@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
@@ -315,7 +621,7 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -401,7 +707,12 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -425,6 +736,47 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+resolve@^1.17.0, resolve@^1.19.0:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
+rollup-plugin-sourcemaps@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz#bf93913ffe056e414419607f1d02780d7ece84ed"
+  integrity sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.9"
+    source-map-resolve "^0.6.0"
+
+rollup-plugin-terser@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
+  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
+    serialize-javascript "^4.0.0"
+    terser "^5.0.0"
+
+rollup@^2.68.0:
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -437,7 +789,22 @@ serialize-javascript@6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-source-map-support@0.5.21:
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+
+source-map-support@0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -449,6 +816,11 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
@@ -478,12 +850,34 @@ supports-color@8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^7.1.0:
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+terser@^5.0.0:
+  version "5.18.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.18.1.tgz#6d8642508ae9fb7b48768e48f16d675c89a78460"
+  integrity sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -491,6 +885,21 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+tslib@^2.3.1:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
+
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^3.7.2:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 workerpool@6.2.1:
   version "6.2.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,13 @@ allprojects {
         mavenCentral()
         google()
         gradlePluginPortal()
+
+        if (version.toString().endsWith("-SNAPSHOT")) {
+            // Only allow snapshot dependencies for non-release versions.
+            // This would cause a build failure if attempting to make a release
+            // while depending on a -SNAPSHOT version (such as core).
+            maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
 }
@@ -109,11 +116,11 @@ tasks.withType<DependencyUpdatesTask> {
     // Example 3: using the full syntax
     resolutionStrategy {
         componentSelection {
-            all {
+            all(Action {
                 if (isNonStable(candidate.version) && !isNonStable(currentVersion)) {
                     reject("Release candidate")
                 }
-            }
+            })
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 atomicfu = "0.20.2"
 coroutines = "1.7.1"
-encoding = "1.2.3-SNAPSHOT"
+encoding = "2.0.0-SNAPSHOT"
 kmpParcelize = "0.1.2"
 jnrUnixSocket = "0.38.20"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-atomicfu = "0.20.0"
-coroutines = "1.6.4"
-encoding = "1.2.1"
+atomicfu = "0.20.2"
+coroutines = "1.7.1"
+encoding = "1.2.3-SNAPSHOT"
 kmpParcelize = "0.1.2"
-jnrUnixSocket = "0.38.19"
+jnrUnixSocket = "0.38.20"
 
 # Gradle Plugins
-android = "7.3.1"
-binaryCompat = "0.13.0"
-configuration = "0.1.0-beta02"
+android = "7.4.2"
+binaryCompat = "0.13.2"
+configuration = "0.1.0"
 gradleVersions = "0.46.0"
-kotlin = "1.8.10"
-publish = "0.24.0"
+kotlin = "1.8.21"
+publish = "0.25.2"
 
 # Samples
 androidx-appCompat = "1.5.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 atomicfu = "0.20.2"
 coroutines = "1.7.1"
-encoding = "2.0.0-SNAPSHOT"
+encoding = "2.0.0"
 kmpParcelize = "0.1.2"
 jnrUnixSocket = "0.38.20"
 
 # Gradle Plugins
 android = "7.4.2"
 binaryCompat = "0.13.2"
-configuration = "0.1.0"
+configuration = "0.1.1"
 gradleVersions = "0.46.0"
 kotlin = "1.8.21"
 publish = "0.25.2"
@@ -29,9 +29,9 @@ atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu"
 
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 
-encoding-base16 = { module = "io.matthewnelson.kotlin-components:encoding-base16", version.ref = "encoding" }
-encoding-base32 = { module = "io.matthewnelson.kotlin-components:encoding-base32", version.ref = "encoding" }
-encoding-base64 = { module = "io.matthewnelson.kotlin-components:encoding-base64", version.ref = "encoding" }
+encoding-base16 = { module = "io.matthewnelson.encoding:base16", version.ref = "encoding" }
+encoding-base32 = { module = "io.matthewnelson.encoding:base32", version.ref = "encoding" }
+encoding-base64 = { module = "io.matthewnelson.encoding:base64", version.ref = "encoding" }
 
 jnrUnixSocket = { module = "com.github.jnr:jnr-unixsocket", version.ref = "jnrUnixSocket" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,5 +5,5 @@ zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 
 # https://gradle.org/release-checksums/
-distributionSha256Sum=948d1e4ccc2f6ae36cbfa087d827aaca51403acae5411e664a6000bb47946f22
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionSha256Sum=5625a0ae20fe000d9225d000b36909c7a0e0e8dda61c19b12da769add847c975
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip

--- a/library/controller/kmp-tor-controller/src/androidMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
+++ b/library/controller/kmp-tor-controller/src/androidMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 @file:JvmName("androidTorController")
+@file:Suppress("UnnecessaryOptInAnnotation")
 
 package io.matthewnelson.kmp.tor.controller
 
@@ -35,6 +36,7 @@ import io.matthewnelson.kmp.tor.controller.internal.io.ReaderWrapper
 import io.matthewnelson.kmp.tor.controller.internal.io.SocketWrapper
 import io.matthewnelson.kmp.tor.controller.internal.io.WriterWrapper
 import io.matthewnelson.kmp.tor.controller.internal.ext.toTorController
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
 import java.io.*
 import java.net.Socket
@@ -115,6 +117,7 @@ actual interface TorController: TorControlProcessor, TorEventProcessor<TorEvent.
                     Closeable { socket.close() }
                 }
 
+                @OptIn(ExperimentalCoroutinesApi::class)
                 return RealTorController(
                     reader = ReaderWrapper.wrap(reader),
                     writer = WriterWrapper.wrap(writer),

--- a/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/controller/-RealTorControlProcessor.kt
+++ b/library/controller/kmp-tor-controller/src/commonMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/controller/-RealTorControlProcessor.kt
@@ -15,7 +15,7 @@
  **/
 package io.matthewnelson.kmp.tor.controller.internal.controller
 
-import io.matthewnelson.encoding.builders.Base16
+import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.kmp.tor.common.address.*
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
@@ -50,6 +50,8 @@ internal class RealTorControlProcessor(
         return processorLock.withContextAndLock {
             val command = StringBuilder("AUTHENTICATE").apply {
                 append(SP)
+                // Cannot use static instance of Base16 as it has a
+                // default lineBreakInterval of 64
                 append(bytes.encodeToString(Base16()))
                 append(CLRF)
             }.toString()

--- a/library/controller/kmp-tor-controller/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/ext/-SocketExt.kt
+++ b/library/controller/kmp-tor-controller/src/jvmAndroidMain/kotlin/io/matthewnelson/kmp/tor/controller/internal/ext/-SocketExt.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("UnnecessaryOptInAnnotation")
+
 package io.matthewnelson.kmp.tor.controller.internal.ext
 
 import io.matthewnelson.kmp.tor.controller.TorController
@@ -22,6 +24,7 @@ import io.matthewnelson.kmp.tor.controller.internal.io.ReaderWrapper
 import io.matthewnelson.kmp.tor.controller.internal.io.SocketWrapper
 import io.matthewnelson.kmp.tor.controller.internal.io.WriterWrapper
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import java.io.IOException
 import java.net.Socket
 import java.net.SocketException
@@ -40,6 +43,7 @@ internal inline fun Socket.toTorController(
         val writerWrapper = WriterWrapper.wrap(getOutputStream().writer())
         val socketWrapper = SocketWrapper.wrap(this)
 
+        @OptIn(ExperimentalCoroutinesApi::class)
         return RealTorController(
             reader = readerWrapper,
             writer = writerWrapper,

--- a/library/controller/kmp-tor-controller/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
+++ b/library/controller/kmp-tor-controller/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/controller/TorController.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 @file:JvmName("jvmTorController")
+@file:Suppress("UnnecessaryOptInAnnotation")
 
 package io.matthewnelson.kmp.tor.controller
 
@@ -34,6 +35,7 @@ import io.matthewnelson.kmp.tor.controller.internal.io.ReaderWrapper
 import io.matthewnelson.kmp.tor.controller.internal.io.SocketWrapper
 import io.matthewnelson.kmp.tor.controller.internal.io.UnselectableByteChannel
 import io.matthewnelson.kmp.tor.controller.internal.io.WriterWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
 import java.io.*
 import java.net.Socket
@@ -139,6 +141,7 @@ actual interface TorController: TorControlProcessor, TorEventProcessor<TorEvent.
                     val writerWrapper = WriterWrapper.wrap(Channels.newOutputStream(channel).writer())
                     val socketWrapper = SocketWrapper.wrap(channel)
 
+                    @OptIn(ExperimentalCoroutinesApi::class)
                     RealTorController(
                         reader = readerWrapper,
                         writer = writerWrapper,

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3.kt
@@ -21,7 +21,6 @@ import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.kmp.tor.common.annotation.ExperimentalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.SealedValueClass
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import io.matthewnelson.kmp.tor.common.internal.findOnionAddressFromUrl
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmStatic
@@ -99,7 +98,7 @@ private value class RealOnionAddressV3(override val value: String): OnionAddress
 
     override fun canonicalHostname(): String = "$value.onion"
 
-    override fun decode(): ByteArray = value.decodeToByteArray(TorStrings.base32)
+    override fun decode(): ByteArray = value.decodeToByteArray(Base32.Default)
 
     override fun toString(): String = "OnionAddressV3(value=$value)"
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3PrivateKey_ED25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/address/OnionAddressV3PrivateKey_ED25519.kt
@@ -21,9 +21,7 @@ import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.kmp.tor.common.annotation.ExperimentalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.SealedValueClass
-import io.matthewnelson.kmp.tor.common.clientauth.OnionClientAuth
 import io.matthewnelson.kmp.tor.common.clientauth.OnionClientAuthPrivateKey_B64_X25519.Companion.REGEX
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import io.matthewnelson.kmp.tor.common.internal.TorStrings.REDACTED
 import io.matthewnelson.kmp.tor.common.internal.stripBaseEncoding
 import kotlin.jvm.JvmInline
@@ -83,7 +81,7 @@ private value class RealOnionAddressV3PrivateKey_ED25519(
         }
     }
 
-    override fun decode(): ByteArray = value.decodeToByteArray(TorStrings.base64)
+    override fun decode(): ByteArray = value.decodeToByteArray(Base64.Default)
 
     override val keyType: OnionAddress.PrivateKey.Type get() = OnionAddress.PrivateKey.Type.ED25519_V3
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B32_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B32_X25519.kt
@@ -17,13 +17,13 @@ package io.matthewnelson.kmp.tor.common.clientauth
 
 import io.matthewnelson.component.parcelize.Parcelize
 import io.matthewnelson.encoding.base32.Base32
+import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.kmp.tor.common.address.OnionAddressV3
 import io.matthewnelson.kmp.tor.common.annotation.ExperimentalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.SealedValueClass
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import io.matthewnelson.kmp.tor.common.internal.TorStrings.REDACTED
 import io.matthewnelson.kmp.tor.common.internal.descriptorString
 import kotlin.jvm.JvmInline
@@ -69,7 +69,7 @@ private value class RealOnionClientAuthPrivateKey_B32_X25519(
     }
 
     override fun base64(padded: Boolean): String {
-        val b64 = decode().encodeToString(TorStrings.base64)
+        val b64 = decode().encodeToString(Base64.Default)
         return if (padded) {
             b64
         } else {
@@ -85,7 +85,7 @@ private value class RealOnionClientAuthPrivateKey_B32_X25519(
         }
     }
 
-    override fun decode(): ByteArray = value.decodeToByteArray(TorStrings.base32)
+    override fun decode(): ByteArray = value.decodeToByteArray(Base32.Default)
 
     override fun descriptor(address: OnionAddressV3): String = descriptorString(address)
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B64_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPrivateKey_B64_X25519.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.kmp.tor.common.clientauth
 
 import io.matthewnelson.component.parcelize.Parcelize
+import io.matthewnelson.encoding.base32.Base32
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -23,7 +24,6 @@ import io.matthewnelson.kmp.tor.common.address.OnionAddressV3
 import io.matthewnelson.kmp.tor.common.annotation.ExperimentalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.SealedValueClass
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import io.matthewnelson.kmp.tor.common.internal.TorStrings.REDACTED
 import io.matthewnelson.kmp.tor.common.internal.descriptorString
 import kotlin.jvm.JvmInline
@@ -76,7 +76,7 @@ private value class RealOnionClientAuthPrivateKey_B64_X25519(
     }
 
     override fun base32(padded: Boolean): String {
-        val b32 = decode().encodeToString(TorStrings.base32)
+        val b32 = decode().encodeToString(Base32.Default)
         return if (padded) {
             b32
         } else {
@@ -84,7 +84,7 @@ private value class RealOnionClientAuthPrivateKey_B64_X25519(
         }
     }
 
-    override fun decode(): ByteArray = value.decodeToByteArray(TorStrings.base64)
+    override fun decode(): ByteArray = value.decodeToByteArray(Base64.Default)
 
     override fun descriptor(address: OnionAddressV3): String = descriptorString(address)
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B32_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B32_X25519.kt
@@ -16,12 +16,12 @@
 package io.matthewnelson.kmp.tor.common.clientauth
 
 import io.matthewnelson.component.parcelize.Parcelize
+import io.matthewnelson.encoding.base32.Base32
+import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.kmp.tor.common.annotation.ExperimentalTorApi
-import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.SealedValueClass
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import io.matthewnelson.kmp.tor.common.internal.descriptorString
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmStatic
@@ -51,7 +51,6 @@ sealed interface OnionClientAuthPublicKey_B32_X25519: OnionClientAuth.PublicKey 
 @JvmInline
 @Parcelize
 @Suppress("ClassName")
-@OptIn(InternalTorApi::class)
 private value class RealOnionClientAuthPublicKey_B32_X25519(
     override val value: String
 ): OnionClientAuthPublicKey_B32_X25519 {
@@ -63,7 +62,7 @@ private value class RealOnionClientAuthPublicKey_B32_X25519(
     }
 
     override fun base64(padded: Boolean): String {
-        val b64 = decode().encodeToString(TorStrings.base64)
+        val b64 = decode().encodeToString(Base64.Default)
         return if (padded) {
             b64
         } else {
@@ -79,7 +78,7 @@ private value class RealOnionClientAuthPublicKey_B32_X25519(
         }
     }
 
-    override fun decode(): ByteArray = value.decodeToByteArray(TorStrings.base32)
+    override fun decode(): ByteArray = value.decodeToByteArray(Base32.Default)
 
     override fun descriptor(): String = descriptorString()
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B64_X25519.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/clientauth/OnionClientAuthPublicKey_B64_X25519.kt
@@ -16,12 +16,12 @@
 package io.matthewnelson.kmp.tor.common.clientauth
 
 import io.matthewnelson.component.parcelize.Parcelize
+import io.matthewnelson.encoding.base32.Base32
+import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.kmp.tor.common.annotation.ExperimentalTorApi
-import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.SealedValueClass
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import io.matthewnelson.kmp.tor.common.internal.descriptorString
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmStatic
@@ -51,7 +51,6 @@ sealed interface OnionClientAuthPublicKey_B64_X25519: OnionClientAuth.PublicKey 
 @JvmInline
 @Parcelize
 @Suppress("ClassName")
-@OptIn(InternalTorApi::class)
 private value class RealOnionClientAuthPublicKey_B64_X25519(
     override val value: String
 ): OnionClientAuthPublicKey_B64_X25519 {
@@ -71,7 +70,7 @@ private value class RealOnionClientAuthPublicKey_B64_X25519(
     }
 
     override fun base32(padded: Boolean): String {
-        val b32 = decode().encodeToString(TorStrings.base32)
+        val b32 = decode().encodeToString(Base32.Default)
         return if (padded) {
             b32
         } else {
@@ -79,7 +78,7 @@ private value class RealOnionClientAuthPublicKey_B64_X25519(
         }
     }
 
-    override fun decode(): ByteArray = value.decodeToByteArray(TorStrings.base64)
+    override fun decode(): ByteArray = value.decodeToByteArray(Base64.Default)
 
     override fun descriptor(): String = descriptorString()
 

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/internal/TorStrings.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/internal/TorStrings.kt
@@ -15,11 +15,7 @@
  **/
 package io.matthewnelson.kmp.tor.common.internal
 
-import io.matthewnelson.encoding.builders.Base16
-import io.matthewnelson.encoding.builders.Base32Default
-import io.matthewnelson.encoding.builders.Base64
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
-import kotlin.jvm.JvmSynthetic
 
 @InternalTorApi
 object TorStrings {
@@ -32,27 +28,4 @@ object TorStrings {
     const val REDACTED: String = "[REDACTED]"
     @InternalTorApi
     const val SP: String = " "
-
-    @JvmSynthetic
-    internal val base16 = Base16 {
-        isLenient = true
-        lineBreakInterval = 0
-        encodeToLowercase = false
-    }
-
-    @JvmSynthetic
-    internal val base32 = Base32Default {
-        isLenient = true
-        lineBreakInterval = 0
-        encodeToLowercase = false
-        padEncoded = true
-    }
-
-    @JvmSynthetic
-    internal val base64 = Base64 {
-        isLenient = true
-        lineBreakInterval = 0
-        encodeToUrlSafe = false
-        padEncoded = true
-    }
 }

--- a/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/server/Server.kt
+++ b/library/kmp-tor-common/src/commonMain/kotlin/io/matthewnelson/kmp/tor/common/server/Server.kt
@@ -19,12 +19,10 @@ import io.matthewnelson.component.parcelize.Parcelable
 import io.matthewnelson.component.parcelize.Parcelize
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.base16.Base16
-import io.matthewnelson.encoding.builders.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.kmp.tor.common.annotation.ExperimentalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
 import io.matthewnelson.kmp.tor.common.annotation.SealedValueClass
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmStatic
@@ -102,7 +100,7 @@ class Server private constructor() {
 
         override fun canonicalName(): String = "${Fingerprint.PREFIX}$value"
 
-        override fun decode(): ByteArray = value.decodeToByteArray(TorStrings.base16)
+        override fun decode(): ByteArray = value.decodeToByteArray(Base16)
 
         override fun toString(): String = "Fingerprint(value=$value)"
 

--- a/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/clientauth/PrivateKeyUnitTest.kt
+++ b/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/clientauth/PrivateKeyUnitTest.kt
@@ -15,17 +15,16 @@
  **/
 package io.matthewnelson.kmp.tor.common.clientauth
 
+import io.matthewnelson.encoding.base32.Base32
+import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.kmp.tor.common.address.OnionAddressV3
 import io.matthewnelson.kmp.tor.common.address.OnionAddressV3UnitTest
-import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@OptIn(InternalTorApi::class)
 class PrivateKeyUnitTest {
 
     companion object {
@@ -93,7 +92,7 @@ class PrivateKeyUnitTest {
     fun givenBase32PrivateKey_whenBase64withPaddingCalled_returnsBase64String() {
         val key = OnionClientAuthPrivateKey_B32_X25519(VALID_BASE32_PRIVATE_KEY)
         val b64 = key.base64(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base64), b64)
+        assertEquals(key.decode().encodeToString(Base64.Default), b64)
     }
 
     @Test
@@ -107,7 +106,7 @@ class PrivateKeyUnitTest {
     fun givenBase32PrivateKey_whenBase32withPaddingCalled_returnsBase32String() {
         val key = OnionClientAuthPrivateKey_B32_X25519(VALID_BASE32_PRIVATE_KEY)
         val b32 = key.base32(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base32), b32)
+        assertEquals(key.decode().encodeToString(Base32.Default), b32)
     }
 
     @Test
@@ -121,7 +120,7 @@ class PrivateKeyUnitTest {
     fun givenBase64PrivateKey_whenBase32withPaddingCalled_returnsBase32String() {
         val key = OnionClientAuthPrivateKey_B64_X25519(VALID_BASE64_PRIVATE_KEY)
         val b32 = key.base32(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base32), b32)
+        assertEquals(key.decode().encodeToString(Base32.Default), b32)
     }
 
     @Test
@@ -135,7 +134,7 @@ class PrivateKeyUnitTest {
     fun givenBase64PrivateKey_whenBase64withPaddingCalled_returnsBase64String() {
         val key = OnionClientAuthPrivateKey_B64_X25519(VALID_BASE64_PRIVATE_KEY)
         val b64 = key.base64(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base64), b64)
+        assertEquals(key.decode().encodeToString(Base64.Default), b64)
     }
 
     @Test

--- a/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/clientauth/PublicKeyUnitTest.kt
+++ b/library/kmp-tor-common/src/commonTest/kotlin/io/matthewnelson/kmp/tor/common/clientauth/PublicKeyUnitTest.kt
@@ -15,15 +15,14 @@
  **/
 package io.matthewnelson.kmp.tor.common.clientauth
 
+import io.matthewnelson.encoding.base32.Base32
+import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import io.matthewnelson.kmp.tor.common.annotation.InternalTorApi
-import io.matthewnelson.kmp.tor.common.internal.TorStrings
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@OptIn(InternalTorApi::class)
 class PublicKeyUnitTest {
 
     companion object {
@@ -78,7 +77,7 @@ class PublicKeyUnitTest {
     fun givenBase32PublicKey_whenBase64withPaddingCalled_returnsBase64String() {
         val key = OnionClientAuthPublicKey_B32_X25519(VALID_BASE32_PUBLIC_KEY)
         val b64 = key.base64(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base64), b64)
+        assertEquals(key.decode().encodeToString(Base64.Default), b64)
     }
 
     @Test
@@ -92,7 +91,7 @@ class PublicKeyUnitTest {
     fun givenBase32PublicKey_whenBase32withPaddingCalled_returnsBase32String() {
         val key = OnionClientAuthPublicKey_B32_X25519(VALID_BASE32_PUBLIC_KEY)
         val b32 = key.base32(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base32), b32)
+        assertEquals(key.decode().encodeToString(Base32.Default), b32)
     }
 
     @Test
@@ -106,7 +105,7 @@ class PublicKeyUnitTest {
     fun givenBase64PublicKey_whenBase32withPaddingCalled_returnsBase32String() {
         val key = OnionClientAuthPublicKey_B64_X25519(VALID_BASE64_PUBLIC_KEY)
         val b32 = key.base32(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base32), b32)
+        assertEquals(key.decode().encodeToString(Base32.Default), b32)
     }
 
     @Test
@@ -120,7 +119,7 @@ class PublicKeyUnitTest {
     fun givenBase64PublicKey_whenBase64withPaddingCalled_returnsBase64String() {
         val key = OnionClientAuthPublicKey_B64_X25519(VALID_BASE64_PUBLIC_KEY)
         val b64 = key.base64(padded = true)
-        assertEquals(key.decode().encodeToString(TorStrings.base64), b64)
+        assertEquals(key.decode().encodeToString(Base64.Default), b64)
     }
 
     @Test

--- a/samples/java/android/src/main/AndroidManifest.xml
+++ b/samples/java/android/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
     Required for connecting to the Tor network.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!--
+    Required when targeting API 33+ and are using foreground service.
+    -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".App"

--- a/samples/kotlin/android/src/main/AndroidManifest.xml
+++ b/samples/kotlin/android/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
     Required for connecting to the Tor network.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!--
+    Required when targeting API 33+ and are using foreground service.
+    -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".SampleApp"

--- a/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/kotlin/javafx/SampleApp.kt
+++ b/samples/kotlin/javafx/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/sample/kotlin/javafx/SampleApp.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("UNUSED_VARIABLE")
+
 package io.matthewnelson.kmp.tor.sample.kotlin.javafx
 
 import io.matthewnelson.kmp.tor.KmpTorLoaderJvm


### PR DESCRIPTION
Closes #301 

Note: This cannot be merged currently as it has a dependency on a `-SNAPSHOT` of `encoding`, and will need verification that the underlying JPMS issue was resolved. ~A `-SNAPSHOT` of `kmp-tor` will be released to do so. In the meantime, adding the `blocked` label to inhibit merging.~

~`kmp-tor` snapshot released: `4.7.13-4-1.4.3-SNAPSHOT`~

Dependencies updated:
`atomicfu` -> `0.20.2`
`corotines` -> `1.7.1`
`encoding` -> `2.0.0`
`kotlin` -> `1.8.21`
`jnr-unix-socket` -> `0.38.20`

Gradle Plugins
`android-gradle-plugin` -> `7.4.2`
`binary-compat` -> `0.13.2`
`kmp-configuration` -> `0.1.1`
`kotlin-gradle-plugin` -> `1.8.21`
`gradle-maven-publish` -> `0.25.2`
`gradle-wrapper` -> `8.1.1`