### PR TITLE
Fix `CtrlConnection` native write functionality

### DIFF
--- a/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -214,8 +214,8 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
             val connection = object : CtrlConnection {
                 // @Throws(CancellationException::class, IllegalStateException::class)
                 override suspend fun startRead(parser: CtrlConnection.Parser) {
-                    if (socket.destroyed) throw IllegalStateException("Socket is destroyed")
-                    if (connParser != null) throw IllegalStateException("Already reading input")
+                    check(!socket.destroyed) { "Socket is destroyed" }
+                    check(connParser == null) { "Already reading input" }
 
                     val latch = Job(currentCoroutineContext().job)
                     connParser = Pair(parser, latch)

--- a/library/runtime-ctrl/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/NativeCtrlConnection.kt
+++ b/library/runtime-ctrl/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/NativeCtrlConnection.kt
@@ -44,8 +44,8 @@ internal class NativeCtrlConnection internal constructor(
     @Throws(CancellationException::class, IllegalStateException::class)
     override suspend fun startRead(parser: CtrlConnection.Parser) {
         synchronized(lock) {
-            if (_isClosed) throw IllegalStateException("Connection is closed")
-            if (_isReading) throw IllegalStateException("Already reading input")
+            check(!_isClosed) { "Connection is closed" }
+            check(!_isReading) { "Already reading input" }
             _isReading = true
         }
 
@@ -81,11 +81,10 @@ internal class NativeCtrlConnection internal constructor(
             command.usePinned { pinned ->
                 var written = 0
                 while (written < command.size) {
-                    val write = send(
+                    val write = write(
                         descriptor,
-                        pinned.addressOf(0),
-                        command.size.convert(),
-                        0,
+                        pinned.addressOf(written),
+                        (command.size - written).convert(),
                     ).toInt()
 
                     if (write == 0) break

--- a/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -198,6 +198,7 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
                 callsInPlace(connect, InvocationKind.EXACTLY_ONCE)
             }
 
+            // TODO: CloseableCoroutineDispatcher ???
             val dispatcher = Dispatchers.IO
 
             val connection = try {


### PR DESCRIPTION
This PR fixes some overlooked functionality for native implementation of `CtrlConnection.write` when the entire array is not written to the stream.