### PR TITLE
Use `sealed interface` for `TorRuntime`

### DIFF
--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/AbstractTorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/AbstractTorRuntime.kt
@@ -13,31 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.matthewnelson.kmp.tor.runtime.internal
+package io.matthewnelson.kmp.tor.runtime
 
-import io.matthewnelson.kmp.tor.core.api.annotation.ExperimentalKmpTorApi
-import io.matthewnelson.kmp.tor.runtime.AbstractTorRuntime
-import io.matthewnelson.kmp.tor.runtime.RuntimeEvent
-import io.matthewnelson.kmp.tor.runtime.TorRuntime
 import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import io.matthewnelson.kmp.tor.runtime.core.TorEvent
+import io.matthewnelson.kmp.tor.runtime.internal.AbstractRuntimeEventProcessor
 import kotlin.jvm.JvmSynthetic
 
-@ExperimentalKmpTorApi
-internal sealed class ServiceFactoryCtrl(
+// TorRuntime is sealed, so.
+internal abstract class AbstractTorRuntime protected constructor(
     staticTag: String?,
     observersRuntimeEvent: Set<RuntimeEvent.Observer<*>>,
     defaultExecutor: OnEvent.Executor,
     observersTorEvent: Set<TorEvent.Observer>,
     syntheticAccess: Any,
-): AbstractTorRuntime(
+):  AbstractRuntimeEventProcessor(
     staticTag,
     observersRuntimeEvent,
     defaultExecutor,
     observersTorEvent,
-    syntheticAccess,
-) {
+),  TorRuntime {
 
-    @get:JvmSynthetic
-    internal abstract val binder: TorRuntime.ServiceFactory.Binder
+    protected companion object {
+
+        @JvmSynthetic
+        internal val INIT = Any()
+    }
+
+    init {
+        check(syntheticAccess == INIT) { "AbstractTorRuntime cannot be extended. Use TorRuntime.Builder." }
+    }
 }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
@@ -297,7 +297,7 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
          * a **single** time per process startup completion. If the currently
          * running process is stopped via [Action.StopDaemon] or
          * [Action.RestartDaemon], [READY] observers will be notified again
-         * in the same manner for the new process instance.
+         * in the same manner when the next process start completion occurs.
          *
          * This is useful for triggering single execution events.
          *
@@ -355,6 +355,8 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
          *         trans: []
          *     ]
          *     TorState[fid=6E96…6985, daemon=Off, network=Disabled]
+         *
+         * @see [TorRuntime.isReady]
          * */
         public data object READY: PROCESS("PROCESS_READY")
 
@@ -396,6 +398,7 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
      *     ]
      *
      * @see [TorState]
+     * @see [TorRuntime.state]
      * */
     public data object STATE: RuntimeEvent<TorState>("STATE")
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -34,9 +34,9 @@ import io.matthewnelson.kmp.tor.runtime.TorRuntime.Environment.Companion.Builder
 import io.matthewnelson.kmp.tor.runtime.core.*
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.core.util.isAvailableAsync
+import io.matthewnelson.kmp.tor.runtime.internal.*
 import io.matthewnelson.kmp.tor.runtime.internal.InstanceKeeper
 import io.matthewnelson.kmp.tor.runtime.internal.RealTorRuntime
-import io.matthewnelson.kmp.tor.runtime.internal.ServiceFactoryCtrl
 import io.matthewnelson.kmp.tor.runtime.internal.TorConfigGenerator
 import org.kotlincrypto.SecRandomCopyException
 import org.kotlincrypto.SecureRandom
@@ -47,16 +47,17 @@ import kotlin.jvm.JvmSynthetic
 import kotlin.random.Random
 
 /**
- * Base interface for managing and interacting with a single tor process.
+ * Base interface for implementations that manage interaction with
+ * a single tor daemon (backed by a stand-alone process instance).
  *
  * @see [Companion.Builder]
  * */
-public interface TorRuntime:
-    FileID,
-    TorCmd.Unprivileged.Processor,
-    TorEvent.Processor,
+public sealed interface TorRuntime:
     Action.Processor,
-    RuntimeEvent.Processor
+    FileID,
+    RuntimeEvent.Processor,
+    TorCmd.Unprivileged.Processor,
+    TorEvent.Processor
 {
 
     /**
@@ -290,6 +291,10 @@ public interface TorRuntime:
      *
      * Specified directories/files are utilized by [TorRuntime.Builder.config]
      * to create a minimum viable [TorConfig].
+     *
+     * The [Environment] API is mostly based around configuration options that
+     * are, or could be, platform-specific. This means less platform-specific
+     * code, and more `commonMain` code.
      *
      * @see [Companion.Builder]
      * */


### PR DESCRIPTION
This PR modifies the `TorRuntime` interface by declaring it as being `sealed`.