### PR TITLE
Fix `Js` implementation for checking port availability

### DIFF
--- a/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtilBaseTest.kt
+++ b/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtilBaseTest.kt
@@ -54,9 +54,16 @@ abstract class PortUtilBaseTest {
 
     @Test
     fun givenFindAvailable_whenCoroutineCancelled_thenHandlesCancellationProperly() = runTest(timeout = 120.seconds) {
+        if (isNodeJs) {
+            // Only needed to test blocking code to ensure
+            // context is checked to trigger cancellation
+            println("Skipping...")
+            return@runTest
+        }
+
         val port = Port.Proxy.MIN.toPortProxy()
         val host = LocalHost.IPv4
-        val limit = if (isNodeJs) 250 else 750
+        val limit = 750
         val i = port.iterator(limit)
 
         var count = 0

--- a/library/runtime-core/src/jsTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtilJsUnitTest.kt
+++ b/library/runtime-core/src/jsTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtilJsUnitTest.kt
@@ -34,7 +34,7 @@ class PortUtilJsUnitTest: PortUtilBaseTest() {
         port: Int,
     ): AutoCloseable {
         val server = net_createServer { it.destroy(); Unit }
-        server.onError { err -> fail(err.toString()) }
+        server.onError { err -> fail("$err") }
         val options = js("{}")
         options["port"] = port
         options["host"] = ipAddress.value


### PR DESCRIPTION
Availability no longer throws exception on timeout, simply returns `false`

Was way to unreliable in terms of `Node.js` being inconsistent when opening server sockets.