### PR TITLE
Fix double instance creation

### DIFF
--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeEnvironmentUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeEnvironmentUnitTest.kt
@@ -39,5 +39,25 @@ class TorRuntimeEnvironmentUnitTest {
 
         val env3 = TorRuntime.Environment.Builder(work.resolve("work"), work.resolve("cache")) { torResource }
         assertNotEquals(env1, env3)
+
+        val innerOuterWork = work.resolve("lambda")
+        var envInner: TorRuntime.Environment? = null
+        val envOuter = TorRuntime.Environment.Builder(
+            innerOuterWork,
+            innerOuterWork.resolve("outer"),
+            { torResource },
+        ) {
+            // Should be the expected instance
+            envInner = TorRuntime.Environment.Builder(
+                innerOuterWork,
+                innerOuterWork.resolve("inner"),
+                { torResource },
+            ) {
+
+            }
+        }
+
+        assertEquals(innerOuterWork.resolve("inner"), envInner?.cacheDir)
+        assertEquals(innerOuterWork.resolve("inner"), envOuter.cacheDir)
     }
 }


### PR DESCRIPTION
Fixes potential double instance creation for `TorRuntime` and `TorRuntime.Environment`, attributed to builder lambda being applied within the `getOrCreateInstance` lambda.