### PR TITLE
Refactor commands with `Key.Private` to always have `destroyKeyOnJobCompletion` as an option

### DIFF
--- a/library/runtime-core/api/runtime-core.api
+++ b/library/runtime-core/api/runtime-core.api
@@ -3366,6 +3366,7 @@ public final class io/matthewnelson/kmp/tor/runtime/core/builder/IsolationFlagBu
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/builder/OnionAddBuilder {
+	public field destroyKeyOnJobCompletion Z
 	public final fun clientAuth (Lio/matthewnelson/kmp/tor/runtime/core/key/X25519$PublicKey;)Lio/matthewnelson/kmp/tor/runtime/core/builder/OnionAddBuilder;
 	public final fun flags (Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/core/builder/OnionAddBuilder;
 	public final fun maxStreams (Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/core/builder/OnionAddBuilder;
@@ -3380,6 +3381,7 @@ public final class io/matthewnelson/kmp/tor/runtime/core/builder/OnionAddBuilder
 
 public final class io/matthewnelson/kmp/tor/runtime/core/builder/OnionClientAuthAddBuilder {
 	public field clientName Ljava/lang/String;
+	public field destroyKeyOnJobCompletion Z
 	public final fun flags (Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)Lio/matthewnelson/kmp/tor/runtime/core/builder/OnionClientAuthAddBuilder;
 }
 
@@ -3685,7 +3687,6 @@ public final class io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$Onion$Add :
 	public final field maxStreams Lio/matthewnelson/kmp/tor/runtime/core/TorConfig$LineItem;
 	public final field ports Ljava/util/Set;
 	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/key/AddressKey$Private;Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)V
-	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/key/AddressKey$Private;ZLio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)V
 	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/key/KeyType$Address;Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)V
 }
 
@@ -3706,6 +3707,7 @@ public final class io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$OnionClient
 	public final field address Lio/matthewnelson/kmp/tor/runtime/core/address/OnionAddress;
 	public final field authKey Lio/matthewnelson/kmp/tor/runtime/core/key/AuthKey$Private;
 	public final field clientName Ljava/lang/String;
+	public final field destroyKeyOnJobCompletion Z
 	public final field flags Ljava/util/Set;
 	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/address/OnionAddress$V3;Lio/matthewnelson/kmp/tor/runtime/core/key/X25519$PrivateKey;)V
 	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/address/OnionAddress$V3;Lio/matthewnelson/kmp/tor/runtime/core/key/X25519$PrivateKey;Lio/matthewnelson/kmp/tor/runtime/core/ThisBlock;)V

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/builder/OnionClientAuthAddBuilder.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/builder/OnionClientAuthAddBuilder.kt
@@ -19,9 +19,11 @@ package io.matthewnelson.kmp.tor.runtime.core.builder
 
 import io.matthewnelson.immutable.collections.toImmutableSet
 import io.matthewnelson.kmp.tor.core.api.annotation.KmpTorDsl
+import io.matthewnelson.kmp.tor.runtime.core.EnqueuedJob
 import io.matthewnelson.kmp.tor.runtime.core.ThisBlock
 import io.matthewnelson.kmp.tor.runtime.core.apply
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
+import io.matthewnelson.kmp.tor.runtime.core.key.AuthKey
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmSynthetic
 
@@ -36,6 +38,17 @@ public class OnionClientAuthAddBuilder private constructor() {
      * */
     @JvmField
     public var clientName: String? = null
+
+    /**
+     * When true, an [EnqueuedJob.invokeOnCompletion] handler is
+     * automatically set which calls [AuthKey.Private.destroy]
+     * once the job completes, either successfully or by
+     * cancellation/error.
+     *
+     * Default = `true`
+     * */
+    @JvmField
+    public var destroyKeyOnJobCompletion: Boolean = true
 
     @KmpTorDsl
     public fun flags(
@@ -74,6 +87,7 @@ public class OnionClientAuthAddBuilder private constructor() {
             }
         }
     }
+
     internal companion object {
 
         @JvmSynthetic
@@ -82,12 +96,17 @@ public class OnionClientAuthAddBuilder private constructor() {
         ): Arguments {
             val b = OnionClientAuthAddBuilder().apply(block)
 
-            return Arguments(b.clientName, b.flags)
+            return Arguments(
+                clientName = b.clientName,
+                destroyKeyOnJobCompletion = b.destroyKeyOnJobCompletion,
+                flags = b.flags,
+            )
         }
     }
 
     internal class Arguments internal constructor(
         internal val clientName: String?,
+        internal val destroyKeyOnJobCompletion: Boolean,
         flags: Set<String>,
     ) {
 
@@ -95,7 +114,7 @@ public class OnionClientAuthAddBuilder private constructor() {
 
         internal companion object {
 
-            internal val EMPTY = Arguments(null, emptySet())
+            internal val EMPTY = Arguments(null, true, emptySet())
         }
     }
 }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd.kt
@@ -337,20 +337,18 @@ public sealed class TorCmd<Success: Any> private constructor(
             public constructor(
                 keyType: KeyType.Address<*, *>,
                 block: ThisBlock<OnionAddBuilder>,
-            ): this(null, false, keyType.configure(block))
+            ): this(null, keyType.configure(block))
 
             /**
              * Creates an [Onion.Add] command that will instruct tor
              * to add a HiddenService to its runtime for the provided
              * [addressKey].
-             *
-             * **NOTE:** Default of [destroyKeyOnJobCompletion] = `true`
              *
              * e.g.
              *
              *     TorCmd.Onion.Add("[Blob Redacted]".toED25519_V3PrivateKey()) {
+             *         port { virtual = 80.toPort() }
              *         flags { DiscardPK = true }
-             *         port { virtual = 80.toPort() }
              *     }
              *
              * @see [OnionAddBuilder]
@@ -359,37 +357,10 @@ public sealed class TorCmd<Success: Any> private constructor(
             public constructor(
                 addressKey: AddressKey.Private,
                 block: ThisBlock<OnionAddBuilder>,
-            ): this(addressKey, true, block)
-
-            /**
-             * Creates an [Onion.Add] command that will instruct tor
-             * to add a HiddenService to its runtime for the provided
-             * [addressKey].
-             *
-             * e.g.
-             *
-             *     TorCmd.Onion.Add(
-             *         addressKey = "[Blob Redacted]".toED25519_V3PrivateKey(),
-             *         destroyKeyOnJobCompletion = false,
-             *     ) {
-             *         port { virtual = 80.toPort() }
-             *     }
-             *
-             * @param [destroyKeyOnJobCompletion] If `true`, when the [EnqueuedJob]
-             *   completes (either by success or cancellation/error) for this
-             *   command, the provided [addressKey] will be destroyed automatically.
-             * @see [OnionAddBuilder]
-             * @see [ED25519_V3.PrivateKey]
-             * */
-            public constructor(
-                addressKey: AddressKey.Private,
-                destroyKeyOnJobCompletion: Boolean,
-                block: ThisBlock<OnionAddBuilder>,
-            ): this(addressKey, destroyKeyOnJobCompletion, addressKey.type().configure(block))
+            ): this(addressKey, addressKey.type().configure(block))
 
             private constructor(
                 addressKey: AddressKey.Private?,
-                destroyKeyOnJobCompletion: Boolean,
                 arguments: OnionAddBuilder.Arguments,
             ): super("ADD_ONION") {
                 this.keyType = arguments.keyType
@@ -398,7 +369,7 @@ public sealed class TorCmd<Success: Any> private constructor(
                 this.flags = arguments.flags
                 this.maxStreams = arguments.maxStreams
                 this.ports = arguments.ports
-                this.destroyKeyOnJobCompletion = destroyKeyOnJobCompletion
+                this.destroyKeyOnJobCompletion = arguments.destroyKeyOnJobCompletion
             }
         }
 
@@ -436,6 +407,8 @@ public sealed class TorCmd<Success: Any> private constructor(
             public val clientName: String?
             @JvmField
             public val flags: Set<String>
+            @JvmField
+            public val destroyKeyOnJobCompletion: Boolean
 
             public constructor(
                 address: OnionAddress.V3,
@@ -457,6 +430,7 @@ public sealed class TorCmd<Success: Any> private constructor(
                 this.authKey = authKey
                 this.clientName = arguments.clientName
                 this.flags = arguments.flags
+                this.destroyKeyOnJobCompletion = arguments.destroyKeyOnJobCompletion
             }
         }
 

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-CommonPlatform.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-CommonPlatform.kt
@@ -80,14 +80,19 @@ internal inline fun TorCmd<*>.toJobName(): String {
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun <Job: EnqueuedJob> Job.invokeOnCompletionForCmd(
     cmd: TorCmd<*>,
-): Job {
-    if (cmd is TorCmd.Onion.Add) {
+): Job = when (cmd) {
+    is TorCmd.Onion.Add -> {
         val key = cmd.addressKey
-
         if (key != null && cmd.destroyKeyOnJobCompletion) {
             invokeOnCompletion { key.destroy() }
         }
+        this
     }
-
-    return this
+    is TorCmd.OnionClientAuth.Add -> {
+        if (cmd.destroyKeyOnJobCompletion) {
+            invokeOnCompletion { cmd.authKey.destroy() }
+        }
+        this
+    }
+    else -> this
 }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorCmdUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorCmdUnitTest.kt
@@ -215,10 +215,10 @@ class TorCmdUnitTest {
 
         runtime.executeAsync(TorCmd.Onion.Delete(entry1.publicKey))
 
-        val entry3 = runtime.executeAsync(TorCmd.Onion.Add(
-            addressKey = keyCopy,
-            destroyKeyOnJobCompletion = false,
-        ) {
+        val entry3 = runtime.executeAsync(TorCmd.Onion.Add(keyCopy) {
+
+            destroyKeyOnJobCompletion = false
+
             for (keys in authKeys) {
                 clientAuth(keys.first)
             }
@@ -247,7 +247,7 @@ class TorCmdUnitTest {
                 if (line.contains("x25519:[REDACTED]")) {
                     containsRedacted = true
                 }
-                println(line)
+//                println(line)
             }
         }.ensureStoppedOnTestCompletion()
 
@@ -282,7 +282,10 @@ class TorCmdUnitTest {
                     entry.publicKey.address() as OnionAddress.V3,
                     // PrivateKey
                     authKeys.first().second,
-                ) { clientName = nickname }
+                ) {
+                    clientName = nickname
+                    destroyKeyOnJobCompletion = false
+                }
             )
 
             assertTrue(containsRedacted)
@@ -300,8 +303,10 @@ class TorCmdUnitTest {
                     TorCmd.OnionClientAuth.Add(
                         entry.publicKey.address() as OnionAddress.V3,
                         authKeys.last().second,
-                        block
-                    )
+                    ) {
+                        destroyKeyOnJobCompletion = false
+                        this.apply(block)
+                    }
                 )
             }
         }


### PR DESCRIPTION
This PR refactors the `TorCmd.Onion.Add` and `TorCmd.OnionClientAuth.Add` classes to incorporate the option for destroying the `Key.Private` in their builders.