### PR TITLE
Compare both `workDirectory` and `cacheDirectory` when getting or creating a `TorRuntime.Environment`

### DIFF
--- a/library/runtime-core/api/runtime-core.api
+++ b/library/runtime-core/api/runtime-core.api
@@ -190,6 +190,7 @@ public final class io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor$Immedi
 
 public final class io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor$Main : io/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor {
 	public static final field INSTANCE Lio/matthewnelson/kmp/tor/runtime/core/OnEvent$Executor$Main;
+	public final fun isAvailable ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -3734,7 +3735,7 @@ public final class io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$OnionClient
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$OnionClientAuth$View : io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$Unprivileged {
-	public static final field All Lio/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$OnionClientAuth$View;
+	public static final field ALL Lio/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$OnionClientAuth$View;
 	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd$OnionClientAuth$View$Companion;
 	public final field address Lio/matthewnelson/kmp/tor/runtime/core/address/OnionAddress;
 	public fun <init> (Lio/matthewnelson/kmp/tor/runtime/core/address/OnionAddress$V3;)V

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/Destroyable.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/Destroyable.kt
@@ -15,7 +15,6 @@
  **/
 package io.matthewnelson.kmp.tor.runtime.core
 
-import io.matthewnelson.kmp.tor.runtime.core.Destroyable.Companion.checkIsNotDestroyed
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/TorConfig.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/TorConfig.kt
@@ -55,7 +55,7 @@ import kotlin.time.Duration.Companion.seconds
  * [tor-manual](https://github.com/05nelsonm/kmp-tor-resource/blob/master/docs/tor-man.adoc)
  * are declared within [TorConfig] as subclasses. Many of them do not
  * have their builders implemented, but are available for use with
- * [TorCmd.Config.Get] queries.
+ * [TorCmd.Config.Get] and [TorCmd.Config.Reset] queries.
  *
  * @see [Builder]
  * @see [Companion.Builder]

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/TorEvent.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/TorEvent.kt
@@ -32,6 +32,9 @@ import kotlin.jvm.JvmStatic
  * @see [Event.observer]
  * @see [Processor]
  * @see [TorEvent.Companion]
+ * @see [valueOf]
+ * @see [valueOfOrNull]
+ * @see [entries]
  * */
 public sealed class TorEvent private constructor(
     name: String,

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/Address.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/Address.kt
@@ -18,7 +18,7 @@ package io.matthewnelson.kmp.tor.runtime.core.address
 import kotlin.jvm.JvmField
 
 /**
- * Base abstraction for all address types
+ * Base abstraction for all address types in `kmp-tor`
  *
  * @see [IPAddress]
  * @see [IPSocketAddress]
@@ -31,33 +31,44 @@ public sealed class Address(
 ): Comparable<Address> {
 
     /**
-     * Returns the [value] in its canonicalized hostname form
+     * Returns [value] in its canonicalized hostname form
      *
      * e.g.
      *
-     *     println("127.0.0.1"
+     *     "127.0.0.1"
      *         .toIPAddressV4()
      *         .canonicalHostName()
-     *     )
+     *         .let { println(it) }
      *     // 127.0.0.1
      *
-     *     println("::1"
+     *     "::1"
      *         .toIPAddressV6()
      *         .canonicalHostName()
-     *     )
-     *     // [::1]
+     *         .let { println(it) }
+     *     // [0:0:0:0:0:0:0:1]
      *
-     *     println("http://127.0.0.1:8081/path"
+     *     "http://127.0.0.1:8081/path"
      *         .toIPSocketAddress()
      *         .canonicalHostName()
-     *     )
+     *         .let { println(it) }
      *     // 127.0.0.1
      *
-     *     println("http://2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion"
+     *     "http://[::1%1]:8081/path"
+     *         .toIPSocketAddress()
+     *         .canonicalHostName()
+     *         .let { println(it) }
+     *     // [0:0:0:0:0:0:0:1%1]
+     *
+     *     "2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid"
      *         .toOnionAddressV3()
      *         .canonicalHostName()
-     *     )
+     *         .let { println(it) }
      *     // 2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion
+     *
+     *     LocalHost.IPv4
+     *         .canonicalHostName()
+     *         .let { println(it) }
+     *     // localhost
      * */
     public fun canonicalHostName(): String = when (this) {
         is IPAddress.V4 -> value

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/IPAddress.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/IPAddress.kt
@@ -28,6 +28,25 @@ import kotlin.jvm.*
 /**
  * Base abstraction for denoting an ip address
  *
+ * e.g.
+ *
+ *     "192.168.0.1".toIPAddress()
+ *     "http://127.0.0.1:8080".toIPAddress()
+ *     "::1".toIPAddress()
+ *     "[::1]".toIPAddress()
+ *     "http://[::1]:8080".toIPAddress()
+ *     "https://uName:pass word@[::1]:8443/some/path".toIPAddress()
+ *
+ *     ByteArray(4).toIPAddressV4().let { address ->
+ *         assertIs<IPAddress.V4.AnyHost>(address)
+ *     }
+ *     ByteArray(16).toIPAddressV6(scope = "1").let { address ->
+ *         assertIs<IPAddress.V6.AnyHost>(address)
+ *         assertIsNot<IPAddress.V6.AnyHost.NoScope>(address)
+ *         println(address)
+ *         // 0:0:0:0:0:0:0:0%1
+ *     }
+ *
  * @see [V4]
  * @see [V6]
  * @see [io.matthewnelson.kmp.tor.runtime.core.util.toInetAddress]
@@ -151,7 +170,9 @@ public sealed class IPAddress private constructor(
             @JvmStatic
             @JvmName("get")
             @Throws(IllegalArgumentException::class)
-            public fun ByteArray.toIPAddressV4(): V4 = toIPAddressV4(copy = true)
+            public fun ByteArray.toIPAddressV4(): V4 {
+                return toIPAddressV4(copy = true)
+            }
 
             /**
              * Parses a String for its IPv4 address.

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/IPSocketAddress.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/IPSocketAddress.kt
@@ -24,6 +24,12 @@ import kotlin.jvm.JvmStatic
 
 /**
  * Holder for a inet socket address' parts
+ *
+ * e.g.
+ *
+ *     "127.0.0.1:8080".toIPSocketAddress()
+ *     "[::1]:8080".toIPSocketAddress()
+ *     IPSocketAddress(IPAddress.V4.AnyHost, 8080.toPort())
  * */
 public class IPSocketAddress(
     @JvmField

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/LocalHost.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/LocalHost.kt
@@ -29,7 +29,7 @@ import kotlin.time.TimeSource
 
 /**
  * The host machine's loopback [IPv4] and [IPv6] addresses,
- * typically 127.0.0.1 and ::1, respectively.
+ * typically `127.0.0.1` and `::1`, respectively.
  *
  * Results from system sources are cached for 5s to inhibit
  * unnecessary repeated calls.
@@ -37,12 +37,13 @@ import kotlin.time.TimeSource
 public sealed class LocalHost private constructor(): Address("localhost") {
 
     /**
-     * Resolves "localhost" to an [IPAddress] via system calls
+     * Resolves `localhost` to an [IPAddress] via system calls
      *
      * **NOTE:** This is a blocking call and should be invoked from
      * a background thread.
      *
-     * @throws [IOException] if there were any errors (e.g. calling from Main thread on Android)
+     * @throws [IOException] if there were any errors (e.g. calling
+     *   from Main thread on Android)
      * */
     @Throws(IOException::class)
     public abstract fun resolve(): IPAddress

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/OnionAddress.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/OnionAddress.kt
@@ -34,6 +34,14 @@ import kotlin.jvm.JvmSynthetic
 /**
  * Base abstraction for denoting a String value as a `.onion` address
  *
+ * e.g.
+ *
+ *     val string = "2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid"
+ *
+ *     string.toOnionAddress()
+ *     "http://${string}.onion:8080/some/path".toOnionAddress()
+ *     "http://subdomain.${string}.onion:8080/some/path".toOnionAddress()
+ *
  * @see [V3]
  * */
 public sealed class OnionAddress private constructor(value: String): Address(value) {
@@ -119,7 +127,7 @@ public sealed class OnionAddress private constructor(value: String): Address(val
      * appended.
      *
      * This is only a preliminary check for character and length correctness.
-     * Public key validity is not checked.
+     * Public key validity is **not** checked.
      * */
     public class V3 private constructor(value: String): OnionAddress(value) {
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/Port.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/address/Port.kt
@@ -24,7 +24,12 @@ import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
 /**
- * Holder for a port between 0 and 65535 (inclusive).
+ * Holder for a port between `0` and `65535` (inclusive).
+ *
+ * e.g.
+ *
+ *     443.toPort()
+ *     8443.toPortEphemeral()
  *
  * @see [Ephemeral]
  * @see [io.matthewnelson.kmp.tor.runtime.core.util.isAvailableAsync]

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/builder/TCPPortBuilder.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/builder/TCPPortBuilder.kt
@@ -26,9 +26,6 @@ import io.matthewnelson.kmp.tor.runtime.core.TorConfig
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmSynthetic
 
-// TODO: allowPortReassignment
-//  not here, but in :runtime configuration DSL
-
 @OptIn(InternalKmpTorApi::class)
 public sealed class TCPPortBuilder private constructor() {
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ClientAuthEntry.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ClientAuthEntry.kt
@@ -21,6 +21,9 @@ import io.matthewnelson.kmp.tor.runtime.core.key.AuthKey
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
+/**
+ * Holder for results from [TorCmd.OnionClientAuth.View]
+ * */
 public class ClientAuthEntry private constructor(
     @JvmField
     public val address: OnionAddress,
@@ -28,12 +31,19 @@ public class ClientAuthEntry private constructor(
     public val privateKey: AuthKey.Private,
     @JvmField
     public val clientName: String?,
-    @JvmField
-    public val flags: Set<String>,
+    flags: Set<String>,
 ) {
+
+    @JvmField
+    public val flags: Set<String> = flags.toImmutableSet()
 
     public companion object {
 
+        /**
+         * Creates a new [ClientAuthEntry] for provided key(s).
+         *
+         * @throws [IllegalArgumentException] if key types are incompatible.
+         * */
         @JvmStatic
         @Throws(IllegalArgumentException::class)
         public fun of(
@@ -54,7 +64,7 @@ public class ClientAuthEntry private constructor(
                 address = address,
                 privateKey = privateKey,
                 clientName = clientName,
-                flags = flags.toImmutableSet(),
+                flags = flags,
             )
         }
     }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/HiddenServiceEntry.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/HiddenServiceEntry.kt
@@ -33,9 +33,11 @@ public class HiddenServiceEntry private constructor(
     public val publicKey: AddressKey.Public,
     @JvmField
     public val privateKey: AddressKey.Private?,
-    @JvmField
-    public val clientAuth: Set<AuthKey.Public>,
+    clientAuth: Set<AuthKey.Public>,
 ) {
+
+    @JvmField
+    public val clientAuth: Set<AuthKey.Public> = clientAuth.toImmutableSet()
 
     public companion object {
 
@@ -67,7 +69,7 @@ public class HiddenServiceEntry private constructor(
             return HiddenServiceEntry(
                 publicKey = publicKey,
                 privateKey = privateKey,
-                clientAuth = clientAuth.toImmutableSet(),
+                clientAuth = clientAuth,
             )
         }
     }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/TorCmd.kt
@@ -479,7 +479,7 @@ public sealed class TorCmd<Success: Any> private constructor(
             public companion object {
 
                 @JvmField
-                public val All: View = View(address = null)
+                public val ALL: View = View(address = null)
             }
         }
     }

--- a/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-ExecutorMainInternal.kt
+++ b/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-ExecutorMainInternal.kt
@@ -26,8 +26,8 @@ import kotlin.coroutines.EmptyCoroutineContext
 
 internal actual object ExecutorMainInternal: OnEvent.Executor {
 
-    private val SCOPE by lazy {
-        val main = run {
+    private val MainScope by lazy {
+        val mainDispatcher = run {
             // Will throw if Missing
             Dispatchers.Main.isDispatchNeeded(EmptyCoroutineContext)
 
@@ -41,12 +41,12 @@ internal actual object ExecutorMainInternal: OnEvent.Executor {
         CoroutineScope(context =
             CoroutineName("OnEvent.Executor.Main")
             + SupervisorJob()
-            + main
+            + mainDispatcher
         )
     }
 
     @InternalKmpTorApi
     actual override fun execute(handler: CoroutineContext, executable: Executable) {
-        SCOPE.launch(handler) { executable.execute() }
+        MainScope.launch(handler) { executable.execute() }
     }
 }

--- a/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -186,10 +186,13 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
                 withContext(NonCancellable) {
                     val mark = TimeSource.Monotonic.markNow()
 
-                    while (!isConnected && threw == null) {
-                        delay(5.milliseconds)
+                    val durationTimeout = (42 * 3).milliseconds
+                    val durationDelay = 5.milliseconds
 
-                        if (mark.elapsedNow() < 42.milliseconds) continue
+                    while (!isConnected && threw == null) {
+                        delay(durationDelay)
+
+                        if (mark.elapsedNow() < durationTimeout) continue
 
                         errorDisposable.dispose()
                         socket.destroy()

--- a/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -185,8 +185,13 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
                     }
 
                 try {
-                    val durationTimeout = (42 * 3).milliseconds
-                    val durationDelay = 5.milliseconds
+                    val durationDelay = 10.milliseconds
+                    val durationTimeout = if (SysDirSep == '\\') {
+                        // Windows may need a little more time...
+                        500.milliseconds
+                    } else {
+                        250.milliseconds
+                    }
 
                     val mark = TimeSource.Monotonic.markNow()
 

--- a/library/runtime-service/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/TorRuntimeEnvironment.kt
+++ b/library/runtime-service/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/TorRuntimeEnvironment.kt
@@ -31,6 +31,9 @@ import io.matthewnelson.kmp.tor.runtime.core.apply
  * to acquire default tor directory locations within the application's data
  * directory to create [TorRuntime.Environment].
  *
+ * **NOTE:** [TorRuntime.Environment.Builder.serviceFactoryLoader] is set
+ * automatically and tor will run inside an [android.app.Service].
+ *
  * - workDir: app_torservice
  * - cacheDir: cache/torservice
  * */
@@ -43,6 +46,9 @@ public fun Context.createTorRuntimeEnvironment(
  * Android extension which utilizes [Context.getDir] and [Context.getCacheDir]
  * to acquire default tor directory locations within the application's data
  * directory to create [TorRuntime.Environment].
+ *
+ * **NOTE:** [TorRuntime.Environment.Builder.serviceFactoryLoader] is set
+ * automatically and tor will run inside an [android.app.Service].
  *
  * - workDir: app_torservice
  * - cacheDir: cache/torservice
@@ -58,6 +64,9 @@ public fun Context.createTorRuntimeEnvironment(
  * to acquire tor directory locations within the application's data directory
  * for specified [dirName] to create [TorRuntime.Environment] with.
  *
+ * **NOTE:** [TorRuntime.Environment.Builder.serviceFactoryLoader] is set
+ * automatically and tor will run inside an [android.app.Service].
+ *
  * - workDir: app_[dirName]
  * - cacheDir: cache/[dirName]
  * */
@@ -71,6 +80,9 @@ public fun Context.createTorRuntimeEnvironment(
  * Android extension which utilizes [Context.getDir] and [Context.getCacheDir]
  * to acquire tor directory locations within the application's data directory
  * for specified [dirName] to create [TorRuntime.Environment] with.
+ *
+ * **NOTE:** [TorRuntime.Environment.Builder.serviceFactoryLoader] is set
+ * automatically and tor will run inside an [android.app.Service].
  *
  * - workDir: app_[dirName]
  * - cacheDir: cache/[dirName]

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
@@ -17,8 +17,6 @@
 
 package io.matthewnelson.kmp.tor.runtime
 
-import io.matthewnelson.kmp.process.Process
-import io.matthewnelson.kmp.process.Stdio
 import io.matthewnelson.kmp.tor.runtime.core.*
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.Reply
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
@@ -55,6 +53,9 @@ import kotlin.jvm.JvmSynthetic
  * @see [Event.observer]
  * @see [Processor]
  * @see [RuntimeEvent.Companion]
+ * @see [valueOf]
+ * @see [valueOfOrNull]
+ * @see [entries]
  * */
 public sealed class RuntimeEvent<Data: Any> private constructor(
     name: String
@@ -391,12 +392,12 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
         public data object READY: PROCESS("PROCESS_READY")
 
         /**
-         * Lines output from tor's [Process] [Stdio.Config.stdout] stream.
+         * Lines from the tor process' standard output stream.
          * */
         public data object STDOUT: PROCESS("PROCESS_STDOUT")
 
         /**
-         * Lines output by tor's [Process] [Stdio.Config.stderr] stream.
+         * Lines form the tor process' error output stream.
          * */
         public data object STDERR: PROCESS("PROCESS_STDERR")
     }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -80,11 +80,15 @@ public sealed interface TorRuntime:
      * If tor is **not** 100% bootstrapped with network enabled,
      * [TorListeners.isEmpty] will always be true for the returned
      * instance of [TorListeners].
+     *
+     * @see [RuntimeEvent.LISTENERS]
      * */
     public fun listeners(): TorListeners
 
     /**
      * Returns the current [TorState] of this [TorRuntime] instance.
+     *
+     * @see [RuntimeEvent.STATE]
      * */
     public fun state(): TorState
 
@@ -334,9 +338,6 @@ public sealed interface TorRuntime:
             /**
              * Opener for creating an [Environment] instance.
              *
-             * If an [Environment] has already been created for the provided
-             * [workDirectory], that [Environment] instance will be returned.
-             *
              * [workDirectory] should be specified within your application's home
              * directory (e.g. `$HOME/.my_application/torservice`). This will
              * be utilized as the tor process' `HOME` environment variable.
@@ -348,9 +349,13 @@ public sealed interface TorRuntime:
              * identical (e.g. `torservice`), especially when creating multiple
              * instances of [Environment].
              *
-             * **WARNING:** When running multiple instances ot [TorRuntime],
-             * declaring the same [cacheDirectory] as another [Environment] will result
-             * in a bad day. No checks are performed for this clash.
+             * **NOTE:** If the same directory is utilized for both [workDirectory]
+             * and [cacheDirectory], tor may fail to start; they **must** be different.
+             *
+             * **NOTE:** If multiple [Environment] are being created, they **must**
+             * have different [workDirectory] and [cacheDirectory]. If an [Environment]
+             * has already been created that uses the declared [workDirectory] or
+             * [cacheDirectory], that [Environment] instance will be returned instead.
              *
              * @param [workDirectory] tor's working directory (e.g. `$HOME/.my_application/torservice`)
              *   This will be utilized as the tor process' `HOME` environment variable.
@@ -369,9 +374,6 @@ public sealed interface TorRuntime:
             /**
              * Opener for creating an [Environment] instance.
              *
-             * If an [Environment] has already been created for the provided
-             * [workDirectory], that [Environment] instance will be returned.
-             *
              * [workDirectory] should be specified within your application's home
              * directory (e.g. `$HOME/.my_application/torservice`). This will
              * be utilized as the tor process' `HOME` environment variable.
@@ -383,9 +385,13 @@ public sealed interface TorRuntime:
              * identical (e.g. `torservice`), especially when creating multiple
              * instances of [Environment].
              *
-             * **WARNING:** When running multiple instances ot [TorRuntime],
-             * declaring the same [cacheDirectory] as another [Environment] will result
-             * in a bad day. No checks are performed for this clash.
+             * **NOTE:** If the same directory is utilized for both [workDirectory]
+             * and [cacheDirectory], tor may fail to start; they **must** be different.
+             *
+             * **NOTE:** If multiple [Environment] are being created, they **must**
+             * have different [workDirectory] and [cacheDirectory]. If an [Environment]
+             * has already been created that uses the declared [workDirectory] or
+             * [cacheDirectory], that [Environment] instance will be returned instead.
              *
              * @param [workDirectory] tor's working directory (e.g. `$HOME/.my_application/torservice`)
              *   This will be utilized as the tor process' `HOME` environment variable.
@@ -463,7 +469,7 @@ public sealed interface TorRuntime:
             @ExperimentalKmpTorApi
             public var serviceFactoryLoader: ServiceFactory.Loader? = null
 
-            internal companion object: InstanceKeeper<File, Environment>() {
+            internal companion object: InstanceKeeper<EnvironmentKey, Environment>() {
 
                 @JvmSynthetic
                 internal fun build(
@@ -478,8 +484,10 @@ public sealed interface TorRuntime:
                     if (block != null) b.apply(block)
                     val torResource = installer(b.installationDirectory.absoluteFile.normalize())
 
+                    val key = EnvironmentKey(b.workDirectory, b.cacheDirectory)
+
                     @OptIn(ExperimentalKmpTorApi::class)
-                    return getOrCreateInstance(key = b.workDirectory, block = {
+                    return getOrCreateInstance(key = key, block = {
 
                         // Always reset, just in case it was overridden
                         b.processEnv["HOME"] = b.workDirectory.path

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntime.kt
@@ -352,10 +352,8 @@ public sealed interface TorRuntime:
              * **NOTE:** If the same directory is utilized for both [workDirectory]
              * and [cacheDirectory], tor may fail to start; they **must** be different.
              *
-             * **NOTE:** If multiple [Environment] are being created, they **must**
-             * have different [workDirectory] and [cacheDirectory]. If an [Environment]
-             * has already been created that uses the declared [workDirectory] or
-             * [cacheDirectory], that [Environment] instance will be returned instead.
+             * **NOTE:** If an [Environment] already exists for the provided [workDirectory]
+             * **or** [cacheDirectory], that instance will be returned.
              *
              * @param [workDirectory] tor's working directory (e.g. `$HOME/.my_application/torservice`)
              *   This will be utilized as the tor process' `HOME` environment variable.
@@ -388,10 +386,8 @@ public sealed interface TorRuntime:
              * **NOTE:** If the same directory is utilized for both [workDirectory]
              * and [cacheDirectory], tor may fail to start; they **must** be different.
              *
-             * **NOTE:** If multiple [Environment] are being created, they **must**
-             * have different [workDirectory] and [cacheDirectory]. If an [Environment]
-             * has already been created that uses the declared [workDirectory] or
-             * [cacheDirectory], that [Environment] instance will be returned instead.
+             * **NOTE:** If an [Environment] already exists for the provided [workDirectory]
+             * **or** [cacheDirectory], that instance will be returned.
              *
              * @param [workDirectory] tor's working directory (e.g. `$HOME/.my_application/torservice`)
              *   This will be utilized as the tor process' `HOME` environment variable.

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/EnvironmentKey.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/EnvironmentKey.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.internal
+
+import io.matthewnelson.kmp.file.File
+
+internal class EnvironmentKey internal constructor(internal val work: File, internal val cache: File) {
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is EnvironmentKey) return false
+        if (other.work == work) return true
+        if (other.work == cache) return true
+        if (other.cache == work) return true
+        if (other.cache == cache) return true
+        return false
+    }
+
+    override fun hashCode(): Int {
+        var result = 17
+        result = result * 42 + work.hashCode()
+        result = result * 42 + cache.hashCode()
+        return result
+    }
+}

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorCmdUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorCmdUnitTest.kt
@@ -375,7 +375,7 @@ class TorCmdUnitTest {
             )
         ).let { result -> assertEquals(1, result.size) }
 
-        val all = runtime.executeAsync(TorCmd.OnionClientAuth.View.All)
+        val all = runtime.executeAsync(TorCmd.OnionClientAuth.View.ALL)
         all.forEach { println(it) }
 
         val filtered = entries.map { it.publicKey.address() }.let { addresses ->
@@ -399,7 +399,7 @@ class TorCmdUnitTest {
             runtime.executeAsync(TorCmd.OnionClientAuth.Remove(address))
         }
 
-        runtime.executeAsync(TorCmd.OnionClientAuth.View.All).let { result ->
+        runtime.executeAsync(TorCmd.OnionClientAuth.View.ALL).let { result ->
             assertEquals(0, result.size)
         }
 

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeEnvironmentUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeEnvironmentUnitTest.kt
@@ -32,17 +32,17 @@ class TorRuntimeEnvironmentUnitTest {
 
     @Test
     fun givenSameWorkDir_whenEnvironmentBuilder_thenReturnsSameInstance() {
-        val work = "".toFile().absoluteFile.resolve("env_instance")
+        val rootDir = "".toFile().absoluteFile.resolve("env_instance")
 
-        val env1 = TorRuntime.Environment.Builder(work, work.resolve("cache")) { torResource(it) }
-        val env2 = TorRuntime.Environment.Builder(work, work.resolve("cache2")) { torResource(it) }
+        val env1 = TorRuntime.Environment.Builder(rootDir.resolve("work"), rootDir.resolve("cache")) { torResource(it) }
+        val env2 = TorRuntime.Environment.Builder(rootDir.resolve("work"), rootDir.resolve("cache2")) { torResource(it) }
         assertEquals(env1, env2)
         assertEquals(64, env1.fid.length)
 
-        val env3 = TorRuntime.Environment.Builder(work.resolve("work"), work.resolve("cache")) { torResource(it) }
+        val env3 = TorRuntime.Environment.Builder(rootDir.resolve("work3"), rootDir.resolve("cache3")) { torResource(it) }
         assertNotEquals(env1, env3)
 
-        val innerOuterWork = work.resolve("lambda")
+        val innerOuterWork = rootDir.resolve("lambda")
         var envInner: TorRuntime.Environment? = null
         val envOuter = TorRuntime.Environment.Builder(
             innerOuterWork,

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/EnvironmentKeyUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/EnvironmentKeyUnitTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime.internal
+
+import io.matthewnelson.kmp.file.File
+import io.matthewnelson.kmp.file.toFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class EnvironmentKeyUnitTest {
+
+    private val key = EnvironmentKey("work".toFile(), "cache".toFile())
+
+    @Test
+    fun givenKey_whenSameWorkDirDifferentCacheDir_thenIsEqual() {
+        val copy = key.copy(cache = "cache2".toFile())
+        assertEquals(key.work, copy.work)
+        assertNotEquals(key.cache, copy.cache)
+        assertEquals(key, copy)
+    }
+
+    @Test
+    fun givenKey_whenSameCacheDirDifferentWorkDir_thenIsEqual() {
+        val copy = key.copy(work = "work2".toFile())
+        assertEquals(key.cache, copy.cache)
+        assertNotEquals(key.work, copy.work)
+        assertEquals(key, copy)
+    }
+
+    @Test
+    fun givenKey_whenCacheDirWorkDirDifferent_thenIsNotEqual() {
+        val other = EnvironmentKey("work2".toFile(), "cache2".toFile())
+        assertNotEquals(key.work, other.work)
+        assertNotEquals(key.cache, other.cache)
+        assertNotEquals(key, other)
+    }
+
+    private fun EnvironmentKey.copy(work: File = this.work, cache: File = this.cache): EnvironmentKey {
+        return EnvironmentKey(work, cache)
+    }
+}


### PR DESCRIPTION
Closes #441 