### PR TITLE
Fix `Processor` implementation potential deadlock

### DIFF
--- a/library/runtime-ctrl/api/runtime-ctrl.api
+++ b/library/runtime-ctrl/api/runtime-ctrl.api
@@ -7,12 +7,12 @@ public abstract class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProc
 	protected final fun isStaticTag (Ljava/lang/String;)Z
 	protected final fun notifyObservers (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent;Ljava/lang/String;)V
 	protected fun onDestroy ()V
+	protected fun registered ()I
 	public final fun remove (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent$Observer;)V
 	public final fun remove ([Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent$Observer;)V
 	public final fun removeAll (Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent;)V
 	public fun removeAll (Ljava/lang/String;)V
 	public final fun removeAll ([Lio/matthewnelson/kmp/tor/runtime/ctrl/api/TorEvent;)V
-	protected final fun withObservers (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 protected final class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor$Companion {

--- a/library/runtime-ctrl/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessorUnitTest.kt
+++ b/library/runtime-ctrl/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessorUnitTest.kt
@@ -23,7 +23,7 @@ import kotlin.test.*
 class AbstractTorEventProcessorUnitTest {
 
     private class TestProcessor: AbstractTorEventProcessor("static", emptySet()) {
-        val size: Int get() = withObservers { size }
+        val size: Int get() = registered()
         fun notify(event: TorEvent, output: String) { event.notifyObservers(output) }
         fun destroy() { onDestroy() }
         fun <T> noOpSet(): MutableSet<T> = noOpMutableSet()

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/NetworkObserver.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/NetworkObserver.kt
@@ -37,7 +37,7 @@ public abstract class NetworkObserver {
 
     @OptIn(InternalKmpTorApi::class)
     private val lock = SynchronizedObject()
-    private val observers = mutableSetOf<Observer>()
+    private val observers = LinkedHashSet<Observer>(1, 1.0F)
 
     internal fun interface Observer {
         operator fun invoke(connectivity: Connectivity)

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/AbstractRuntimeEventProcessorUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/AbstractRuntimeEventProcessorUnitTest.kt
@@ -22,8 +22,7 @@ import kotlin.test.*
 class AbstractRuntimeEventProcessorUnitTest {
 
     private class TestProcessor: AbstractRuntimeEventProcessor("static", emptySet(), emptySet()) {
-        val sizeRuntime: Int get() = withRuntimeObservers { size }
-        val sizeTor: Int get() = withObservers { size }
+        val size: Int get() = registered()
 
         fun <R: Any> notify(event: RuntimeEvent<R>, output: R) { event.notifyObservers(output) }
         fun destroy() { onDestroy() }
@@ -35,11 +34,11 @@ class AbstractRuntimeEventProcessorUnitTest {
     fun givenObserver_whenAddRemove_thenIsAsExpected() {
         val observer = RuntimeEvent.LOG.DEBUG.observer {}
         processor.add(observer)
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
         processor.add(observer)
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
         processor.remove(observer)
-        assertEquals(0, processor.sizeRuntime)
+        assertEquals(0, processor.size)
     }
 
     @Test
@@ -49,10 +48,10 @@ class AbstractRuntimeEventProcessorUnitTest {
         val o2 = RuntimeEvent.LOG.INFO.observer {}
         val o3 = RuntimeEvent.LOG.INFO.observer {}
         processor.add(o1, o2, o3, o3)
-        assertEquals(3, processor.sizeRuntime)
+        assertEquals(3, processor.size)
 
         processor.removeAll(RuntimeEvent.LOG.INFO)
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
 
         processor.notify(RuntimeEvent.LOG.DEBUG, "out")
         assertEquals(1, invocations)
@@ -65,10 +64,10 @@ class AbstractRuntimeEventProcessorUnitTest {
         val o2 = RuntimeEvent.LOG.INFO.observer {}
         val o3 = RuntimeEvent.LOG.INFO.observer {}
         processor.add(o1, o2, o3)
-        assertEquals(3, processor.sizeRuntime)
+        assertEquals(3, processor.size)
 
         processor.remove(o2, o3)
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
 
         processor.notify(RuntimeEvent.LOG.DEBUG, "out")
         assertEquals(1, invocations)
@@ -81,10 +80,10 @@ class AbstractRuntimeEventProcessorUnitTest {
         val o2 = RuntimeEvent.LOG.INFO.observer("test2") {}
         val o3 = RuntimeEvent.LOG.WARN.observer("test2") {}
         processor.add(o1, o1, o2, o2, o3, o3)
-        assertEquals(3, processor.sizeRuntime)
+        assertEquals(3, processor.size)
 
         processor.removeAll("test2")
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
 
         // Is the proper tagged observer removed
         processor.notify(RuntimeEvent.LOG.DEBUG, "out")
@@ -105,23 +104,23 @@ class AbstractRuntimeEventProcessorUnitTest {
 
         // should do nothing
         processor.removeAll("static")
-        assertEquals(2, processor.sizeRuntime)
+        assertEquals(2, processor.size)
 
         // Should only remove the non-static observer
         processor.removeAll(RuntimeEvent.LOG.DEBUG)
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
 
         // Should only remove the non-static observer
         processor.add(nonStaticObserver)
-        assertEquals(2, processor.sizeRuntime)
+        assertEquals(2, processor.size)
         processor.removeAll(RuntimeEvent.LOG.DEBUG, RuntimeEvent.LOG.WARN)
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
 
         // Should not remove the static observer
         processor.add(nonStaticObserver)
-        assertEquals(2, processor.sizeRuntime)
+        assertEquals(2, processor.size)
         processor.clearObservers()
-        assertEquals(1, processor.sizeRuntime)
+        assertEquals(1, processor.size)
     }
 
     @Test
@@ -131,15 +130,13 @@ class AbstractRuntimeEventProcessorUnitTest {
         processor.add(TorEvent.BW.observer("static") {})
 
         processor.clearObservers()
-        assertEquals(1, processor.sizeRuntime)
-        assertEquals(1, processor.sizeTor)
+        assertEquals(2, processor.size)
 
         // Should also clear out static TorEvent observers
         processor.destroy()
-        assertEquals(0, processor.sizeRuntime)
-        assertEquals(0, processor.sizeTor)
+        assertEquals(0, processor.size)
 
         processor.add(observer)
-        assertEquals(0, processor.sizeRuntime)
+        assertEquals(0, processor.size)
     }
 }


### PR DESCRIPTION
This PR fixes an issue with `AbstractTorEventProcessor` and `AbstractRuntimeEventProcessor`.

Inheritors of either could have potentially called `withObservers { add(TorEvent.BW.observer {} }` which would have caused a deadlock. This fix adds the `registered` function (needed for testing), and changes visibility of `withObservers` to `private`.