### PR TITLE
Refactor `EnqueuedJob.CancellationPolicy`

### DIFF
--- a/library/runtime-core/api/runtime-core.api
+++ b/library/runtime-core/api/runtime-core.api
@@ -31,7 +31,7 @@ public abstract class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob {
 	protected fun <init> (Ljava/lang/String;Lio/matthewnelson/kmp/tor/runtime/core/OnFailure;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;)V
 	public final fun cancel (Ljava/util/concurrent/CancellationException;)Z
 	protected final fun cancellationAttempt ()Ljava/util/concurrent/CancellationException;
-	public fun getCancellationPolicy ()Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy;
+	public fun getExecutionPolicy ()Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy;
 	public static final fun immediateErrorJob (Lio/matthewnelson/kmp/tor/runtime/core/OnFailure;Ljava/lang/String;Ljava/lang/Throwable;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob;
 	public static final fun immediateSuccessJob (Lio/matthewnelson/kmp/tor/runtime/core/OnSuccess;Ljava/lang/String;Ljava/lang/Object;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob;
 	public final fun invokeOnCompletion (Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)Lio/matthewnelson/kmp/tor/runtime/core/Disposable;
@@ -48,34 +48,51 @@ public abstract class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob {
 	public final fun toString ()Ljava/lang/String;
 }
 
-public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy {
-	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy$Companion;
-	public static final field DEFAULT Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy;
-	public final field accessibilityOpen Z
-	public final field allowAttempts Z
-	public final field isDefault Z
-	public final field substituteOnErrorWithAttempt Z
-	public fun <init> ()V
-	public fun <init> (Z)V
-	public fun <init> (ZZ)V
-	public fun <init> (ZZZ)V
-	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Z
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun copy (ZZZ)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy;
-	public static synthetic fun copy$default (Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy;ZZZILjava/lang/Object;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$CancellationPolicy$Companion {
-}
-
 public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$Companion {
 	public final fun immediateErrorJob (Lio/matthewnelson/kmp/tor/runtime/core/OnFailure;Ljava/lang/String;Ljava/lang/Throwable;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob;
 	public final fun immediateSuccessJob (Lio/matthewnelson/kmp/tor/runtime/core/OnSuccess;Ljava/lang/String;Ljava/lang/Object;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy {
+	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Companion;
+	public static final field DEFAULT Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy;
+	public final field cancellation Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Cancellation;
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Cancellation;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun Builder (Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isDefault ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Builder {
+	public final fun cancellation (Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Builder;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Cancellation {
+	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Cancellation$Companion;
+	public static final field DEFAULT Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Cancellation;
+	public final field accessibilityOpen Z
+	public final field allowAttempts Z
+	public final field substituteErrorWithAttempt Z
+	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isDefault ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Cancellation$Builder {
+	public field accessibilityOpen Z
+	public field allowAttempts Z
+	public field substituteErrorWithAttempt Z
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Cancellation$Companion {
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy$Companion {
+	public final fun Builder (Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$ExecutionPolicy;
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob$State : java/lang/Enum {

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd.kt
@@ -132,16 +132,15 @@ public sealed class TorCmd<Success: Any> private constructor(
 
             @JvmField
             public val configText: String = buildString {
-                val lines = configText.lines()
-                var isFirst = true
-                for (line in lines) {
-                    if (line.isBlank()) continue
-                    if (line.startsWith('#')) continue
+                for (line in configText.lines()) {
+                    val isCommentOrBlank = run {
+                        val i = line.indexOfFirst { !it.isWhitespace() }
+                        if (i == -1) true else line[i] == '#'
+                    }
 
-                    if (!isFirst) appendLine()
-
+                    if (isCommentOrBlank) continue
+                    if (isNotEmpty()) appendLine()
                     append(line)
-                    isFirst = false
                 }
             }
         }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-CommonPlatform.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-CommonPlatform.kt
@@ -43,8 +43,10 @@ internal suspend inline fun <Arg: EnqueuedJob.Argument, Success: Any> Arg.common
         callsInPlace(enqueue, InvocationKind.AT_MOST_ONCE)
     }
 
-    val cancellable = Job(currentCoroutineContext()[Job])
-    cancellable.ensureActive()
+    val cancellable = currentCoroutineContext()[Job].let { parent ->
+        parent?.ensureActive()
+        Job(parent)
+    }
 
     var failure: Throwable? = null
     var success: Success? = null

--- a/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ConfigLoadUnitTest.kt
+++ b/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ConfigLoadUnitTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.core.ctrl
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConfigLoadUnitTest {
+
+    @Test
+    fun givenText_whenCommentOrBlankLine_thenIsNotIncluded() {
+        val expected = "SocksPort 9050"
+        val load = TorCmd.Config.Load(configText = """
+            # comment1
+              # indented comment
+
+            $expected
+        """.trimIndent())
+
+        assertEquals(expected, load.configText)
+    }
+}

--- a/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/JobUtilUnitTest.kt
+++ b/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/JobUtilUnitTest.kt
@@ -128,10 +128,12 @@ class JobUtilUnitTest {
                 EnqueuedJobUnitTest.TestJob(
                     onFailure = onFailure,
                     onSuccess = onSuccess,
-                    cancellationPolicy = EnqueuedJob.CancellationPolicy(
-                        allowAttempts = true,
-                        substituteOnErrorWithAttempt = true,
-                    )
+                    executionPolicy = EnqueuedJob.ExecutionPolicy.Builder {
+                        cancellation {
+                            allowAttempts = true
+                            substituteErrorWithAttempt = true
+                        }
+                    }
                 )
                     .also { testJob = it }
             }

--- a/library/runtime/api/runtime.api
+++ b/library/runtime/api/runtime.api
@@ -226,7 +226,7 @@ public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$EXECUTE$ACTION 
 
 public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$EXECUTE$CMD : io/matthewnelson/kmp/tor/runtime/RuntimeEvent {
 	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$EXECUTE$CMD;
-	public static final fun observeSignalNewNym (Lio/matthewnelson/kmp/tor/runtime/RuntimeEvent$Processor;Ljava/lang/String;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)Lio/matthewnelson/kmp/tor/runtime/core/Disposable;
+	public static final fun observeSignalNewNym (Lio/matthewnelson/kmp/tor/runtime/TorRuntime;Ljava/lang/String;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor;Lio/matthewnelson/kmp/tor/runtime/core/OnEvent;)Lio/matthewnelson/kmp/tor/runtime/core/Disposable;
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/RuntimeEvent$LIFECYCLE : io/matthewnelson/kmp/tor/runtime/RuntimeEvent {

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/Action.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/Action.kt
@@ -122,7 +122,7 @@ public expect enum class Action: EnqueuedJob.Argument {
          * until completion or cancellation/error.
          *
          * **NOTE:** If [Action] is [StartDaemon] or [RestartDaemon],
-         * the [EnqueuedJob.CancellationPolicy] allows for handling of
+         * the [EnqueuedJob.ExecutionPolicy] allows for handling of
          * [kotlinx.coroutines.Job] cancellation while the action is
          * being executed (normally a non-cancellable state). In the
          * event the underlying [kotlinx.coroutines.Job] for the caller

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ActionJob.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ActionJob.kt
@@ -83,7 +83,7 @@ public abstract class ActionJob private constructor(
 
         @Volatile
         private var _interrupt: InterruptedException? = null
-        public final override val cancellationPolicy = CANCELLATION_POLICY
+        public final override val executionPolicy = EXECUTION_POLICY
 
         @JvmSynthetic
         internal fun interruptBy(enqueuedJob: StopJob) {
@@ -106,7 +106,11 @@ public abstract class ActionJob private constructor(
         }
 
         private companion object {
-            private val CANCELLATION_POLICY = CancellationPolicy(allowAttempts = true)
+            private val EXECUTION_POLICY = ExecutionPolicy.Builder {
+                cancellation {
+                    allowAttempts = true
+                }
+            }
         }
     }
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
@@ -125,7 +125,7 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
         public data object CMD: RuntimeEvent<TorCmdJob>("EXECUTE_CMD") {
 
             /**
-             * Subscribes with provided [Processor] a [CMD] observer
+             * Subscribes with provided [TorRuntime] a [CMD] observer
              * which will intercept execution of all [TorCmd.Signal.NewNym]
              * jobs in order to transform tor's generic server response
              * of [Reply.Success.OK].
@@ -138,12 +138,11 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
              * signal, it may or may not dispatch a [TorEvent.NOTICE]
              * indicating that it was rate-limited. This observer handles
              * that transformation and notifies the provided [onEvent]
-             * callback whenever there is a successful execution of
-             * [TorCmd.Signal.NewNym] with either:
+             * callback whenever there is a successful execution of a
+             * [TorCmd.Signal.NewNym] job with either:
              *
-             *  - `null` indicating tor accepted the signal and did **not**
-             *    rate-limit it.
-             *  - The rate-limit notice itself.
+             *  - null: tor accepted the signal without rate-limiting.
+             *  - non-null: the rate-limiting notice.
              *
              * e.g.
              *
@@ -172,14 +171,12 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
              * @return [Disposable] to unsubscribe the observer
              * @param [tag] A string to help grouping/identifying observer(s)
              * @param [executor] The thread context in which [onEvent] will be
-             *   invoked in. If `null` and [Processor] is an instance of
-             *   [TorRuntime], it will use whatever was declared via
-             *   [TorRuntime.Environment.Builder.defaultEventExecutor]. Otherwise,
-             *   [OnEvent.Executor.Immediate] will be used.
+             *   invoked in. If `null` whatever was declared via
+             *   [TorRuntime.Environment.Builder.defaultEventExecutor] is used.
              * @param [onEvent] The callback to pass the data to.
              * */
             @JvmStatic
-            public fun Processor.observeSignalNewNym(
+            public fun TorRuntime.observeSignalNewNym(
                 tag: String?,
                 executor: OnEvent.Executor?,
                 onEvent: OnEvent<String?>,

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorListeners.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorListeners.kt
@@ -212,22 +212,16 @@ public class TorListeners private constructor(
         }
 
         appendLine(": [")
-
         append("    dns: [")
         appendListeners(dns)
-
         append("    http: [")
         appendListeners(http)
-
         append("    socks: [")
         appendListeners(socks)
-
         append("    socksUnix: [")
         appendListeners(socksUnix)
-
         append("    trans: [")
         appendListeners(trans)
-
         append(']')
     }
 
@@ -492,7 +486,7 @@ public class TorListeners private constructor(
                 // failed job will be "partially-constructed" and tor dispatches
                 // a NOTICE closing them which contains the full file path and
                 // occurs before replying with the Reply.Error for this job.
-                val isRecoveryNeeded = with(listeners) {
+                val isRecoveryNeeded = with(_listeners) {
                     socksUnix.isNotEmpty()
                 }
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -684,7 +684,6 @@ public interface TorRuntime:
 
         public final override fun equals(other: Any?): Boolean = other is ServiceFactory && other.ctrl == ctrl
         public final override fun hashCode(): Int = ctrl.hashCode()
-        private val _toString by lazy { toFIDString(defaultClassName = "ServiceFactory", includeHashCode = false) }
-        public final override fun toString(): String = _toString
+        public final override fun toString(): String = toFIDString(defaultClassName = "ServiceFactory", includeHashCode = false)
     }
 }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
@@ -710,8 +710,7 @@ internal class RealTorRuntime private constructor(
 
         public override fun equals(other: Any?): Boolean = other is ActionProcessor && other.hashCode() == hashCode()
         public override fun hashCode(): Int = this@RealTorRuntime.hashCode()
-        private val _toString by lazy { this.toFIDString(includeHashCode = isService) }
-        public override fun toString(): String = _toString
+        public override fun toString(): String = this.toFIDString(includeHashCode = isService)
     }
 
     private inner class Notifier(
@@ -1026,8 +1025,9 @@ internal class RealTorRuntime private constructor(
             }
         }
 
-        private inner class ServiceCtrlBinder:
-            TorRuntime.ServiceFactory.Binder,
+        private inner class ServiceCtrlBinder(
+
+        ):  TorRuntime.ServiceFactory.Binder,
             FileID by generator.environment,
             RuntimeEvent.Notifier by this
         {

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/-TorCmdObserver.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/-TorCmdObserver.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.tor.runtime.internal.observer
 
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
@@ -76,20 +78,16 @@ internal fun <T: Processor> observeSignalNewNymInternal(
             processor.unsubscribe(stdout)
 
             if (job.isError) return@invokeOnCompletion
-
-            onEvent.notify(
-                job.handlerContext(),
-                _rateLimited,
-                executor,
-            )
+            onEvent.notify(executor, job.handlerContext(), _rateLimited)
         }
     }
 }
 
+@Suppress("NOTHING_TO_INLINE")
 private inline fun <Data: Any?> OnEvent<Data>.notify(
+    executor: OnEvent.Executor,
     handler: CoroutineContext,
     data: Data,
-    executor: OnEvent.Executor,
 ) {
     val executable = when (executor) {
         is OnEvent.Executor.Immediate -> null

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParser.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/StartupFeedParser.kt
@@ -22,7 +22,7 @@ import io.matthewnelson.kmp.tor.core.resource.synchronized
 import kotlin.concurrent.Volatile
 
 @OptIn(InternalKmpTorApi::class)
-internal class StartupFeedParser(private val lineLimit: Int = 50, private val exitCode: () -> Int?) {
+internal class StartupFeedParser(private val lineLimit: Int = 50, private val exitCodeOrNull: () -> Int?) {
 
     @Volatile
     private var _isReady: Boolean = false
@@ -121,7 +121,7 @@ internal class StartupFeedParser(private val lineLimit: Int = 50, private val ex
         // Generate error
         val stdout = _stdout?.toString() ?: ""
         val stderr = _stderr?.toString() ?: ""
-        val code = exitCode()?.toString() ?: "not exited"
+        val exitCode = exitCodeOrNull()?.toString() ?: "not exited"
 
         // append to current StringBuilder after calling
         // toString on both (above) so that if another
@@ -134,7 +134,7 @@ internal class StartupFeedParser(private val lineLimit: Int = 50, private val ex
         val message = StringBuilder(stdout.length + stderr.length + 100)
             .appendLine("Process Failure: [")
             .append("    exitCode: ")
-            .appendLine(code)
+            .appendLine(exitCode)
             .append("    cause: ")
             .appendLine(line)
             .append("    stdout: [")

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/TorDaemon.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/process/TorDaemon.kt
@@ -199,7 +199,7 @@ internal class TorDaemon private constructor(
         NOTIFIER.lce(Lifecycle.Event.OnStart(this@TorDaemon))
         NOTIFIER.i(this@TorDaemon, process.toString())
 
-        val startupFeed = StartupFeedParser(exitCode = {
+        val startupFeed = StartupFeedParser(exitCodeOrNull = {
             try {
                 process.exitCode()
             } catch (_: IllegalStateException) {
@@ -289,7 +289,7 @@ internal class TorDaemon private constructor(
             .toFile()
 
         val lines = ctrlPortFile
-            .awaitRead(feed, 10.seconds, checkCancellationOrInterrupt)
+            .awaitRead(feed, 4_500.milliseconds, checkCancellationOrInterrupt)
             .decodeToString()
             .lines()
             .mapNotNull { it.ifBlank { null } }
@@ -323,7 +323,7 @@ internal class TorDaemon private constructor(
             return CtrlArguments.Connection(socketAddress)
         }
 
-        throw feed.createError("Failed to acquire control connection info from file[$ctrlPortFile]")
+        throw feed.createError("Failed to acquire control connection info from file[${ctrlPortFile.name}]")
     }
 
     @Throws(CancellationException::class, InterruptedException::class, IOException::class)

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/ServiceFactoryUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/ServiceFactoryUnitTest.kt
@@ -255,6 +255,7 @@ class ServiceFactoryUnitTest {
 //            observerStatic(RuntimeEvent.LOG.WARN) { println(it) }
 //            observerStatic(RuntimeEvent.PROCESS.STDOUT) { println(it) }
             observerStatic(RuntimeEvent.PROCESS.STDERR) { println(it) }
+//            observerStatic(RuntimeEvent.PROCESS.READY) { println(it) }
 //            observerStatic(RuntimeEvent.STATE) { println(it) }
         }.ensureStoppedOnTestCompletion()
 

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeUnitTest.kt
@@ -35,6 +35,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KClass
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(InternalKmpTorApi::class)
 class TorRuntimeUnitTest {
@@ -133,7 +134,7 @@ class TorRuntimeUnitTest {
     }
 
     @Test
-    fun givenStartedAction_whenCancelledOrInterrupted_thenStops() = runTest {
+    fun givenStartedAction_whenCancelledOrInterrupted_thenStops() = runTest(timeout = 120.seconds) {
         val runtime = TorRuntime.Builder(testEnv("rt_interrupt")) {
 //            observerStatic(RuntimeEvent.EXECUTE.ACTION) { println(it) }
 //            observerStatic(RuntimeEvent.EXECUTE.CMD) { println(it) }

--- a/library/runtime/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/Action.kt
+++ b/library/runtime/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/Action.kt
@@ -122,7 +122,7 @@ public actual enum class Action: EnqueuedJob.Argument {
          * until completion or cancellation/error.
          *
          * **NOTE:** If [Action] is [StartDaemon] or [RestartDaemon],
-         * the [EnqueuedJob.CancellationPolicy] allows for handling of
+         * the [EnqueuedJob.ExecutionPolicy] allows for handling of
          * [kotlinx.coroutines.Job] cancellation while the action is
          * being executed (normally a non-cancellable state). In the
          * event the underlying [kotlinx.coroutines.Job] for the caller

--- a/library/runtime/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/Action.kt
+++ b/library/runtime/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/Action.kt
@@ -126,7 +126,7 @@ public actual enum class Action: EnqueuedJob.Argument {
          * until completion or cancellation/error.
          *
          * **NOTE:** If [Action] is [StartDaemon] or [RestartDaemon],
-         * the [EnqueuedJob.CancellationPolicy] allows for handling of
+         * the [EnqueuedJob.ExecutionPolicy] allows for handling of
          * [kotlinx.coroutines.Job] cancellation while the action is
          * being executed (normally a non-cancellable state). In the
          * event the underlying [kotlinx.coroutines.Job] for the caller
@@ -160,7 +160,7 @@ public actual enum class Action: EnqueuedJob.Argument {
          * until completion or cancellation/error.
          *
          * **NOTE:** If [Action] is [StartDaemon] or [RestartDaemon],
-         * the [EnqueuedJob.CancellationPolicy] allows for handling of
+         * the [EnqueuedJob.ExecutionPolicy] allows for handling of
          * cancellation while the action is being executed (normally
          * a non-cancellable state). In the event the [cancellation]
          * callback returns [CancellationException], [TorRuntime] will


### PR DESCRIPTION
To mitigate potentially breaking the API with future changes, this PR refactors the `EnqueuedJob.CancellationPolicy` subclass to use a builder pattern.