### PR TITLE
Re-use `ResourceInstaller` when same `installationDirectory` is defined

### DIFF
--- a/library/runtime-core/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/NativeLocalHostExt.kt
+++ b/library/runtime-core/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/NativeLocalHostExt.kt
@@ -17,7 +17,6 @@
 
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
-import io.matthewnelson.kmp.file.errnoToIOException
 import io.matthewnelson.kmp.tor.runtime.core.address.IPAddress
 import io.matthewnelson.kmp.tor.runtime.core.address.IPAddress.V4.Companion.toIPAddressV4OrNull
 import io.matthewnelson.kmp.tor.runtime.core.address.IPAddress.V6.Companion.toIPAddressV6OrNull
@@ -37,9 +36,10 @@ internal actual fun LocalHost.Companion.tryPlatformResolve(set: LinkedHashSet<IP
         }
 
         val result = alloc<CPointerVar<addrinfo>>()
+        defer { freeaddrinfo(result.value) }
 
         if (getaddrinfo("localhost", null, hint, result.ptr) != 0) {
-            throw errnoToIOException(errno)
+            return@memScoped
         }
 
         var info: addrinfo? = result.pointed
@@ -52,8 +52,6 @@ internal actual fun LocalHost.Companion.tryPlatformResolve(set: LinkedHashSet<IP
 
             info = info.ai_next?.pointed
         }
-
-        freeaddrinfo(result.value)
     }
 }
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/InstanceKeeper.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/InstanceKeeper.kt
@@ -15,6 +15,7 @@
  **/
 package io.matthewnelson.kmp.tor.runtime.internal
 
+import io.matthewnelson.immutable.collections.toImmutableList
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.resource.SynchronizedObject
 import io.matthewnelson.kmp.tor.core.resource.synchronized
@@ -27,7 +28,7 @@ internal abstract class InstanceKeeper<K: Any, V: Any> internal constructor(init
 
     protected fun getOrCreateInstance(
         key: K,
-        block: () -> V,
+        block: (others: List<Pair<K, V>>) -> V,
     ): V = synchronized(lock) {
         var instance: V? = null
 
@@ -39,7 +40,8 @@ internal abstract class InstanceKeeper<K: Any, V: Any> internal constructor(init
         }
 
         if (instance == null) {
-            val i = block()
+            val others = instances.toImmutableList()
+            val i = block(others)
             instances.add(key to i)
             instance = i
         }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorConfigGenerator.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorConfigGenerator.kt
@@ -72,7 +72,11 @@ internal class TorConfigGenerator internal constructor(
         NOTIFIER: Notifier,
     ): TorConfig = TorConfig.Builder {
         NOTIFIER.d(this@TorConfigGenerator, "Refreshing localhost IP address cache")
-        LocalHost.refreshCache()
+        try {
+            LocalHost.refreshCache()
+        } catch (_: IOException) {
+            NOTIFIER.w(this@TorConfigGenerator, "Refreshing localhost IP addresses failed")
+        }
 
         // Apply library consumers' configuration(s)
         config.forEach { block -> apply(environment, block) }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeEnvironmentUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/TorRuntimeEnvironmentUnitTest.kt
@@ -71,4 +71,26 @@ class TorRuntimeEnvironmentUnitTest {
         }
         assertEquals(env.processEnv["HOME"], workDir.path)
     }
+
+    @Test
+    fun givenMultipleEnvironments_whenSameInstallationDir_thenUsesSameResourceInstaller() {
+        val rootDir = "".toFile().absoluteFile.resolve("env_installer")
+        val env1 = TorRuntime.Environment.Builder(
+            rootDir.resolve("work1"),
+            rootDir.resolve("cache1"),
+            installer = { torResource(it) }
+        ) {
+            installationDirectory = rootDir
+        }
+        val env2 = TorRuntime.Environment.Builder(
+            rootDir.resolve("work2"),
+            rootDir.resolve("cache2"),
+            installer = { torResource(it) }
+        ) {
+            installationDirectory = rootDir
+        }
+
+        assertNotEquals(env1, env2)
+        assertEquals(env1.torResource, env2.torResource)
+    }
 }


### PR DESCRIPTION
Closes #447 