### PR TITLE
Add generation of minimum necessary `TorConfig` for runtime operation

### DIFF
--- a/library/runtime-ctrl-api/api/runtime-ctrl-api.api
+++ b/library/runtime-ctrl-api/api/runtime-ctrl-api.api
@@ -693,6 +693,9 @@ public class io/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port : java/lang/
 	public static final fun getOrNull (I)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port;
 	public static final fun getOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port;
 	public final fun hashCode ()I
+	public final fun isAvailable ()Z
+	public final fun isAvailable (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress;)Z
+	public static synthetic fun isAvailable$default (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port;Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress;ILjava/lang/Object;)Z
 	public final fun toString ()Ljava/lang/String;
 }
 
@@ -708,6 +711,9 @@ public final class io/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy 
 	public static final field MAX I
 	public static final field MIN I
 	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun findAvailable (I)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy;
+	public final fun findAvailable (ILio/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy;
+	public static synthetic fun findAvailable$default (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy;ILio/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress;ILjava/lang/Object;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy;
 	public static final fun get (I)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy;
 	public static final fun get (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy;
 	public static final fun getOrNull (I)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port$Proxy;

--- a/library/runtime-ctrl-api/api/runtime-ctrl-api.api
+++ b/library/runtime-ctrl-api/api/runtime-ctrl-api.api
@@ -634,6 +634,13 @@ public final class io/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress$V
 	public final fun getOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress$V6;
 }
 
+public final class io/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost : io/matthewnelson/kmp/tor/runtime/ctrl/api/address/Address {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost;
+	public fun canonicalHostname ()Ljava/lang/String;
+	public static final fun resolveIPv4 ()Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress$V4;
+	public static final fun resolveIPv6 ()Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/IPAddress$V6;
+}
+
 public abstract class io/matthewnelson/kmp/tor/runtime/ctrl/api/address/OnionAddress : io/matthewnelson/kmp/tor/runtime/ctrl/api/address/Address {
 	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/ctrl/api/address/OnionAddress$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/library/runtime-ctrl-api/api/runtime-ctrl-api.api
+++ b/library/runtime-ctrl-api/api/runtime-ctrl-api.api
@@ -57,9 +57,9 @@ public final class io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$AutomapHo
 }
 
 public class io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder {
+	protected final field inheritedDisabledPorts Ljava/util/Set;
+	protected final field settings Ljava/util/Set;
 	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected final fun getInheritedDisabledPorts ()Ljava/util/Set;
-	protected final fun getSettings ()Ljava/util/Set;
 	public final fun put (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Setting$Factory;Lio/matthewnelson/kmp/tor/runtime/ctrl/api/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder;
 	public final fun put (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Setting;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder;
 	public final fun putIfAbsent (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Setting$Factory;Lio/matthewnelson/kmp/tor/runtime/ctrl/api/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder;

--- a/library/runtime-ctrl-api/api/runtime-ctrl-api.api
+++ b/library/runtime-ctrl-api/api/runtime-ctrl-api.api
@@ -56,8 +56,10 @@ public final class io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$AutomapHo
 public final class io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$AutomapHostsSuffixes$Companion : io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Setting$Factory {
 }
 
-public final class io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder {
+public class io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder {
 	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected final fun getInheritedDisabledPorts ()Ljava/util/Set;
+	protected final fun getSettings ()Ljava/util/Set;
 	public final fun put (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Setting$Factory;Lio/matthewnelson/kmp/tor/runtime/ctrl/api/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder;
 	public final fun put (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Setting;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder;
 	public final fun putIfAbsent (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Setting$Factory;Lio/matthewnelson/kmp/tor/runtime/ctrl/api/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig$Builder;

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig.kt
@@ -31,6 +31,10 @@ import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig.Keyword.Attribute
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig.LineItem.Companion.toLineItem
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig.Setting.Companion.filterByAttribute
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig.Setting.Companion.filterByKeyword
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.LocalHost
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port.Companion.toPort
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.ProxyAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.ProxyAddress.Companion.toProxyAddressOrNull
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.builder.*
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.internal.IsAndroidHost
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.internal.IsUnixLikeHost
@@ -2059,6 +2063,48 @@ public class TorConfig private constructor(
             items.joinTo(this, separator = "\n")
         }
         // TODO: public fun toCtrlString(): String
+
+        // Returns null if setting is not a configured
+        // TCP Port, or that port was available. Otherwise,
+        // Will return a modified Setting with "auto" as its
+        // argument.
+        @InternalKmpTorApi
+        @Throws(IOException::class)
+        public fun checkTCPPortAvailability(
+            isPortAvailable: (IPAddress, Port) -> Boolean = { ip, p -> p.isAvailable(ip) },
+        ): Setting? {
+            // Setting does not have Attribute.Port
+            if (!keyword.attributes.contains(Attribute.Port)) return null
+
+            // Not configured as a TCP port that needs validation
+            if (argument == "0" || argument == AUTO) return null
+            if (argument.startsWith("unix:")) return null
+
+            val (address, port) = argument.toProxyAddressOrNull() ?: run {
+                val localhost = try {
+                    LocalHost.resolveIPv4()
+                } catch (_: IOException) {
+                    // TODO: Issue #313
+                    //  Move to builders
+                    "127.0.0.1".toIPAddressV4()
+                }
+
+                ProxyAddress(localhost, argument.toPort())
+            }
+
+            // Assigned TCP Port is available. No action required
+            if (isPortAvailable(address, port)) return null
+
+            // Remove and replace argument with auto
+            val list = items.toMutableList()
+            val removed = list.removeAt(0)
+
+            // TODO: Issue #313
+            //  Will need to figure out how to handle a non-localhost IPAddress
+            list.add(0, removed.keyword.toLineItem(AUTO, removed.optionals)!!)
+
+            return Setting(list.toImmutableSet(), extraInfo)
+        }
     }
 
     /**
@@ -2099,6 +2145,15 @@ public class TorConfig private constructor(
         public val isUnique: Boolean,
     ): Comparable<Keyword>, CharSequence {
 
+        public sealed class Attribute private constructor() {
+            public data object Directory: Attribute()
+            public data object File: Attribute()
+            public data object HiddenService: Attribute()
+            public data object Logging: Attribute()
+            public data object Port: Attribute()
+            public data object UnixSocket: Attribute()
+        }
+
         public final override val length: Int get() = name.length
         public final override fun get(index: Int): Char = name[index]
         public final override fun subSequence(
@@ -2112,15 +2167,6 @@ public class TorConfig private constructor(
         public final override fun equals(other: Any?): Boolean = other is Keyword && other.name == name
         public final override fun hashCode(): Int = 21 * 31 + name.hashCode()
         public final override fun toString(): String = name
-
-        public sealed class Attribute private constructor() {
-            public data object Directory: Attribute()
-            public data object File: Attribute()
-            public data object HiddenService: Attribute()
-            public data object Logging: Attribute()
-            public data object Port: Attribute()
-            public data object UnixSocket: Attribute()
-        }
     }
 
     public override fun equals(other: Any?): Boolean = other is TorConfig && other.settings == settings

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig.kt
@@ -126,8 +126,10 @@ public class TorConfig private constructor(
     @KmpTorDsl
     public open class Builder private constructor(other: TorConfig?) {
 
+        @JvmField
         protected val settings: MutableSet<Setting> = mutableSetOf()
         // For dealing with inherited disabled port
+        @JvmField
         protected val inheritedDisabledPorts: MutableSet<Setting> = mutableSetOf()
 
         /**

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorConfig.kt
@@ -244,16 +244,24 @@ public class TorConfig private constructor(
                     }
                 }
 
+                if (keyword.attributes.contains(Attribute.Port)) {
+                    for (port in inheritedDisabledPorts) {
+                        if (port.keyword == keyword) return true
+                    }
+                }
+
                 return false
             }
 
             override fun ports(): List<Setting> {
-                return settings
+                val ports = settings
                     .filterByAttribute<Attribute.Port>()
                     .filter { setting ->
                         // remove any configured hidden service settings
                         setting.keyword != HiddenServiceDir
-                    }
+                    }.toMutableList()
+                ports.addAll(inheritedDisabledPorts)
+                return ports
             }
 
             override fun remove(setting: Setting) {

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent.kt
@@ -298,7 +298,7 @@ public enum class TorEvent {
         public fun removeAll(tag: String)
 
         /**
-         * Remove all [Observer] that are currently registered.
+         * Remove all non-static [Observer] that are currently registered.
          * */
         public fun clearObservers()
     }

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost.kt
@@ -41,11 +41,11 @@ public object LocalHost: Address("localhost") {
 
         private val timeMark = TimeSource.Monotonic.markNow()
 
-        private fun isExpired(): Boolean {
+        private fun isNotExpired(): Boolean {
             val elapsedNanos = timeMark.elapsedNow().inWholeNanoseconds
             // java uses 5s expiry time, so the extra 250 ns
             // ensures there is always going to be a refresh.
-            return elapsedNanos > 5_000_000_250L
+            return elapsedNanos < 5_000_000_250L
         }
 
         object IPv4 {
@@ -56,7 +56,7 @@ public object LocalHost: Address("localhost") {
             @JvmStatic
             fun getOrNull(): IPAddress.V4? {
                 val cached = cache ?: return null
-                if (!cached.isExpired()) {
+                if (cached.isNotExpired()) {
                     return cached.address as IPAddress.V4
                 }
                 cache = null
@@ -85,7 +85,7 @@ public object LocalHost: Address("localhost") {
             @JvmStatic
             fun getOrNull(): IPAddress.V6? {
                 val cached = cache ?: return null
-                if (!cached.isExpired()) {
+                if (cached.isNotExpired()) {
                     return cached.address as IPAddress.V6
                 }
                 cache = null

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost.kt
@@ -29,11 +29,11 @@ public object LocalHost: Address("localhost") {
 
     @JvmStatic
     @Throws(IOException::class)
-    public fun resolveIPv4(): IPAddress.V4 = Cache.V4.resolve(checkCache = true)
+    public fun resolveIPv4(): IPAddress.V4 = Cache.IPv4.resolve(checkCache = true)
 
     @JvmStatic
     @Throws(IOException::class)
-    public fun resolveIPv6(): IPAddress.V6 = Cache.V6.resolve(checkCache = true)
+    public fun resolveIPv6(): IPAddress.V6 = Cache.IPv6.resolve(checkCache = true)
 
     public override fun canonicalHostname(): String = value
 
@@ -48,7 +48,7 @@ public object LocalHost: Address("localhost") {
             return elapsedNanos > 5_000_000_250L
         }
 
-        object V4 {
+        object IPv4 {
 
             @Volatile
             private var cache: Cache? = null
@@ -77,7 +77,7 @@ public object LocalHost: Address("localhost") {
             }
         }
 
-        object V6 {
+        object IPv6 {
 
             @Volatile
             private var cache: Cache? = null
@@ -110,15 +110,15 @@ public object LocalHost: Address("localhost") {
     @JvmStatic
     @InternalKmpTorApi
     @Throws(IOException::class)
-    public fun resolveIPv4NoCache(): IPAddress.V4 = Cache.V4.resolve(checkCache = false)
+    public fun resolveIPv4NoCache(): IPAddress.V4 = Cache.IPv4.resolve(checkCache = false)
 
     @JvmStatic
     @InternalKmpTorApi
     @Throws(IOException::class)
-    public fun resolveIPv6NoCache(): IPAddress.V6 = Cache.V6.resolve(checkCache = false)
+    public fun resolveIPv6NoCache(): IPAddress.V6 = Cache.IPv6.resolve(checkCache = false)
 
     @JvmSynthetic
-    internal fun cachedIPv4OrNull(): IPAddress.V4? = Cache.V4.getOrNull()
+    internal fun cachedIPv4OrNull(): IPAddress.V4? = Cache.IPv4.getOrNull()
     @JvmSynthetic
-    internal fun cachedIPv6OrNull(): IPAddress.V6? = Cache.V6.getOrNull()
+    internal fun cachedIPv6OrNull(): IPAddress.V6? = Cache.IPv6.getOrNull()
 }

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/LocalHost.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.address
+
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.wrapIOException
+import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.internal.platformResolveIPv4
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.internal.platformResolveIPv6
+import kotlin.concurrent.Volatile
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
+import kotlin.time.TimeSource
+
+public object LocalHost: Address("localhost") {
+
+    @JvmStatic
+    @Throws(IOException::class)
+    public fun resolveIPv4(): IPAddress.V4 = Cache.V4.resolve(checkCache = true)
+
+    @JvmStatic
+    @Throws(IOException::class)
+    public fun resolveIPv6(): IPAddress.V6 = Cache.V6.resolve(checkCache = true)
+
+    public override fun canonicalHostname(): String = value
+
+    private class Cache private constructor(private val address: IPAddress) {
+
+        private val timeMark = TimeSource.Monotonic.markNow()
+
+        private fun isExpired(): Boolean {
+            val elapsedNanos = timeMark.elapsedNow().inWholeNanoseconds
+            // java uses 5s expiry time, so the extra 250 ns
+            // ensures there is always going to be a refresh.
+            return elapsedNanos > 5_000_000_250L
+        }
+
+        object V4 {
+
+            @Volatile
+            private var cache: Cache? = null
+
+            @JvmStatic
+            fun getOrNull(): IPAddress.V4? {
+                val cached = cache ?: return null
+                if (!cached.isExpired()) {
+                    return cached.address as IPAddress.V4
+                }
+                cache = null
+                return null
+            }
+
+            @JvmStatic
+            @Throws(IOException::class)
+            fun resolve(checkCache: Boolean): IPAddress.V4 {
+                if (checkCache) getOrNull()?.let { return it }
+                val address: IPAddress.V4 = try {
+                    platformResolveIPv4()
+                } catch (t: Throwable) {
+                    throw t.wrapIOException { "Failed to resolve IPv4 address for $value" }
+                }
+                cache = Cache(address)
+                return address
+            }
+        }
+
+        object V6 {
+
+            @Volatile
+            private var cache: Cache? = null
+
+            @JvmStatic
+            fun getOrNull(): IPAddress.V6? {
+                val cached = cache ?: return null
+                if (!cached.isExpired()) {
+                    return cached.address as IPAddress.V6
+                }
+                cache = null
+                return null
+            }
+
+            @JvmStatic
+            @Throws(IOException::class)
+            fun resolve(checkCache: Boolean): IPAddress.V6 {
+                if (checkCache) getOrNull()?.let { return it }
+                val address: IPAddress.V6 = try {
+                    platformResolveIPv6()
+                } catch (t: Throwable) {
+                    throw t.wrapIOException { "Failed to resolve IPv6 address for $value" }
+                }
+                cache = Cache(address)
+                return address
+            }
+        }
+    }
+
+    @JvmStatic
+    @InternalKmpTorApi
+    @Throws(IOException::class)
+    public fun resolveIPv4NoCache(): IPAddress.V4 = Cache.V4.resolve(checkCache = false)
+
+    @JvmStatic
+    @InternalKmpTorApi
+    @Throws(IOException::class)
+    public fun resolveIPv6NoCache(): IPAddress.V6 = Cache.V6.resolve(checkCache = false)
+
+    @JvmSynthetic
+    internal fun cachedIPv4OrNull(): IPAddress.V4? = Cache.V4.getOrNull()
+    @JvmSynthetic
+    internal fun cachedIPv6OrNull(): IPAddress.V6? = Cache.V6.getOrNull()
+}

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/address/Port.kt
@@ -15,10 +15,14 @@
  **/
 package io.matthewnelson.kmp.tor.runtime.ctrl.api.address
 
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.wrapIOException
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port.Proxy.Companion.toPortProxyOrNull
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.internal.PortAvailability
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.internal.findHostnameAndPortFromURL
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
 /**
@@ -32,6 +36,27 @@ public open class Port private constructor(
 ): Comparable<Port> {
 
     public final override fun compareTo(other: Port): Int = value.compareTo(other.value)
+
+    /**
+     * Checks if the TCP port is available or not for the specified [address].
+     *
+     * **NOTE:** This is a blocking call and should be invoked from
+     * a background thread.
+     *
+     * @param [address] The [IPAddress] to check. If null, [LocalHost.resolveIPv4] is used
+     * @throws [IOException] if the check fails (e.g. calling from Main thread on Android)
+     * */
+    @JvmOverloads
+    @Throws(IOException::class)
+    public fun isAvailable(address: IPAddress? = null): Boolean {
+        val ipAddress = address ?: LocalHost.resolveIPv4()
+
+        try {
+            return PortAvailability.of(ipAddress).isAvailable(value)
+        } catch (t: Throwable) {
+            throw t.wrapIOException()
+        }
+    }
 
     public companion object {
 
@@ -98,6 +123,54 @@ public open class Port private constructor(
      * A [Port] with a more constrained range of 1024 and 65535 (inclusive)
      * */
     public class Proxy private constructor(value: Int): Port(value) {
+
+        /**
+         * Finds the next available TCP port starting with the current
+         * [value] and iterating up [limit] times.
+         *
+         * If [MAX] is exceeded while iterating through ports and [limit]
+         * has not been exhausted, the remaining checks will start from [MIN].
+         *
+         * **NOTE:** This is a blocking call and should be invoked from
+         * a background thread.
+         *
+         * @param [address] The [IPAddress] to check. If null, [LocalHost.resolveIPv4] is used
+         * @throws [IllegalArgumentException] if [limit] is not between 1 to 10_000 (inclusive)
+         * @throws [IOException] if the check fails (e.g. calling from Main thread on Android)
+         * */
+        @JvmOverloads
+        @Throws(IllegalArgumentException::class, IOException::class)
+        public fun findAvailable(limit: Int, address: IPAddress? = null): Proxy {
+            require(limit in 1..10_000) { "limit must be between 1 to 10_000 (inclusive)" }
+
+            val ipAddress = address ?: LocalHost.resolveIPv4()
+
+            val availability = try {
+                PortAvailability.of(ipAddress)
+            } catch (t: Throwable) {
+                throw t.wrapIOException {
+                    "Failed to create ${PortAvailability::class.simpleName} for ${ipAddress.canonicalHostname()}"
+                }
+            }
+
+            var remaining = limit
+            var port = value
+
+            while (remaining-- > 0) {
+                if (availability.isAvailable(port)) return Proxy(port)
+                port = if (port == Port.MAX) MIN else port + 1
+            }
+
+            val top = value + limit
+            val ranges = if (top <= MAX) {
+                "($value - $top)"
+            } else {
+                val bottom = top - MAX + MIN
+                "($value - $MAX) and ($MIN - $bottom)"
+            }
+
+            throw IOException("Failed to find available port for ${ipAddress.canonicalHostname()} $ranges")
+        }
 
         public companion object {
 

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/builder/ExtendedTorConfigBuilder.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/builder/ExtendedTorConfigBuilder.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.builder
+
+import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig
+
+@InternalKmpTorApi
+public interface ExtendedTorConfigBuilder {
+    public fun contains(keyword: TorConfig.Keyword): Boolean
+    public fun ports(): List<TorConfig.Setting>
+    public fun remove(setting: TorConfig.Setting)
+}

--- a/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
+++ b/library/runtime-ctrl-api/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
+
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+
+internal expect class PortAvailability {
+
+    @Throws(Exception::class)
+    internal fun isAvailable(port: Int): Boolean
+
+    internal companion object {
+
+        @Throws(Exception::class)
+        internal fun of(address: IPAddress): PortAvailability
+    }
+}

--- a/library/runtime-ctrl-api/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/JsPlatform.kt
+++ b/library/runtime-ctrl-api/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/JsPlatform.kt
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
 
 import io.matthewnelson.kmp.file.SysPathSep
+import io.matthewnelson.kmp.file.wrapIOException
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.resource.OSHost
 import io.matthewnelson.kmp.tor.core.resource.OSInfo
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.LocalHost
 
 @OptIn(InternalKmpTorApi::class)
 internal actual val UnixSocketsNotSupportedMessage: String? by lazy {
@@ -35,3 +40,15 @@ internal actual val UnixSocketsNotSupportedMessage: String? by lazy {
 }
 
 internal actual val ProcessID: Int? get() = process_pid
+
+@Suppress("NOTHING_TO_INLINE", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+internal actual inline fun LocalHost.platformResolveIPv4(): IPAddress.V4 {
+    // check exception code
+    TODO()
+}
+
+@Suppress("NOTHING_TO_INLINE", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+internal actual inline fun LocalHost.platformResolveIPv6(): IPAddress.V6 {
+    // check exception code
+    TODO()
+}

--- a/library/runtime-ctrl-api/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/JsPlatform.kt
+++ b/library/runtime-ctrl-api/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/JsPlatform.kt
@@ -43,12 +43,12 @@ internal actual val ProcessID: Int? get() = process_pid
 
 @Suppress("NOTHING_TO_INLINE", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
 internal actual inline fun LocalHost.platformResolveIPv4(): IPAddress.V4 {
-    // check exception code
+    // check exception error code
     TODO()
 }
 
 @Suppress("NOTHING_TO_INLINE", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
 internal actual inline fun LocalHost.platformResolveIPv6(): IPAddress.V6 {
-    // check exception code
+    // check exception error code
     TODO()
 }

--- a/library/runtime-ctrl-api/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
+++ b/library/runtime-ctrl-api/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
+
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+
+internal actual class PortAvailability private constructor() {
+
+    internal actual fun isAvailable(port: Int): Boolean {
+        // check exception error code
+        TODO()
+    }
+
+    internal actual companion object {
+
+        internal actual fun of(address: IPAddress): PortAvailability {
+            TODO()
+        }
+    }
+}

--- a/library/runtime-ctrl-api/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/-JvmPlatform.kt
+++ b/library/runtime-ctrl-api/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/-JvmPlatform.kt
@@ -13,14 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
 
 import io.matthewnelson.kmp.file.SysPathSep
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.resource.OSHost
 import io.matthewnelson.kmp.tor.core.resource.OSInfo
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress.V4.Companion.toIPAddressV4
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress.V6.Companion.toIPAddressV6
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.LocalHost
+import java.net.Inet4Address
+import java.net.Inet6Address
 
-@get:JvmSynthetic
 @OptIn(InternalKmpTorApi::class)
 internal actual val UnixSocketsNotSupportedMessage: String? by lazy {
     // Android support via android.net.LocalSocket since API 1
@@ -46,7 +53,6 @@ internal actual val UnixSocketsNotSupportedMessage: String? by lazy {
     }
 }
 
-@get:JvmSynthetic
 internal actual val ProcessID: Int? get() {
     @OptIn(InternalKmpTorApi::class)
     return if (OSInfo.INSTANCE.isAndroidRuntime()) {
@@ -72,4 +78,16 @@ private val AndroidPID: Int? by lazy {
     } catch (_: Throwable) {
         null
     }
+}
+
+@Throws(Exception::class)
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun LocalHost.platformResolveIPv4(): IPAddress.V4 {
+    return Inet4Address.getByName(value).hostAddress.toIPAddressV4()
+}
+
+@Throws(Exception::class)
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun LocalHost.platformResolveIPv6(): IPAddress.V6 {
+    return Inet6Address.getByName(value).hostAddress.toIPAddressV6()
 }

--- a/library/runtime-ctrl-api/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
+++ b/library/runtime-ctrl-api/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
+
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+import java.net.InetAddress
+import javax.net.ServerSocketFactory
+
+internal actual class PortAvailability private constructor(
+    private val address: InetAddress,
+) {
+
+    private val factory = ServerSocketFactory.getDefault()
+
+    @Throws(Exception::class)
+    internal actual fun isAvailable(port: Int): Boolean {
+        try {
+            factory.createServerSocket(port, 1, address).close()
+            return true
+        } catch (t: Throwable) {
+            // Android will throw NetworkOnMainThreadException here,
+            // and if port is invalid an IllegalArgumentException is
+            // thrown. So, only check for IOException which indicated
+            // that the ServerSocket failed to bind
+            if (t is IOException) return false
+            throw t
+        }
+    }
+
+    internal actual companion object {
+
+        @JvmSynthetic
+        @Throws(Exception::class)
+        internal actual fun of(address: IPAddress): PortAvailability {
+            val inetAddress = InetAddress.getByName(address.canonicalHostname())
+            return PortAvailability(inetAddress)
+        }
+    }
+}

--- a/library/runtime-ctrl-api/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/builder/LocalHostUnitTest.kt
+++ b/library/runtime-ctrl-api/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/builder/LocalHostUnitTest.kt
@@ -13,25 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("KotlinRedundantDiagnosticSuppress")
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.builder
 
-package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
-
-import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.LocalHost
+import kotlin.test.Test
+import kotlin.test.assertNotNull
 
-internal expect val UnixSocketsNotSupportedMessage: String?
+// TODO: Move to commonMain
+class LocalHostUnitTest {
 
-internal expect val IsUnixLikeHost: Boolean
+    @Test
+    fun givenIPv4_whenResolved_thenIsCached() {
+        LocalHost.resolveIPv4()
+        assertNotNull(LocalHost.cachedIPv4OrNull())
+    }
 
-internal expect val IsAndroidHost: Boolean
+    @Test
+    fun givenIPv6_whenResolved_thenIsCached() {
+        try {
+            LocalHost.resolveIPv6()
+        } catch (e: IOException) {
+            println("IPv6 unavailable for host. Skipping...")
+            return
+        }
 
-internal expect val ProcessID: Int?
-
-@Throws(Exception::class)
-@Suppress("NOTHING_TO_INLINE")
-internal expect inline fun LocalHost.platformResolveIPv4(): IPAddress.V4
-
-@Throws(Exception::class)
-@Suppress("NOTHING_TO_INLINE")
-internal expect inline fun LocalHost.platformResolveIPv6(): IPAddress.V6
+        assertNotNull(LocalHost.cachedIPv6OrNull())
+    }
+}

--- a/library/runtime-ctrl-api/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/builder/PortUnitTest.kt
+++ b/library/runtime-ctrl-api/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/builder/PortUnitTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.builder
+
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.LocalHost
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port.Proxy.Companion.toPortProxy
+import java.lang.IllegalArgumentException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+// TODO: Move to commonMain
+class PortUnitTest {
+
+    @Test
+    fun givenLocalHostIPv4_whenFindAvailable_thenSucceeds() {
+        // Should not fail on any host
+        Port.Proxy.MIN.toPortProxy().findAvailable(10_000)
+    }
+
+    @Test
+    fun givenLocalHostIPv6_whenFindAvailable_thenSucceeds() {
+        val localhost = try {
+            LocalHost.resolveIPv6()
+        } catch (e: IOException) {
+            println("IPv6 unavailable for host. Skipping...")
+            return
+        }
+
+        Port.Proxy.MIN.toPortProxy().findAvailable(10_000, localhost)
+    }
+
+    @Test
+    fun givenFindAvailable_whenInvalidLimit_thenThrowsException() {
+        val port = Port.Proxy.MIN.toPortProxy()
+        assertFailsWith<IllegalArgumentException> { port.findAvailable(0) }
+        assertFailsWith<IllegalArgumentException> { port.findAvailable(10_001) }
+    }
+}

--- a/library/runtime-ctrl-api/src/unixMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
+++ b/library/runtime-ctrl-api/src/unixMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/PortAvailability.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
+
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+
+internal actual class PortAvailability private constructor() {
+
+    @Throws(Exception::class)
+    internal actual fun isAvailable(port: Int): Boolean {
+        TODO()
+    }
+
+    internal actual companion object {
+
+        @Throws(Exception::class)
+        internal actual fun of(address: IPAddress): PortAvailability {
+            TODO()
+        }
+    }
+}

--- a/library/runtime-ctrl-api/src/unixMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/UnixPlatform.kt
+++ b/library/runtime-ctrl-api/src/unixMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/api/internal/UnixPlatform.kt
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.tor.runtime.ctrl.api.internal
 
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.LocalHost
 import platform.posix.getpid
 
 internal actual val UnixSocketsNotSupportedMessage: String? = null
@@ -24,3 +28,15 @@ internal actual val IsUnixLikeHost: Boolean get() = true
 internal actual val IsAndroidHost: Boolean get() = false
 
 internal actual val ProcessID: Int? get() = getpid()
+
+@Throws(Exception::class)
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun LocalHost.platformResolveIPv4(): IPAddress.V4 {
+    TODO()
+}
+
+@Throws(Exception::class)
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun LocalHost.platformResolveIPv6(): IPAddress.V6 {
+    TODO()
+}

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor.kt
@@ -93,7 +93,6 @@ protected constructor(
 
     public override fun removeAll(tag: String) {
         if (tag.isStaticTag()) return
-
         withObservers {
             val iterator = iterator()
             while (iterator.hasNext()) {

--- a/library/runtime-mobile/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/mobile/TorService.kt
+++ b/library/runtime-mobile/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/mobile/TorService.kt
@@ -18,7 +18,6 @@ package io.matthewnelson.kmp.tor.runtime.mobile
 import android.content.Context
 import android.content.Intent
 import androidx.startup.AppInitializer
-import androidx.startup.Initializer
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.runtime.RuntimeEvent
 import io.matthewnelson.kmp.tor.runtime.TorRuntime

--- a/library/runtime/api/runtime.api
+++ b/library/runtime/api/runtime.api
@@ -84,6 +84,10 @@ public abstract interface class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$Pr
 	public abstract fun removeAll ([Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent;)V
 }
 
+public final class io/matthewnelson/kmp/tor/runtime/TorConfigGenerator {
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Environment;ZZLjava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public abstract interface class io/matthewnelson/kmp/tor/runtime/TorRuntime : io/matthewnelson/kmp/tor/runtime/RuntimeEvent$Processor, io/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent$Processor {
 	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Companion;
 	public static fun Builder (Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Environment;Lio/matthewnelson/kmp/tor/runtime/ctrl/api/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/TorRuntime;

--- a/library/runtime/api/runtime.api
+++ b/library/runtime/api/runtime.api
@@ -34,22 +34,32 @@ public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$Companion {
 	public final fun valueOfOrNull (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent;
 }
 
-public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$DEBUG : io/matthewnelson/kmp/tor/runtime/RuntimeEvent {
-	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$DEBUG;
+public abstract class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG : io/matthewnelson/kmp/tor/runtime/RuntimeEvent {
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$DEBUG : io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$DEBUG;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$ERROR : io/matthewnelson/kmp/tor/runtime/RuntimeEvent {
-	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$ERROR;
+public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$ERROR : io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$ERROR;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$INFO : io/matthewnelson/kmp/tor/runtime/RuntimeEvent {
-	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$INFO;
+public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$INFO : io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$INFO;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$WARN : io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$LOG$WARN;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -72,13 +82,6 @@ public abstract interface class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$Pr
 	public abstract fun removeAll (Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent;)V
 	public abstract fun removeAll (Ljava/lang/String;)V
 	public abstract fun removeAll ([Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent;)V
-}
-
-public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$WARN : io/matthewnelson/kmp/tor/runtime/RuntimeEvent {
-	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$WARN;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class io/matthewnelson/kmp/tor/runtime/TorRuntime : io/matthewnelson/kmp/tor/runtime/RuntimeEvent$Processor, io/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent$Processor {

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.kmp.tor.runtime
 
 import io.matthewnelson.immutable.collections.immutableSetOf
+import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.ItBlock
 import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorEvent
 import kotlin.jvm.JvmField
@@ -35,24 +36,14 @@ public sealed class RuntimeEvent<R: Any> private constructor() {
     public val name: String get() = toString()
 
     /**
-     * Debug log messages
+     * Log Messages
      * */
-    public data object DEBUG: RuntimeEvent<String>()
-
-    /**
-     * Error log messages
-     * */
-    public data object ERROR: RuntimeEvent<String>()
-
-    /**
-     * Info log messages
-     * */
-    public data object INFO: RuntimeEvent<String>()
-
-    /**
-     * Warn log messages
-     * */
-    public data object WARN: RuntimeEvent<String>()
+    public sealed class LOG private constructor(): RuntimeEvent<String>() {
+        public data object DEBUG: LOG()
+        public data object ERROR: LOG()
+        public data object INFO: LOG()
+        public data object WARN: LOG()
+    }
 
     // TODO: Other events
 
@@ -167,7 +158,7 @@ public sealed class RuntimeEvent<R: Any> private constructor() {
         public fun removeAll(tag: String)
 
         /**
-         * Remove all [Observer] that are currently registered.
+         * Remove all non-static [Observer] that are currently registered.
          *
          * If the implementing class extends both [Processor]
          * and [TorEvent.Processor], all [TorEvent.Observer]
@@ -194,10 +185,15 @@ public sealed class RuntimeEvent<R: Any> private constructor() {
 
         @JvmField
         public val entries: Set<RuntimeEvent<*>> = immutableSetOf(
-            DEBUG,
-            ERROR,
-            INFO,
-            WARN,
+            LOG.DEBUG,
+            LOG.ERROR,
+            LOG.INFO,
+            LOG.WARN,
         )
+    }
+
+    @InternalKmpTorApi
+    public interface Notifier {
+        public fun <R: Any> notify(event: RuntimeEvent<R>, output: R)
     }
 }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorConfigGenerator.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorConfigGenerator.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime
+
+import io.matthewnelson.kmp.file.IOException
+import io.matthewnelson.kmp.file.resolve
+import io.matthewnelson.kmp.tor.core.api.ResourceInstaller
+import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.runtime.RuntimeEvent.*
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.ThisBlock
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig.*
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.LocalHost
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port.Companion.toPort
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.apply
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.builder.ExtendedTorConfigBuilder
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.builder.UnixSocketBuilder
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Generates a minimum viable [TorConfig] using the provided settings from
+ * [TorRuntime.Builder] and [TorRuntime.Environment].
+ *
+ * [generate] is called from a background thread during runtime operations
+ * prior to each tor daemon start.
+ * */
+@OptIn(InternalKmpTorApi::class)
+public class TorConfigGenerator private constructor(
+    private val environment: TorRuntime.Environment,
+    private val allowPortReassignment: Boolean,
+    private val omitGeoIPFileSettings: Boolean,
+    private val config: List<ThisBlock.WithIt<Builder, TorRuntime.Environment>>,
+    private val isPortAvailable: (IPAddress, Port) -> Boolean,
+) {
+
+    @Throws(Exception::class)
+    internal fun generate(n: Notifier): TorConfig = TorConfig.Builder {
+        n.notify(LOG.DEBUG, "Installing tor resources (if needed)")
+        val pathsTor = environment.torResource.install()
+
+        // TODO: Issue #313
+        //  Resolve localhost so that it is in the cache
+        //  and the builders can set as default.
+        try {
+            n.notify(LOG.DEBUG, "Resolving localhost IPv4 address to cache")
+            LocalHost.resolveIPv4NoCache()
+        } catch (_: IOException) {
+            n.notify(LOG.WARN, "localhost IPv4 resolution failed")
+        }
+
+        try {
+            n.notify(LOG.DEBUG, "Resolving localhost IPv6 address to cache")
+            LocalHost.resolveIPv6NoCache()
+        } catch (_: IOException) {
+            // no WARN like with IPv4 b/c a lot of machines/networks have IPv6 disabled
+            n.notify(LOG.DEBUG, "localhost IPv6 resolution failed")
+        }
+
+        // Apply library consumers' configuration(s)
+        config.forEach { apply(it, environment) }
+
+        validate(n, pathsTor)
+    }
+
+    private fun Builder.validate(n: Notifier, pathsTor: ResourceInstaller.Paths.Tor) {
+        // Dirs/Files
+        if (!omitGeoIPFileSettings) {
+            put(GeoIPFile) { file = pathsTor.geoip }
+            put(GeoIPv6File) { file = pathsTor.geoip6 }
+        }
+
+        putIfAbsent(DataDirectory) {
+            directory = environment.workDir
+                .resolve(DataDirectory.DEFAULT_NAME)
+        }
+        putIfAbsent(CacheDirectory) {
+            directory = environment.cacheDir
+        }
+        putIfAbsent(ControlPortWriteToFile) {
+            file = environment.workDir
+                .resolve(ControlPortWriteToFile.DEFAULT_NAME)
+        }
+
+        // Authentication
+        if (
+            !(this as ExtendedTorConfigBuilder).contains(CookieAuthFile)
+            // && !contains(HashedControlPassword)
+        ) {
+            put(CookieAuthFile) {
+                file = environment.workDir
+                    .resolve(CookieAuthFile.DEFAULT_NAME)
+            }
+        }
+
+        // Ports
+        if (!contains(__SocksPort)) {
+            // Add default socks port so that port availability check
+            // can reassign it to auto if needed
+            put(__SocksPort) { asPort { /* default: 9050 */ } }
+        }
+
+        if (!contains(__ControlPort)) {
+            put(__ControlPort) {
+                try {
+                    // Prefer using Unix Domain Sockets where possible
+                    asUnixSocket {
+                        file = environment.workDir
+                            .resolve(UnixSocketBuilder.DEFAULT_NAME_CTRL)
+                    }
+                } catch (_: UnsupportedOperationException) {
+                    // fallback to TCP if unavailable on the system
+                    asPort { auto() }
+                }
+            }
+        }
+
+        checkPortAvailability(n)
+
+        // Required for TorRuntime
+        put(DisableNetwork) { disable = true }
+        put(RunAsDaemon) { enable = false }
+        put(__OwningControllerProcess) { /* default */ }
+    }
+
+    private fun Builder.checkPortAvailability(n: Notifier) {
+        if (!allowPortReassignment) return
+        (this as ExtendedTorConfigBuilder).ports().forEach { port ->
+            val reassigned = port.checkTCPPortAvailability(isPortAvailable) ?: return@forEach
+            n.notify(
+                LOG.WARN,
+                "Unavailable Port[${port.argument.toPort()}]. " +
+                "${port.keyword} reassigned to ${reassigned.argument}"
+            )
+
+            // Remove and replace
+            remove(port)
+            put(reassigned)
+        }
+    }
+
+    internal companion object {
+
+        @JvmSynthetic
+        internal fun of(
+            environment: TorRuntime.Environment,
+            allowPortReassignment: Boolean,
+            omitGeoIPFileSettings: Boolean,
+            config: List<ThisBlock.WithIt<Builder, TorRuntime.Environment>>,
+            isPortAvailable: (IPAddress, Port) -> Boolean = { ip, p -> p.isAvailable(ip) },
+        ): TorConfigGenerator = TorConfigGenerator(
+            environment,
+            allowPortReassignment,
+            omitGeoIPFileSettings,
+            config,
+            isPortAvailable
+        )
+    }
+}

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -139,7 +139,8 @@ public interface TorRuntime: TorEvent.Processor, RuntimeEvent.Processor {
          * Any exception thrown within [block] will be propagated to the caller.
          *
          * **NOTE:** This can be omitted as a minimum viable configuration
-         * is always created using [Environment].
+         * is always created. See [TorConfigGenerator.validate] for what settings
+         * are automatically applied.
          *
          * **NOTE:** [block] should not contain any non-singleton references
          * such as Android Activity context.
@@ -205,6 +206,8 @@ public interface TorRuntime: TorEvent.Processor, RuntimeEvent.Processor {
             ): TorRuntime = getOrCreateInstance(environment.id) {
                 val b = Builder(environment)
                 if (block != null) b.apply(block)
+
+                // TODO: Use TorConfigGenerator.of
 
                 RealTorRuntime.of(
                     environment = environment,

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -376,11 +376,13 @@ public interface TorRuntime: TorEvent.Processor, RuntimeEvent.Processor {
     }
 
     @InternalKmpTorApi
-    public interface ServiceFactory: TorEvent.Processor, RuntimeEvent.Processor {
+    public interface ServiceFactory:
+        TorEvent.Processor,
+        RuntimeEvent.Processor,
+        RuntimeEvent.Notifier
+    {
 
         public val environment: Environment
-
-        public fun <R: Any> notify(event: RuntimeEvent<R>, output: R)
 
         public fun create(
             lifecycleHook: Job,

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessor.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessor.kt
@@ -85,7 +85,6 @@ internal abstract class AbstractRuntimeEventProcessor(
 
     public final override fun removeAll(tag: String) {
         if (tag.isStaticTag()) return
-
         withRuntimeObservers {
             val iterator = iterator()
             while (iterator.hasNext()) {

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
@@ -133,10 +133,7 @@ internal class RealTorRuntime private constructor(
 
             RuntimeEvent.entries.forEach { event ->
                 val observer = when (event) {
-                    is RuntimeEvent.DEBUG -> event.observer(tag) { event.notifyObservers(it) }
-                    is RuntimeEvent.ERROR -> event.observer(tag) { event.notifyObservers(it) }
-                    is RuntimeEvent.INFO -> event.observer(tag) { event.notifyObservers(it) }
-                    is RuntimeEvent.WARN -> event.observer(tag) { event.notifyObservers(it) }
+                    is RuntimeEvent.LOG -> event.observer(tag) { event.notifyObservers(it) }
                 }
                 add(observer)
             }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/AbstractRuntimeEventProcessorUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/AbstractRuntimeEventProcessorUnitTest.kt
@@ -33,7 +33,7 @@ class AbstractRuntimeEventProcessorUnitTest {
 
     @Test
     fun givenObserver_whenAddRemove_thenIsAsExpected() {
-        val observer = RuntimeEvent.DEBUG.observer {}
+        val observer = RuntimeEvent.LOG.DEBUG.observer {}
         processor.add(observer)
         assertEquals(1, processor.sizeRuntime)
         processor.add(observer)
@@ -45,41 +45,41 @@ class AbstractRuntimeEventProcessorUnitTest {
     @Test
     fun givenObservers_whenRemoveAllByEvent_thenAreRemoved() {
         var invocations = 0
-        val o1 = RuntimeEvent.DEBUG.observer { invocations++ }
-        val o2 = RuntimeEvent.INFO.observer {}
-        val o3 = RuntimeEvent.INFO.observer {}
+        val o1 = RuntimeEvent.LOG.DEBUG.observer { invocations++ }
+        val o2 = RuntimeEvent.LOG.INFO.observer {}
+        val o3 = RuntimeEvent.LOG.INFO.observer {}
         processor.add(o1, o2, o3, o3)
         assertEquals(3, processor.sizeRuntime)
 
-        processor.removeAll(RuntimeEvent.INFO)
+        processor.removeAll(RuntimeEvent.LOG.INFO)
         assertEquals(1, processor.sizeRuntime)
 
-        processor.notify(RuntimeEvent.DEBUG, "out")
+        processor.notify(RuntimeEvent.LOG.DEBUG, "out")
         assertEquals(1, invocations)
     }
 
     @Test
     fun givenObservers_whenRemoveMultiple_thenAreRemoved() {
         var invocations = 0
-        val o1 = RuntimeEvent.DEBUG.observer { invocations++ }
-        val o2 = RuntimeEvent.INFO.observer {}
-        val o3 = RuntimeEvent.INFO.observer {}
+        val o1 = RuntimeEvent.LOG.DEBUG.observer { invocations++ }
+        val o2 = RuntimeEvent.LOG.INFO.observer {}
+        val o3 = RuntimeEvent.LOG.INFO.observer {}
         processor.add(o1, o2, o3)
         assertEquals(3, processor.sizeRuntime)
 
         processor.remove(o2, o3)
         assertEquals(1, processor.sizeRuntime)
 
-        processor.notify(RuntimeEvent.DEBUG, "out")
+        processor.notify(RuntimeEvent.LOG.DEBUG, "out")
         assertEquals(1, invocations)
     }
 
     @Test
     fun givenTaggedObserver_whenRemoveByTag_thenAreRemoved() {
         var invocations = 0
-        val o1 = RuntimeEvent.DEBUG.observer("test1") { invocations++ }
-        val o2 = RuntimeEvent.INFO.observer("test2") {}
-        val o3 = RuntimeEvent.WARN.observer("test2") {}
+        val o1 = RuntimeEvent.LOG.DEBUG.observer("test1") { invocations++ }
+        val o2 = RuntimeEvent.LOG.INFO.observer("test2") {}
+        val o3 = RuntimeEvent.LOG.WARN.observer("test2") {}
         processor.add(o1, o1, o2, o2, o3, o3)
         assertEquals(3, processor.sizeRuntime)
 
@@ -87,20 +87,20 @@ class AbstractRuntimeEventProcessorUnitTest {
         assertEquals(1, processor.sizeRuntime)
 
         // Is the proper tagged observer removed
-        processor.notify(RuntimeEvent.DEBUG, "out")
+        processor.notify(RuntimeEvent.LOG.DEBUG, "out")
         assertEquals(1, invocations)
     }
 
     @Test
     fun givenBlankTag_whenObserver_thenTagIsNull() {
-        assertNull(RuntimeEvent.Observer("  ", RuntimeEvent.DEBUG) { }.tag)
+        assertNull(RuntimeEvent.Observer("  ", RuntimeEvent.LOG.DEBUG) { }.tag)
     }
 
     @Test
     fun givenStaticTag_whenRemove_thenDoesNothing() {
-        processor.add(RuntimeEvent.DEBUG.observer("static") {})
+        processor.add(RuntimeEvent.LOG.DEBUG.observer("static") {})
 
-        val nonStaticObserver = RuntimeEvent.DEBUG.observer("non-static") {}
+        val nonStaticObserver = RuntimeEvent.LOG.DEBUG.observer("non-static") {}
         processor.add(nonStaticObserver)
 
         // should do nothing
@@ -108,13 +108,13 @@ class AbstractRuntimeEventProcessorUnitTest {
         assertEquals(2, processor.sizeRuntime)
 
         // Should only remove the non-static observer
-        processor.removeAll(RuntimeEvent.DEBUG)
+        processor.removeAll(RuntimeEvent.LOG.DEBUG)
         assertEquals(1, processor.sizeRuntime)
 
         // Should only remove the non-static observer
         processor.add(nonStaticObserver)
         assertEquals(2, processor.sizeRuntime)
-        processor.removeAll(RuntimeEvent.DEBUG, RuntimeEvent.WARN)
+        processor.removeAll(RuntimeEvent.LOG.DEBUG, RuntimeEvent.LOG.WARN)
         assertEquals(1, processor.sizeRuntime)
 
         // Should not remove the static observer
@@ -126,7 +126,7 @@ class AbstractRuntimeEventProcessorUnitTest {
 
     @Test
     fun givenStaticObservers_whenOnDestroy_thenEvictsAll() {
-        val observer = RuntimeEvent.DEBUG.observer("static") {}
+        val observer = RuntimeEvent.LOG.DEBUG.observer("static") {}
         processor.add(observer)
         processor.add(TorEvent.BW.observer("static") {})
 

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorConfigGeneratorUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorConfigGeneratorUnitTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime
+
+import io.matthewnelson.kmp.file.absoluteFile
+import io.matthewnelson.kmp.file.resolve
+import io.matthewnelson.kmp.file.toFile
+import io.matthewnelson.kmp.tor.core.api.ResourceInstaller
+import io.matthewnelson.kmp.tor.core.api.ResourceInstaller.Paths
+import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.ThisBlock
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.TorConfig.Setting.Companion.filterByKeyword
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.IPAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port
+import io.matthewnelson.kmp.tor.runtime.ctrl.api.address.Port.Proxy.Companion.toPortProxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(InternalKmpTorApi::class)
+class TorConfigGeneratorUnitTest {
+
+    private val environment = "".toFile().absoluteFile.let { workDir ->
+        TorRuntime.Environment.Builder(workDir, workDir.resolve("cache")) { installationDir ->
+            object : ResourceInstaller<Paths.Tor>(installationDir) {
+                private val paths = Paths.Tor(
+                    geoip = installationDir.resolve("geoip"),
+                    geoip6 = installationDir.resolve("geoip6"),
+                    tor = installationDir.resolve("tor")
+                )
+
+                override fun install(): Paths.Tor = paths
+            }
+        }
+    }
+
+    private val notifier = object : RuntimeEvent.Notifier {
+        override fun <R : Any> notify(event: RuntimeEvent<R>, output: R) {}
+    }
+
+    @Test
+    fun givenGeoipOmission_whenGenerate_thenDoesNotContainSettings() {
+        val settings = newGenerator(omitGeoIPFileSettings = true).generate(notifier).settings
+        assertEquals(0, settings.filterByKeyword<TorConfig.GeoIPFile.Companion>().size)
+        assertEquals(0, settings.filterByKeyword<TorConfig.GeoIPv6File.Companion>().size)
+    }
+
+    @Test
+    fun givenGeoipNoOmission_whenGenerate_thenContainsSettings() {
+        with(newGenerator(omitGeoIPFileSettings = false).generate(notifier).settings) {
+            assertContains(TorConfig.GeoIPFile)
+            assertContains(TorConfig.GeoIPv6File)
+        }
+    }
+
+    @Test
+    fun givenMultipleUserConfigs_whenGenerate_thenAllAreApplied() {
+        var invocations = 0
+        newGenerator(
+            config = listOf(
+                ThisBlock.WithIt { _ -> invocations++ },
+                ThisBlock.WithIt { _ -> invocations++ },
+            )
+        ).generate(notifier)
+
+        assertEquals(2, invocations)
+    }
+
+    @Test
+    fun givenNoConfig_whenGenerate_thenMinimumSettingsApplied() {
+        with(newGenerator().generate(notifier).settings) {
+            assertContains(TorConfig.DataDirectory)
+            assertContains(TorConfig.CacheDirectory)
+            assertContains(TorConfig.ControlPortWriteToFile)
+            assertContains(TorConfig.CookieAuthFile)
+            assertContains(TorConfig.__SocksPort)
+            assertContains(TorConfig.__ControlPort)
+            assertContains(TorConfig.DisableNetwork)
+            assertContains(TorConfig.RunAsDaemon)
+            assertContains(TorConfig.__OwningControllerProcess)
+        }
+    }
+
+    @Test
+    fun givenUnavailablePort_whenGenerate_thenPortRemovedAndReplaced() {
+        // socks port at 9050 is automatically added
+        val settings = newGenerator(
+            allowPortReassignment = true,
+            config = listOf(
+                ThisBlock.WithIt {
+                    put(TorConfig.__DNSPort) { port(1080.toPortProxy()) }
+                }
+            ),
+            isPortAvailable = { _, _ -> false }
+        ).generate(notifier).settings
+
+        val socks = settings.filterByKeyword<TorConfig.__SocksPort.Companion>().first()
+        assertEquals("auto", socks.argument)
+        val dns = settings.filterByKeyword<TorConfig.__DNSPort.Companion>().first()
+        assertEquals("auto", dns.argument)
+    }
+
+    private inline fun <reified K: TorConfig.Keyword> Set<TorConfig.Setting>.assertContains(keyword: K) {
+        assertTrue(filterByKeyword<K>().isNotEmpty())
+    }
+
+    private fun newGenerator(
+        allowPortReassignment: Boolean = true,
+        omitGeoIPFileSettings: Boolean = false,
+        config: List<ThisBlock.WithIt<TorConfig.Builder, TorRuntime.Environment>> = emptyList(),
+        isPortAvailable: (IPAddress, Port) -> Boolean = { _, _ -> true },
+    ): TorConfigGenerator = TorConfigGenerator.of(
+        environment,
+        allowPortReassignment,
+        omitGeoIPFileSettings,
+        config,
+        isPortAvailable
+    )
+}


### PR DESCRIPTION
Closes #330 

Still some things to take care of for platform specific stuff. Will be breaking that out into separate issue tickets to handle. This just gets the bulk of the API and functionality set in place.