### PR TITLE
Create fixed thread pool instead of using `Dispatchers.IO` for `TorCtrl`

### DIFF
--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
@@ -19,6 +19,7 @@ import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.resource.SynchronizedObject
 import io.matthewnelson.kmp.tor.core.resource.synchronized
+import io.matthewnelson.kmp.tor.runtime.core.Disposable
 import io.matthewnelson.kmp.tor.runtime.core.TorEvent
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
@@ -35,6 +36,7 @@ import kotlin.time.Duration.Companion.milliseconds
 internal class RealTorCtrl private constructor(
     factory: TorCtrl.Factory,
     dispatcher: CoroutineDispatcher,
+    private val disposeDispatcher: Disposable,
     private val connection: CtrlConnection,
 ): AbstractTorCtrl(
     factory.staticTag,
@@ -142,6 +144,7 @@ internal class RealTorCtrl private constructor(
             }
         } finally {
             (handler.delegate as CloseableExceptionHandler).close()
+            disposeDispatcher.invoke()
         }
 
         return true
@@ -276,10 +279,12 @@ internal class RealTorCtrl private constructor(
         internal fun of(
             factory: TorCtrl.Factory,
             dispatcher: CoroutineDispatcher,
+            disposeDispatcher: Disposable,
             connection: CtrlConnection,
         ): RealTorCtrl = RealTorCtrl(
             factory,
             dispatcher,
+            disposeDispatcher,
             connection,
         )
     }

--- a/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -271,7 +271,7 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
                 override fun close() { socket.destroy() }
             }
 
-            val ctrl = RealTorCtrl.of(this, Dispatchers.Main, connection)
+            val ctrl = RealTorCtrl.of(this, Dispatchers.Main, Disposable.NOOP, connection)
 
             try {
                 // A slight delay is needed before returning in order

--- a/library/runtime-ctrl/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/NativePlatform.kt
+++ b/library/runtime-ctrl/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/NativePlatform.kt
@@ -21,8 +21,17 @@ import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.file.errnoToIOException
 import io.matthewnelson.kmp.tor.runtime.core.address.IPAddress
 import io.matthewnelson.kmp.tor.runtime.core.address.ProxyAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
 import kotlinx.cinterop.*
+import kotlinx.coroutines.CloseableCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newFixedThreadPoolContext
 import platform.posix.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal actual fun TorCtrl.Factory.newTorCtrlDispatcher(): CloseableCoroutineDispatcher {
+    return newFixedThreadPoolContext(2, "TorCtrl")
+}
 
 @Throws(Throwable::class)
 @OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)

--- a/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -27,6 +27,7 @@ import io.matthewnelson.kmp.tor.runtime.core.*
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.requireInstanceIsNotSuppressed
 import io.matthewnelson.kmp.tor.runtime.core.address.ProxyAddress
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
+import io.matthewnelson.kmp.tor.runtime.ctrl.internal.*
 import io.matthewnelson.kmp.tor.runtime.ctrl.internal.CtrlConnection
 import io.matthewnelson.kmp.tor.runtime.ctrl.internal.RealTorCtrl
 import io.matthewnelson.kmp.tor.runtime.ctrl.internal.checkUnixSockedSupport
@@ -190,7 +191,7 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
 
         @Throws(IOException::class)
         @Suppress("NOTHING_TO_INLINE")
-        @OptIn(ExperimentalContracts::class)
+        @OptIn(ExperimentalContracts::class, ExperimentalCoroutinesApi::class)
         private inline fun connect(
             connect: (context: CoroutineContext) -> CtrlConnection,
         ): TorCtrl {
@@ -198,16 +199,16 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
                 callsInPlace(connect, InvocationKind.EXACTLY_ONCE)
             }
 
-            // TODO: CloseableCoroutineDispatcher ???
-            val dispatcher = Dispatchers.IO
+            val dispatcher = newTorCtrlDispatcher()
 
             val connection = try {
                 connect(dispatcher)
             } catch (t: Throwable) {
+                dispatcher.close()
                 throw t.wrapIOException()
             }
 
-            return RealTorCtrl.of(this, dispatcher, connection)
+            return RealTorCtrl.of(this, dispatcher, Disposable(dispatcher::close), connection)
         }
 
         /**

--- a/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-NonJsPlatform.kt
+++ b/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-NonJsPlatform.kt
@@ -17,6 +17,12 @@ package io.matthewnelson.kmp.tor.runtime.ctrl.internal
 
 import io.matthewnelson.kmp.file.File
 import io.matthewnelson.kmp.tor.runtime.core.address.ProxyAddress
+import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
+import kotlinx.coroutines.CloseableCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal expect fun TorCtrl.Factory.newTorCtrlDispatcher(): CloseableCoroutineDispatcher
 
 @Throws(Throwable::class)
 internal expect fun ProxyAddress.connect(): CtrlConnection


### PR DESCRIPTION
Closes #362 