### PR TITLE
Pass `UncaughtException.Handler` as `CoroutineContext` to `OnEvent.Executor`

### DIFF
--- a/library/runtime-core/api/runtime-core.api
+++ b/library/runtime-core/api/runtime-core.api
@@ -32,18 +32,18 @@ public abstract interface class io/matthewnelson/kmp/tor/runtime/core/OnEvent : 
 }
 
 public abstract interface class io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor {
-	public abstract fun execute (Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
+	public abstract fun execute (Lkotlin/coroutines/CoroutineContext;Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor$Main : io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor {
 	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor$Main;
-	public fun execute (Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
+	public fun execute (Lkotlin/coroutines/CoroutineContext;Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor$Unconfined : io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor {
 	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor$Unconfined;
-	public fun execute (Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
+	public fun execute (Lkotlin/coroutines/CoroutineContext;Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -627,6 +627,7 @@ public class io/matthewnelson/kmp/tor/runtime/core/TorEvent$Observer {
 	public final field tag Ljava/lang/String;
 	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/TorEvent;Ljava/lang/String;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)V
 	public final fun notify (Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Ljava/lang/String;)V
+	public final fun notify (Lkotlin/coroutines/CoroutineContext;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Ljava/lang/String;)V
 	public final fun toString ()Ljava/lang/String;
 	public final fun toString (Z)Ljava/lang/String;
 }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/TorEvent.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/TorEvent.kt
@@ -17,6 +17,9 @@
 
 package io.matthewnelson.kmp.tor.runtime.core
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.jvm.JvmField
 
 /**
@@ -299,8 +302,21 @@ public enum class TorEvent {
          *   back to if [executor] was not defined for this observer.
          * */
         public fun notify(default: OnEvent.Executor, event: String) {
-            (executor ?: default).execute { onEvent(event) }
+            notify(EmptyCoroutineContext, default, event)
         }
+
+        /**
+         * Invokes [OnEvent] for the given [event] string
+         *
+         * @param [handler] Optional ability to pass [UncaughtException.Handler]
+         *   wrapped as [CoroutineExceptionHandler]
+         * @param [default] the default [OnEvent.Executor] to fall
+         *   back to if [executor] was not defined for this observer.
+         * */
+        public fun notify(handler: CoroutineContext, default: OnEvent.Executor, event: String) {
+            (executor ?: default).execute(handler) { onEvent(event) }
+        }
+
 
         public final override fun toString(): String = toString(isStatic = false)
 
@@ -309,7 +325,7 @@ public enum class TorEvent {
 
             append("TorEvent.Observer[tag=")
             append(tag.toString())
-            append(",event=")
+            append(", event=")
             append(event.name)
 
             when (executor) {
@@ -318,7 +334,7 @@ public enum class TorEvent {
                 OnEvent.Executor.Unconfined -> executor.toString()
                 else -> "Custom"
             }.let {
-                append(",executor=")
+                append(", executor=")
                 append(it)
             }
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/ExecutorMainInternal.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/ExecutorMainInternal.kt
@@ -22,5 +22,5 @@ import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import kotlin.coroutines.CoroutineContext
 
 internal expect object ExecutorMainInternal: OnEvent.Executor {
-    override fun execute(block: ItBlock<Unit>)
+    override fun execute(handler: CoroutineContext, block: ItBlock<Unit>)
 }

--- a/library/runtime-core/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/MainExecutorJvmUnitTest.kt
+++ b/library/runtime-core/src/jvmTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/MainExecutorJvmUnitTest.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
 import io.matthewnelson.kmp.tor.runtime.core.OnEvent
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -24,7 +25,7 @@ class MainExecutorJvmUnitTest {
     @Test
     fun givenExecute_whenNoDispatchersMain_thenThrowsException() {
         assertFailsWith<IllegalStateException> {
-            OnEvent.Executor.Main.execute {  }
+            OnEvent.Executor.Main.execute(EmptyCoroutineContext) {  }
         }
     }
 }

--- a/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-ExecutorMainInternal.kt
+++ b/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-ExecutorMainInternal.kt
@@ -21,12 +21,13 @@ import io.matthewnelson.kmp.tor.runtime.core.ItBlock
 import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Runnable
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 internal actual object ExecutorMainInternal: OnEvent.Executor {
 
-    actual override fun execute(block: ItBlock<Unit>) {
-        Main.dispatch(EmptyCoroutineContext, Runnable { block(Unit) })
+    actual override fun execute(handler: CoroutineContext, block: ItBlock<Unit>) {
+        Main.dispatch(handler, Runnable { block(Unit) })
     }
 
     private val Main by lazy {

--- a/library/runtime-ctrl/api/runtime-ctrl.api
+++ b/library/runtime-ctrl/api/runtime-ctrl.api
@@ -4,7 +4,7 @@ public abstract class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProc
 	protected final fun destroyed ()Z
 	protected fun getDebug ()Z
 	protected final fun getDefaultExecutor ()Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;
-	protected abstract fun getHandler ()Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;
+	protected abstract fun getHandler ()Lio/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor$HandlerWithContext;
 	protected final fun isStaticTag (Ljava/lang/String;)Z
 	protected final fun notifyObservers (Lio/matthewnelson/kmp/tor/runtime/core/TorEvent;Ljava/lang/String;)V
 	protected fun onDestroy ()Z
@@ -19,6 +19,24 @@ public abstract class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProc
 }
 
 protected final class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor$Companion {
+}
+
+protected final class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor$HandlerWithContext : kotlin/coroutines/AbstractCoroutineContextElement, io/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler, kotlinx/coroutines/CoroutineExceptionHandler {
+	public final field delegate Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;
+	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;)V
+	public fun handleException (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Throwable;)V
+	public fun invoke (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException;)V
+	public synthetic fun invoke (Ljava/lang/Object;)V
+}
+
+protected final class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor$ObserverNameContext : kotlin/coroutines/AbstractCoroutineContextElement {
+	public static final field Key Lio/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor$ObserverNameContext$Key;
+	public final field context Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/ctrl/AbstractTorEventProcessor$ObserverNameContext$Key : kotlin/coroutines/CoroutineContext$Key {
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/ctrl/TempTorCmdQueue : io/matthewnelson/kmp/tor/runtime/core/Destroyable, io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$Unprivileged$Processor {

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/AbstractTorCmdQueue.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/AbstractTorCmdQueue.kt
@@ -33,7 +33,7 @@ internal abstract class AbstractTorCmdQueue internal constructor(
     staticTag: String?,
     initialObservers: Set<TorEvent.Observer>,
     defaultExecutor: OnEvent.Executor,
-    protected final override val handler: UncaughtException.Handler,
+    handler: UncaughtException.Handler,
 ):  AbstractTorEventProcessor(staticTag, initialObservers, defaultExecutor),
     Destroyable,
     TorCmd.Privileged.Processor
@@ -45,6 +45,7 @@ internal abstract class AbstractTorCmdQueue internal constructor(
     @Volatile
     @Suppress("PropertyName")
     protected open var LOG: Debugger? = null
+    protected final override val handler: HandlerWithContext = HandlerWithContext(handler)
 
     public final override fun isDestroyed(): Boolean = destroyed
 

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
@@ -141,7 +141,7 @@ internal class RealTorCtrl private constructor(
                 LOG = null
             }
         } finally {
-            (handler as CloseableExceptionHandler).close()
+            (handler.delegate as CloseableExceptionHandler).close()
         }
 
         return true

--- a/library/runtime-mobile/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/runtime/mobile/OnEventExecutorMainTest.kt
+++ b/library/runtime-mobile/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/runtime/mobile/OnEventExecutorMainTest.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.tor.runtime.mobile
 import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -26,7 +27,7 @@ class OnEventExecutorMainTest {
     @Test
     fun givenAndroid_whenExecutorMain_thenUsesDispatchersImmediate() = runTest {
         val job = Job()
-        OnEvent.Executor.Main.execute { job.complete() }
+        OnEvent.Executor.Main.execute(EmptyCoroutineContext) { job.complete() }
         job.join()
         assertTrue(job.isCompleted)
     }

--- a/library/runtime/api/runtime.api
+++ b/library/runtime/api/runtime.api
@@ -92,6 +92,7 @@ public class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$Observer {
 	public final field tag Ljava/lang/String;
 	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent;Ljava/lang/String;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)V
 	public final fun notify (Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Ljava/lang/Object;)V
+	public final fun notify (Lkotlin/coroutines/CoroutineContext;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Ljava/lang/Object;)V
 	public final fun toString ()Ljava/lang/String;
 	public final fun toString (Z)Ljava/lang/String;
 }
@@ -124,7 +125,9 @@ public final class io/matthewnelson/kmp/tor/runtime/TorRuntime$Builder {
 	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Environment;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun config (Lio/matthewnelson/kmp/tor/runtime/ConfigBuilderCallback;)Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Builder;
 	public final fun required (Lio/matthewnelson/kmp/tor/runtime/core/TorEvent;)Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Builder;
+	public final fun staticObserver (Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Builder;
 	public final fun staticObserver (Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Builder;
+	public final fun staticObserver (Lio/matthewnelson/kmp/tor/runtime/core/TorEvent;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Builder;
 	public final fun staticObserver (Lio/matthewnelson/kmp/tor/runtime/core/TorEvent;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)Lio/matthewnelson/kmp/tor/runtime/TorRuntime$Builder;
 }
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -169,8 +169,20 @@ public interface TorRuntime:
         public fun staticObserver(
             event: TorEvent,
             onEvent: OnEvent<String>,
+        ): Builder = staticObserver(event, null, onEvent)
+
+        /**
+         * Add [TorEvent.Observer] which will never be removed from [TorRuntime].
+         *
+         * Useful for logging purposes.
+         * */
+        @KmpTorDsl
+        public fun staticObserver(
+            event: TorEvent,
+            executor: OnEvent.Executor?,
+            onEvent: OnEvent<String>,
         ): Builder {
-            val observer = event.observer(environment.staticObserverTag, onEvent)
+            val observer = TorEvent.Observer(event, environment.staticObserverTag, executor, onEvent)
             staticTorEventObservers.add(observer)
             return this
         }
@@ -184,8 +196,20 @@ public interface TorRuntime:
         public fun <R: Any> staticObserver(
             event: RuntimeEvent<R>,
             onEvent: OnEvent<R>,
+        ): Builder = staticObserver(event, null, onEvent)
+
+        /**
+         * Add [RuntimeEvent.Observer] which will never be removed from [TorRuntime].
+         *
+         * Useful for logging purposes.
+         * */
+        @KmpTorDsl
+        public fun <R: Any> staticObserver(
+            event: RuntimeEvent<R>,
+            executor: OnEvent.Executor?,
+            onEvent: OnEvent<R>,
         ): Builder {
-            val observer = event.observer(environment.staticObserverTag, onEvent)
+            val observer = RuntimeEvent.Observer(event, environment.staticObserverTag, executor, onEvent)
             staticRuntimeEventObservers.add(observer)
             return this
         }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessorUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessorUnitTest.kt
@@ -237,6 +237,5 @@ class AbstractRuntimeEventProcessorUnitTest {
         assertEquals(0, invocationEvent)
         assertIs<UncaughtException>(exceptions.first())
         assertTrue(exceptions.first().message!!.contains(expectedTag))
-        exceptions.first().printStackTrace()
     }
 }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessorUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessorUnitTest.kt
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.runtime
+package io.matthewnelson.kmp.tor.runtime.internal
 
+import io.matthewnelson.kmp.tor.runtime.RuntimeEvent
 import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import io.matthewnelson.kmp.tor.runtime.core.TorEvent
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException
-import io.matthewnelson.kmp.tor.runtime.internal.AbstractRuntimeEventProcessor
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
 class AbstractRuntimeEventProcessorUnitTest {
@@ -207,5 +212,31 @@ class AbstractRuntimeEventProcessorUnitTest {
         processor._debug = true
         processor.notify(observer.event, "")
         assertEquals(2, invocations)
+    }
+
+    @Test
+    fun givenHandler_whenPassedAsCoroutineContext_thenObserverNameContextIsPassed() = runTest {
+        val exceptions = mutableListOf<Throwable>()
+
+        val expectedTag = "Expected Tag"
+        var invocationEvent = 0
+        val latch = Job()
+        processor.subscribe(RuntimeEvent.LOG.ERROR.observer { exceptions.add(it); fail() })
+        processor.subscribe(RuntimeEvent.LOG.DEBUG.observer(
+            tag = expectedTag,
+            executor = { handler, _ ->
+                @OptIn(DelicateCoroutinesApi::class)
+                GlobalScope.launch(handler) { throw IllegalStateException() }
+                    .invokeOnCompletion { latch.cancel() }
+            },
+            onEvent = { invocationEvent++ }
+        ))
+        processor.notify(RuntimeEvent.LOG.DEBUG, "")
+        latch.join()
+        assertEquals(1, exceptions.size)
+        assertEquals(0, invocationEvent)
+        assertIs<UncaughtException>(exceptions.first())
+        assertTrue(exceptions.first().message!!.contains(expectedTag))
+        exceptions.first().printStackTrace()
     }
 }


### PR DESCRIPTION
This PR adds to the `OnEvent.Executor.execute` function another parameter, `CoroutineContext`, in order to pass the `UncaughtException.Handler` for piping any exceptions when using with coroutines.