### PR TITLE
Refactor `TorProcess`

### DIFF
--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
@@ -21,7 +21,7 @@ import io.matthewnelson.kmp.process.Process
 import io.matthewnelson.kmp.process.Stdio
 import io.matthewnelson.kmp.tor.runtime.core.*
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
-import io.matthewnelson.kmp.tor.runtime.internal.TorProcess
+import io.matthewnelson.kmp.tor.runtime.internal.process.TorDaemon
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -128,20 +128,20 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
      *
      *     Lifecycle.Event[obj=RealTorRuntime[fid=6E96…6985]@1625090026, name=onCreate]
      *     StartJob[name=StartDaemon, state=Executing]@1652817137
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@158078174, name=onCreate]
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@158078174, name=onStart]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@158078174, name=onCreate]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@158078174, name=onStart]
      *     Lifecycle.Event[obj=RealTorCtrl[fid=6E96…6985]@1682130731, name=onCreate]
      *     RestartJob[name=RestartDaemon, state=Executing]@1830373812
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@85303615, name=onCreate]
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@158078174, name=onStop]
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@158078174, name=onDestroy]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@85303615, name=onCreate]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@158078174, name=onStop]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@158078174, name=onDestroy]
      *     Lifecycle.Event[obj=RealTorCtrl[fid=6E96…6985]@1682130731, name=onDestroy]
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@85303615, name=onStart]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@85303615, name=onStart]
      *     Lifecycle.Event[obj=RealTorCtrl[fid=6E96…6985]@1241844104, name=onCreate]
      *     StopJob[name=StopDaemon, state=Executing]@560446930
      *     Lifecycle.Event[obj=RealTorCtrl[fid=6E96…6985]@1241844104, name=onDestroy]
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@85303615, name=onStop]
-     *     Lifecycle.Event[obj=TorProcess[fid=6E96…6985]@85303615, name=onDestroy]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@85303615, name=onStop]
+     *     Lifecycle.Event[obj=TorDaemon[fid=6E96…6985]@85303615, name=onDestroy]
      *
      * @see [Lifecycle.Event]
      * */
@@ -492,12 +492,12 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
             }
 
             @JvmSynthetic
-            internal fun Notifier.stdout(from: TorProcess, line: String) {
+            internal fun Notifier.stdout(from: TorDaemon, line: String) {
                 notify(PROCESS.STDOUT, from.appendLog(line))
             }
 
             @JvmSynthetic
-            internal fun Notifier.stderr(from: TorProcess, line: String) {
+            internal fun Notifier.stderr(from: TorDaemon, line: String) {
                 notify(PROCESS.STDERR, from.appendLog(line))
             }
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -457,6 +457,11 @@ public interface TorRuntime:
             @ExperimentalKmpTorApi
             public val processEnv: LinkedHashMap<String, String> = LinkedHashMap(1, 1.0F)
 
+            init {
+                @OptIn(ExperimentalKmpTorApi::class)
+                processEnv["HOME"] = workDirectory.path
+            }
+
             /**
              * Experimental support for running tor as a service. Currently
              * only Android support is available via the `runtime-service`
@@ -485,6 +490,8 @@ public interface TorRuntime:
 
                     @OptIn(ExperimentalKmpTorApi::class)
                     return getOrCreateInstance(key = b.workDirectory, block = {
+
+                        // Always reset, just in case it was overridden
                         b.processEnv["HOME"] = b.workDirectory.path
 
                         Environment(

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
@@ -43,6 +43,7 @@ import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
 import io.matthewnelson.kmp.tor.runtime.internal.observer.ObserverConfChanged
 import io.matthewnelson.kmp.tor.runtime.internal.observer.ObserverConnectivity
 import io.matthewnelson.kmp.tor.runtime.internal.observer.ObserverProcessStdout
+import io.matthewnelson.kmp.tor.runtime.internal.process.TorDaemon
 import kotlinx.coroutines.*
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.cancellation.CancellationException
@@ -567,7 +568,7 @@ internal class RealTorRuntime private constructor(
                 return
             }
 
-            TorProcess.start(generator, manager, NOTIFIER, scope, ::checkInterrupt, connect = {
+            TorDaemon.start(generator, manager, NOTIFIER, scope, ::checkInterrupt, connect = {
                 val ctrl = connection.openWith(factory)
 
                 val lceCtrl = RealTorCtrl(ctrl)

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
@@ -40,6 +40,9 @@ import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
 import io.matthewnelson.kmp.tor.runtime.ctrl.TempTorCmdQueue
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCmdInterceptor
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
+import io.matthewnelson.kmp.tor.runtime.internal.observer.ObserverConfChanged
+import io.matthewnelson.kmp.tor.runtime.internal.observer.ObserverConnectivity
+import io.matthewnelson.kmp.tor.runtime.internal.observer.ObserverProcessStdout
 import kotlinx.coroutines.*
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.cancellation.CancellationException

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConfChanged.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConfChanged.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.runtime.internal
+package io.matthewnelson.kmp.tor.runtime.internal.observer
 
 import io.matthewnelson.kmp.tor.runtime.TorListeners
 import io.matthewnelson.kmp.tor.runtime.TorState

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConnectivity.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConnectivity.kt
@@ -15,7 +15,7 @@
  **/
 @file:Suppress("PrivatePropertyName")
 
-package io.matthewnelson.kmp.tor.runtime.internal
+package io.matthewnelson.kmp.tor.runtime.internal.observer
 
 import io.matthewnelson.kmp.file.InterruptedException
 import io.matthewnelson.kmp.tor.runtime.Lifecycle
@@ -29,6 +29,7 @@ import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import io.matthewnelson.kmp.tor.runtime.core.TorConfig
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
+import io.matthewnelson.kmp.tor.runtime.internal.timedDelay
 import kotlinx.coroutines.*
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.cancellation.CancellationException

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverProcessStdout.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverProcessStdout.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.runtime.internal
+package io.matthewnelson.kmp.tor.runtime.internal.observer
 
 import io.matthewnelson.kmp.tor.runtime.TorListeners
 import io.matthewnelson.kmp.tor.runtime.TorState

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/ProcessStartException.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/ProcessStartException.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.internal.process
+
+import io.matthewnelson.kmp.file.IOException
+
+internal class ProcessStartException(override val message: String): IOException(message)

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParser.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParser.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.internal.process
+
+import io.matthewnelson.kmp.process.OutputFeed
+import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.core.resource.SynchronizedObject
+import io.matthewnelson.kmp.tor.core.resource.synchronized
+import kotlin.concurrent.Volatile
+
+@OptIn(InternalKmpTorApi::class)
+internal class StartupFeedParser(private val lineLimit: Int = 50, private val exitCode: () -> Int?) {
+
+    @Volatile
+    private var _isReady: Boolean = false
+    @Volatile
+    private var _lines = 0
+    @Volatile
+    private var _error: ProcessStartException? = null
+    @Volatile
+    private var _stdout: StringBuilder? = StringBuilder()
+    @Volatile
+    private var _stderr: StringBuilder? = StringBuilder()
+
+    private val lock = SynchronizedObject()
+
+    internal val isClosed: Boolean get() = _stdout == null
+    internal val isReady: Boolean get() = _isReady
+
+    internal val stderr = OutputFeed { line ->
+        val stderr = _stderr ?: return@OutputFeed
+        if (line == null) return@OutputFeed
+        stderr.appendLine(line, generateError = false)
+    }
+
+    internal val stdout = OutputFeed { line ->
+        val sb = _stdout ?: return@OutputFeed
+
+        if (_lines >= lineLimit) {
+            if (!_isReady && _error == null) {
+                // Feed is not closed, nor has tor has output
+                // control connection info within the first
+                // {lineLimit} lines... something is wrong.
+                @Suppress("ThrowableNotThrown")
+                createError("Process has output $lineLimit lines without informing us of a control listener yet")
+            }
+            return@OutputFeed
+        }
+
+        _lines++
+
+        if (line == null) {
+            @Suppress("ThrowableNotThrown")
+            createError("Process exited unexpectedly")
+            return@OutputFeed
+        }
+
+        if (!_isReady) {
+            if (line.contains(CHECK_READY, ignoreCase = true)) {
+                _isReady = true
+            }
+        }
+
+        sb.appendLine(
+            line,
+            generateError =
+                line.contains(CHECK_ERR)
+                || line.contains(CHECK_ANOTHER)
+        )
+    }
+
+    fun close() {
+        if (_stdout == null && _stderr == null) return
+
+        synchronized(lock) {
+            val stdout = _stdout ?: return
+            val stderr = _stderr ?: return
+            _stdout = null
+            _stderr = null
+
+            listOf(stdout, stderr).forEach { sb ->
+                val count = sb.count()
+                sb.clear()
+                repeat(count) { sb.append(' ') }
+            }
+        }
+    }
+
+    @Throws(ProcessStartException::class)
+    fun checkError() { _error?.let { t -> throw t } }
+
+    fun createError(message: String): ProcessStartException {
+        return NULL.appendLine(message, generateError = true)!!
+    }
+
+    private fun StringBuilder?.appendLine(
+        line: String,
+        generateError: Boolean
+    ): ProcessStartException? = synchronized(lock) {
+        if (!generateError) {
+            if (this != null) {
+                if (isNotEmpty()) appendLine()
+                append(line)
+            }
+            return@synchronized null
+        }
+
+        // Generate error
+        val stdout = _stdout?.toString() ?: ""
+        val stderr = _stderr?.toString() ?: ""
+        val code = exitCode()?.toString() ?: "not exited"
+
+        // append to current StringBuilder after calling
+        // toString on both (above) so that if another
+        // error is generated, that line will be present
+        if (this != null) {
+            if (isNotEmpty()) appendLine()
+            append(line)
+        }
+
+        val message = StringBuilder(stdout.length + stderr.length + 100)
+            .appendLine("Process Failure: [")
+            .append("    exitCode: ")
+            .appendLine(code)
+            .append("    cause: ")
+            .appendLine(line)
+            .append("    stdout: [")
+            .appendMultiLine(stdout)
+            .append("    stderr: [")
+            .appendMultiLine(stderr)
+            .append(']')
+            .toString()
+
+        ProcessStartException(message).also { _error = it }
+    }
+
+    private fun StringBuilder.appendMultiLine(lines: String): StringBuilder {
+        if (lines.isBlank()) {
+            appendLine(']')
+            return this
+        }
+
+        for (l in lines.lines()) {
+            appendLine()
+            append("        ")
+            append(l)
+        }
+
+        appendLine()
+        appendLine("    ]")
+        return this
+    }
+
+    private companion object {
+        private const val CHECK_ANOTHER = " [warn] It looks like another Tor process is running with the same data directory."
+        private const val CHECK_ERR = " [err] "
+        private const val CHECK_READY = " [notice] Opened Control listener connection (ready) on "
+
+        private val NULL: StringBuilder? = null
+    }
+}

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParser.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParser.kt
@@ -77,8 +77,8 @@ internal class StartupFeedParser(private val lineLimit: Int = 50, private val ex
         sb.appendLine(
             line,
             generateError =
-                line.contains(CHECK_ERR)
-                || line.contains(CHECK_ANOTHER)
+                line.contains(CHECK_ERR, ignoreCase = true)
+                || line.contains(CHECK_ANOTHER, ignoreCase = true)
         )
     }
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/TorDaemon.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/TorDaemon.kt
@@ -148,7 +148,7 @@ internal class TorDaemon private constructor(
         // process' stop, and this process' start for TorDaemon
         val lastStop = stopMark ?: return
 
-        val delayTime = 1_000.milliseconds
+        val delayTime = 500.milliseconds
         val delayIncrement = 100.milliseconds
         val start = TimeSource.Monotonic.markNow()
         var remainder = delayTime - lastStop.elapsedNow()

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/ServiceFactoryUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/ServiceFactoryUnitTest.kt
@@ -264,11 +264,11 @@ class ServiceFactoryUnitTest {
         synchronized(lock) {
             lces.assertContains("RealTorRuntime", Lifecycle.Event.Name.OnCreate, fid = factory)
             lces.assertContains("DestroyableTorRuntime", Lifecycle.Event.Name.OnCreate, fid = factory)
-            lces.assertContains("TorProcess", Lifecycle.Event.Name.OnCreate, fid = factory)
-            lces.assertContains("TorProcess", Lifecycle.Event.Name.OnStart, fid = factory)
+            lces.assertContains("TorDaemon", Lifecycle.Event.Name.OnCreate, fid = factory)
+            lces.assertContains("TorDaemon", Lifecycle.Event.Name.OnStart, fid = factory)
             lces.assertContains("RealTorCtrl", Lifecycle.Event.Name.OnCreate, fid = factory)
 
-            lces.assertDoesNotContain("TorProcess", Lifecycle.Event.Name.OnDestroy, fid = factory)
+            lces.assertDoesNotContain("TorDaemon", Lifecycle.Event.Name.OnDestroy, fid = factory)
             lces.assertDoesNotContain("RealTorCtrl", Lifecycle.Event.Name.OnDestroy, fid = factory)
             lces.clear()
         }
@@ -284,12 +284,12 @@ class ServiceFactoryUnitTest {
 
         synchronized(lock) {
             // Old process stopped
-            lces.assertContains("TorProcess", Lifecycle.Event.Name.OnDestroy, fid = factory)
+            lces.assertContains("TorDaemon", Lifecycle.Event.Name.OnDestroy, fid = factory)
             lces.assertContains("RealTorCtrl", Lifecycle.Event.Name.OnDestroy, fid = factory)
 
             // New process started
-            lces.assertContains("TorProcess", Lifecycle.Event.Name.OnCreate, fid = factory)
-            lces.assertContains("TorProcess", Lifecycle.Event.Name.OnStart, fid = factory)
+            lces.assertContains("TorDaemon", Lifecycle.Event.Name.OnCreate, fid = factory)
+            lces.assertContains("TorDaemon", Lifecycle.Event.Name.OnStart, fid = factory)
             lces.assertContains("RealTorCtrl", Lifecycle.Event.Name.OnCreate, fid = factory)
 
             lces.assertDoesNotContain("RealTorRuntime", Lifecycle.Event.Name.OnDestroy, fid = factory)
@@ -339,8 +339,8 @@ class ServiceFactoryUnitTest {
             synchronized(lock) {
                 lces.assertContains("RealTorRuntime", Lifecycle.Event.Name.OnDestroy)
                 lces.assertContains("DestroyableTorRuntime", Lifecycle.Event.Name.OnDestroy)
-                lces.assertContains("TorProcess", Lifecycle.Event.Name.OnCreate)
-                lces.assertContains("TorProcess", Lifecycle.Event.Name.OnDestroy)
+                lces.assertContains("TorDaemon", Lifecycle.Event.Name.OnCreate)
+                lces.assertContains("TorDaemon", Lifecycle.Event.Name.OnDestroy)
                 lces.clear()
             }
         }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeUnitTest.kt
@@ -181,7 +181,7 @@ class TorRuntimeUnitTest {
             runtime.subscribe(observerLCE)
 
             listOf(
-                "TorProcess" to Lifecycle.Event.Name.OnStart,
+                "TorDaemon" to Lifecycle.Event.Name.OnStart,
                 "RealTorCtrl" to Lifecycle.Event.Name.OnCreate,
             ).forEach { (clazz, event) ->
                 eventClassName = clazz

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConfChangedUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConfChangedUnitTest.kt
@@ -15,7 +15,7 @@
  **/
 @file:Suppress("UnnecessaryVariable")
 
-package io.matthewnelson.kmp.tor.runtime.internal
+package io.matthewnelson.kmp.tor.runtime.internal.observer
 
 import io.matthewnelson.kmp.tor.runtime.test.TestTorListenersManager
 import io.matthewnelson.kmp.tor.runtime.TorState

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConnectivityUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConnectivityUnitTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.runtime.internal
+package io.matthewnelson.kmp.tor.runtime.internal.observer
 
 import io.matthewnelson.kmp.file.InterruptedException
 import io.matthewnelson.kmp.tor.runtime.*

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverProcessStdoutUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverProcessStdoutUnitTest.kt
@@ -33,14 +33,14 @@ class ObserverProcessStdoutUnitTest {
     @Test
     fun givenBootstrapped_whenParsed_thenUpdatesTorStateManager() {
         val values = listOf(
-            5 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 5% (conn): Connecting to a relay",
-            10 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 10% (conn_done): Connected to a relay",
-            14 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 14% (handshake): Handshaking with a relay",
-            15 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 15% (handshake_done): Handshake with a relay done",
-            75 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 75% (enough_dirinfo): Loaded enough directory info to build circuits",
-            90 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 90% (ap_handshake_done): Handshake finished with a relay to build circuits",
-            95 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 95% (circuit_create): Establishing a Tor circuit",
-            100 to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:08.000 [notice] Bootstrapped 100% (done): Done",
+            5 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 5% (conn): Connecting to a relay",
+            10 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 10% (conn_done): Connected to a relay",
+            14 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 14% (handshake): Handshaking with a relay",
+            15 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 15% (handshake_done): Handshake with a relay done",
+            75 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 75% (enough_dirinfo): Loaded enough directory info to build circuits",
+            90 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 90% (ap_handshake_done): Handshake finished with a relay to build circuits",
+            95 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Bootstrapped 95% (circuit_create): Establishing a Tor circuit",
+            100 to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:08.000 [notice] Bootstrapped 100% (done): Done",
         )
 
         values.forEach { (_, line) -> observer.notify(line) }
@@ -58,12 +58,12 @@ class ObserverProcessStdoutUnitTest {
     @Test
     fun givenCloseListener_whenParsed_thenUpdatesTorListenersManager() {
         val values = listOf(
-            Pair("DNS", "127.0.0.1:53085") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured DNS listener on 127.0.0.1:53085",
-            Pair("HTTP", "127.0.0.1:48932") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured HTTP tunnel listener on 127.0.0.1:48932",
-            Pair("Socks", "127.0.0.1:9150") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured Socks listener on 127.0.0.1:9150",
-            Pair("Transparent", "127.0.0.1:45963") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured Transparent pf/netfilter listener on 127.0.0.1:45963",
-            Pair("Socks", "???:0") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured Socks listener on ???:0",
-            Pair("Socks", "/tmp/kmp_tor_test/obs_conn_no_net/work/socks5.sock") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing partially-constructed Socks listener connection (ready) on /tmp/kmp_tor_test/obs_conn_no_net/work/socks5.sock",
+            Pair("DNS", "127.0.0.1:53085") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured DNS listener on 127.0.0.1:53085",
+            Pair("HTTP", "127.0.0.1:48932") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured HTTP tunnel listener on 127.0.0.1:48932",
+            Pair("Socks", "127.0.0.1:9150") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured Socks listener on 127.0.0.1:9150",
+            Pair("Transparent", "127.0.0.1:45963") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured Transparent pf/netfilter listener on 127.0.0.1:45963",
+            Pair("Socks", "???:0") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing no-longer-configured Socks listener on ???:0",
+            Pair("Socks", "/tmp/kmp_tor_test/obs_conn_no_net/work/socks5.sock") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Closing partially-constructed Socks listener connection (ready) on /tmp/kmp_tor_test/obs_conn_no_net/work/socks5.sock",
         )
 
         values.forEach { (_, line) -> observer.notify(line) }
@@ -82,11 +82,11 @@ class ObserverProcessStdoutUnitTest {
     @Test
     fun givenOpenListener_whenParsed_thenUpdatesTorListenersManager() {
         val values = listOf(
-            Pair("DNS", "127.0.0.1:53085") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened DNS listener connection (ready) on 127.0.0.1:53085",
-            Pair("HTTP", "127.0.0.1:48932") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened HTTP tunnel listener connection (ready) on 127.0.0.1:48932",
-            Pair("Socks", "127.0.0.1:9150") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened Socks listener connection (ready) on 127.0.0.1:9150",
-            Pair("Transparent", "127.0.0.1:45963") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened Transparent pf/netfilter listener connection (ready) on 127.0.0.1:45963",
-            Pair("Socks", "/tmp/kmp_tor_test/sf_restart/work/socks.sock") to "TorProcess[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened Socks listener connection (ready) on /tmp/kmp_tor_test/sf_restart/work/socks.sock",
+            Pair("DNS", "127.0.0.1:53085") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened DNS listener connection (ready) on 127.0.0.1:53085",
+            Pair("HTTP", "127.0.0.1:48932") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened HTTP tunnel listener connection (ready) on 127.0.0.1:48932",
+            Pair("Socks", "127.0.0.1:9150") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened Socks listener connection (ready) on 127.0.0.1:9150",
+            Pair("Transparent", "127.0.0.1:45963") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened Transparent pf/netfilter listener connection (ready) on 127.0.0.1:45963",
+            Pair("Socks", "/tmp/kmp_tor_test/sf_restart/work/socks.sock") to "TorDaemon[fid=A3C2…6595]@1414604497 May 24 18:10:05.000 [notice] Opened Socks listener connection (ready) on /tmp/kmp_tor_test/sf_restart/work/socks.sock",
         )
 
         values.forEach { (_, line) -> observer.notify(line) }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverProcessStdoutUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverProcessStdoutUnitTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.runtime.internal
+package io.matthewnelson.kmp.tor.runtime.internal.observer
 
 import io.matthewnelson.kmp.tor.runtime.test.TestTorListenersManager
 import io.matthewnelson.kmp.tor.runtime.TorState

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParserUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParserUnitTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.internal.process
+
+import kotlin.test.*
+
+class StartupFeedParserUnitTest {
+
+    @Test
+    fun givenParser_whenThrowError_thenCauseIsNotAppendedToStdout() {
+        val parser = StartupFeedParser { null }
+
+        listOf("expected1", "expected2").forEach { expected ->
+            val ex = parser.createError(expected)
+
+            assertTrue(ex.message.contains("exitCode: not exited"))
+            assertTrue(ex.message.contains("cause: $expected"))
+
+            // if this is expected2, expected1 cause should have been
+            // appended to the empty StringBuilder, not stdout.
+            assertTrue(ex.message.contains("stdout: []"))
+            assertTrue(ex.message.contains("stderr: []"))
+
+            // _error is set as the current error message
+            try {
+                parser.checkError()
+                fail()
+            } catch (e: ProcessStartException) {
+                assertEquals(ex, e)
+            }
+        }
+    }
+
+    @Test
+    fun givenLineLimit_whenExceededAndNotReady_thenGeneratesError() {
+        val parser = StartupFeedParser(lineLimit = 3) { null }
+        parser.stdout.onOutput("1")
+        parser.stdout.onOutput("2")
+        parser.stdout.onOutput("3")
+        parser.checkError()
+        parser.stdout.onOutput("4")
+        assertFailsWith<ProcessStartException> { parser.checkError() }
+    }
+
+    @Test
+    fun givenLineLimit_whenExceededAndReady_thenDoesNotGeneratesError() {
+        val out = """
+            May 28 11:17:14.295 [notice] Tor 0.4.8.10 running on Linux with Libevent 2.1.12-stable, OpenSSL 3.2.0, Zlib 1.3, Liblzma 5.4.5, Libzstd N/A and Glibc 2.35 as libc.
+            May 28 11:17:14.295 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://support.torproject.org/faq/staying-anonymous/
+            May 28 11:17:14.295 [notice] Read configuration file "/tmp/kmp_tor_test/obs_conn_no_net/work/torrc-defaults".
+            May 28 11:17:14.295 [notice] Read configuration file "/tmp/kmp_tor_test/obs_conn_no_net/work/torrc".
+            May 28 11:17:14.296 [notice] Opening Control listener on /tmp/kmp_tor_test/obs_conn_no_net/work/ctrl.sock
+            May 28 11:17:14.296 [notice] Opened Control listener connection (ready) on /tmp/kmp_tor_test/obs_conn_no_net/work/ctrl.sock
+        """.trimIndent()
+
+        val lines = out.lines()
+
+        val parser = StartupFeedParser(lineLimit = lines.size) { null }
+        assertFalse(parser.isReady)
+        lines.forEach { line -> parser.stdout.onOutput(line) }
+        assertTrue(parser.isReady)
+        parser.checkError()
+
+        parser.stdout.onOutput("something else")
+        parser.checkError()
+    }
+
+    @Test
+    fun givenTorError_whenCreated_thenContainsInErrorMessage() {
+        val out = """
+            May 28 11:21:32.559 [notice] Tor 0.4.8.10 running on Linux with Libevent 2.1.12-stable, OpenSSL 3.2.0, Zlib 1.3, Liblzma 5.4.5, Libzstd N/A and Glibc 2.35 as libc.
+            May 28 11:21:32.559 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://support.torproject.org/faq/staying-anonymous/
+            May 28 11:21:32.559 [notice] Read configuration file "/tmp/kmp_tor_test/rt_start_fail/work/torrc-defaults".
+            May 28 11:21:32.559 [notice] Read configuration file "/tmp/kmp_tor_test/rt_start_fail/work/torrc".
+            May 28 11:21:32.560 [warn] Couldn't parse address "-1" for DNSPort
+            May 28 11:21:32.560 [warn] Failed to parse/validate config: Invalid DNSPort configuration
+            May 28 11:21:32.560 [err] Reading config failed--see warnings above.
+        """.trimIndent()
+
+        val lines = out.lines()
+
+        val parser = StartupFeedParser { null }
+        lines.forEach { line -> parser.stdout.onOutput(line) }
+
+        try {
+            parser.checkError()
+            fail()
+        } catch (e: ProcessStartException) {
+            lines.forEach { line -> assertTrue(e.message.contains(line)) }
+            // last line was used for the error cause
+            e.message.contains("    cause: ${lines.last()}")
+        }
+    }
+
+    @Test
+    fun givenNullOutput_whenLineLimitNotExceeded_thenCreatesException() {
+        val parser = StartupFeedParser(lineLimit = 2) { null }
+        parser.stdout.onOutput("1")
+        parser.stdout.onOutput(null)
+        assertFailsWith<ProcessStartException> { parser.checkError() }
+    }
+
+    @Test
+    fun givenOutput_whenExceptionCreated_thenIsPresentInMessage() {
+        val parser = StartupFeedParser(lineLimit = 3) { null }
+        parser.stderr.onOutput("STDERR")
+        parser.stdout.onOutput("STDOUT")
+        parser.stdout.onOutput("STDOUT")
+        parser.stdout.onOutput("STDOUT")
+        parser.stdout.onOutput("STDOUT")
+        try {
+            parser.checkError()
+            fail()
+        } catch (e: ProcessStartException) {
+            e.message.contains("STDOUT")
+            e.message.contains("STDERR")
+        }
+    }
+
+    @Test
+    fun givenParser_whenClose_thenClearsOutputAndDereferences() {
+        val parser = StartupFeedParser { 2 }
+        parser.stdout.onOutput("STDOUT")
+        parser.stderr.onOutput("STDERR")
+        parser.createError("something").message.let { message ->
+            assertTrue(message.contains("STDOUT"))
+            assertTrue(message.contains("STDERR"))
+        }
+        parser.close()
+        val ex = parser.createError("something")
+        ex.message.let { message ->
+            assertFalse(message.contains("STDOUT"))
+            assertFalse(message.contains("STDERR"))
+        }
+
+        // confirming it was set as our exception
+        try {
+            parser.checkError()
+            fail()
+        } catch (e: ProcessStartException) {
+            assertEquals(ex, e)
+        }
+
+        // Should create a "Process exited unexpectedly" exception
+        parser.stdout.onOutput(null)
+        try {
+            parser.checkError()
+            fail()
+        } catch (e: ProcessStartException) {
+            // onOutput did nothing, it was closed
+            assertEquals(ex, e)
+        }
+    }
+}


### PR DESCRIPTION
This PR refactors the `TorProcess` class (now named `TorDaemon`) by cleaning up some internals and extracting out a critical component for better testability & error handling.