### PR TITLE
Add check for other tor process

### DIFF
--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/Lifecycle.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/Lifecycle.kt
@@ -76,24 +76,26 @@ public class Lifecycle: Destroyable {
             @JvmStatic
             public fun OnCreate(obj: Any): Event = Event(obj, Name.OnCreate)
             @JvmStatic
-            public fun OnDestroy(obj: Any): Event = Event(obj, Name.OnDestroy)
-
-            // TorRuntime.ServiceFactory LCEs
-            @JvmStatic
             public fun OnStart(obj: Any): Event = Event(obj, Name.OnStart)
             @JvmStatic
-            public fun OnBind(obj: Any): Event = Event(obj, Name.OnBind)
-            @JvmStatic
-            public fun OnUnbind(obj: Any): Event = Event(obj, Name.OnUnbind)
-            @JvmStatic
-            public fun OnRemoved(obj: Any): Event = Event(obj, Name.OnRemoved)
-            @JvmStatic
-            public fun OnReturned(obj: Any): Event = Event(obj, Name.OnReturned)
+            public fun OnDestroy(obj: Any): Event = Event(obj, Name.OnDestroy)
 
             @JvmStatic
             public fun OnSubscribed(obj: Any): Event = Event(obj, Name.OnSubscribed)
             @JvmStatic
             public fun OnUnsubscribed(obj: Any): Event = Event(obj, Name.OnUnsubscribed)
+
+            // TorRuntime.ServiceFactory LCEs
+            @JvmStatic
+            public fun OnBind(obj: Any): Event = Event(obj, Name.OnBind)
+            @JvmStatic
+            public fun OnUnbind(obj: Any): Event = Event(obj, Name.OnUnbind)
+
+            // Android TorService LCEs
+            @JvmStatic
+            public fun OnRemoved(obj: Any): Event = Event(obj, Name.OnRemoved)
+            @JvmStatic
+            public fun OnReturned(obj: Any): Event = Event(obj, Name.OnReturned)
         }
 
         public class Name private constructor(private val value: String) {
@@ -103,24 +105,26 @@ public class Lifecycle: Destroyable {
                 @JvmField
                 public val OnCreate: Name = Name("onCreate")
                 @JvmField
-                public val OnDestroy: Name = Name("onDestroy")
-
-                // TorRuntime.ServiceFactory LCEs
-                @JvmField
                 public val OnStart: Name = Name("onStart")
                 @JvmField
-                public val OnBind: Name = Name("onBind")
-                @JvmField
-                public val OnUnbind: Name = Name("onUnbind")
-                @JvmField
-                public val OnRemoved: Name = Name("onRemoved")
-                @JvmField
-                public val OnReturned: Name = Name("onReturned")
+                public val OnDestroy: Name = Name("onDestroy")
 
                 @JvmField
                 public val OnSubscribed: Name = Name("onSubscribed")
                 @JvmField
                 public val OnUnsubscribed: Name = Name("onUnsubscribed")
+
+                // TorRuntime.ServiceFactory LCEs
+                @JvmField
+                public val OnBind: Name = Name("onBind")
+                @JvmField
+                public val OnUnbind: Name = Name("onUnbind")
+
+                // Android TorService LCEs
+                @JvmField
+                public val OnRemoved: Name = Name("onRemoved")
+                @JvmField
+                public val OnReturned: Name = Name("onReturned")
             }
 
             override fun equals(other: Any?): Boolean = other is Name && other.value == value

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorProcess.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorProcess.kt
@@ -325,7 +325,7 @@ internal class TorProcess private constructor(
 
         private fun String.parseForError() {
             when {
-                contains(" [err] ") -> {}
+                contains(PROCESS_ERR) || contains(PROCESS_OTHER) -> {}
                 else -> return
             }
 
@@ -482,5 +482,8 @@ internal class TorProcess private constructor(
             @Volatile
             var stopMark: TimeSource.Monotonic.ValueTimeMark? = null
         }
+
+        private const val PROCESS_ERR: String = " [err] "
+        private const val PROCESS_OTHER: String = " [warn] It looks like another Tor process is running with the same data directory."
     }
 }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorProcess.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorProcess.kt
@@ -123,13 +123,13 @@ internal class TorProcess private constructor(
         job.cancelAndJoin()
         delay(ensureFinally)
 
-        // Need to ensure there is at least 350ms between last
+        // Need to ensure there is at least 500ms between last
         // process' stop, and this process' start for TorProcess
         val lastStop = stopMark ?: return
 
         var wasNotified = false
         while (true) {
-            val duration = 350.milliseconds - lastStop.elapsedNow()
+            val duration = 500.milliseconds - lastStop.elapsedNow()
             if (duration < 1.milliseconds) break
 
             if (!wasNotified) {
@@ -146,9 +146,7 @@ internal class TorProcess private constructor(
     }
 
     @Throws(Throwable::class)
-    private suspend fun StartArgs.spawnProcess(
-        paths: ResourceInstaller.Paths.Tor
-    ): Pair<StdoutFeed, Job> {
+    private suspend fun StartArgs.spawnProcess(paths: ResourceInstaller.Paths.Tor): Pair<StdoutFeed, Job> {
         val process = try {
             Process.Builder(command = paths.tor.path)
                 .args(cmdLine)


### PR DESCRIPTION
This PR adds a check for initial process startup for stdout warning indicating that another process is currently running with the same data directory.