### PR TITLE
Make `RuntimeEvent.ERROR` observers always utilize `OnEvent.Executor.Immediate`

### DIFF
--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEvent.kt
@@ -68,6 +68,8 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
      * observers (including [TorEvent] observers) are piped to [ERROR]
      * observers as [UncaughtException].
      *
+     * **NOTE:** All [ERROR] observers utilize [OnEvent.Executor.Immediate].
+     *
      * **NOTE:** Any exceptions thrown by [ERROR] observers are re-thrown
      * as [UncaughtException] (if not already one). This will likely crash
      * the program.
@@ -456,10 +458,13 @@ public sealed class RuntimeEvent<Data: Any> private constructor(
         executor: OnEvent.Executor?,
         onEvent: OnEvent<Data>,
     ): Event.Observer<Data, RuntimeEvent<Data>>(
-        event,
-        tag,
-        executor,
-        onEvent,
+        event = event,
+        tag = tag,
+        executor = when (event) {
+            is ERROR -> OnEvent.Executor.Immediate
+            else -> executor
+        },
+        onEvent = onEvent,
     )
 
     /**

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessor.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessor.kt
@@ -138,21 +138,20 @@ internal abstract class AbstractRuntimeEventProcessor internal constructor(
         }
 
         if (event is RuntimeEvent.ERROR) {
-            UncaughtException.Handler.THROW.withSuppression {
-                notify(observers, data)
-            }
+            UncaughtException.Handler.THROW.withSuppression { notify(observers, data) }
         } else {
             handler.notify(observers, data)
         }
     }
 
-    private fun <Data: Any> UncaughtException.Handler?.notify(observers: List<RuntimeEvent.Observer<*>>, data: Data) {
+    private fun <Data: Any> UncaughtException.Handler.notify(observers: List<RuntimeEvent.Observer<*>>, data: Data) {
         observers.forEach { observer ->
             val ctx = ObserverContext(observer.toString(isStatic = observer.tag.isStaticTag()))
+            val handlerContext = if (this is HandlerWithContext) this + ctx else ctx
 
             tryCatch(ctx) {
                 @Suppress("UNCHECKED_CAST")
-                (observer as RuntimeEvent.Observer<Data>).notify(handler + ctx, defaultExecutor, data)
+                (observer as RuntimeEvent.Observer<Data>).notify(handlerContext, defaultExecutor, data)
             }
         }
     }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessor.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessor.kt
@@ -24,6 +24,7 @@ import io.matthewnelson.kmp.tor.runtime.ctrl.AbstractTorEventProcessor
 import io.matthewnelson.kmp.tor.runtime.core.TorEvent
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
 
 @OptIn(InternalKmpTorApi::class)
 internal abstract class AbstractRuntimeEventProcessor internal constructor(
@@ -38,8 +39,6 @@ internal abstract class AbstractRuntimeEventProcessor internal constructor(
     private val observers = LinkedHashSet<RuntimeEvent.Observer<*>>(observersRuntimeEvent.size + 1, 1.0F)
     private val lock = SynchronizedObject()
     protected override val handler = HandlerWithContext.of { t -> RuntimeEvent.ERROR.notifyObservers(t) }
-    // Used for RuntimeEvent.ERROR ONLY
-    private val handlerERROR = HandlerWithContext.of(UncaughtException.Handler.THROW)
 
     init {
         observers.addAll(observersRuntimeEvent)
@@ -138,19 +137,22 @@ internal abstract class AbstractRuntimeEventProcessor internal constructor(
             return
         }
 
-        val handler = if (event is RuntimeEvent.ERROR) {
-            handlerERROR
+        if (event is RuntimeEvent.ERROR) {
+            UncaughtException.Handler.THROW.withSuppression {
+                notify(observers, data)
+            }
         } else {
-            handler
+            handler.notify(observers, data)
         }
+    }
 
+    private fun <Data: Any> UncaughtException.Handler?.notify(observers: List<RuntimeEvent.Observer<*>>, data: Data) {
         observers.forEach { observer ->
             val ctx = ObserverContext(observer.toString(isStatic = observer.tag.isStaticTag()))
 
-            handler.tryCatch(ctx) {
+            tryCatch(ctx) {
                 @Suppress("UNCHECKED_CAST")
-                (observer as RuntimeEvent.Observer<Data>)
-                    .notify(handler + ctx, defaultExecutor, data)
+                (observer as RuntimeEvent.Observer<Data>).notify(handler + ctx, defaultExecutor, data)
             }
         }
     }

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEventUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/RuntimeEventUnitTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.runtime
+
+import io.matthewnelson.kmp.tor.runtime.core.OnEvent
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class RuntimeEventUnitTest {
+
+    @Test
+    fun givenEvent_whenERROR_thenExecutorIsAlwaysImmediate() {
+        val immediate = OnEvent.Executor.Immediate.toString()
+
+        assertTrue(RuntimeEvent.ERROR.observer {}.toString().contains(immediate))
+        assertTrue(RuntimeEvent.ERROR.observer(null, OnEvent.Executor.Main) {}.toString().contains(immediate))
+    }
+}

--- a/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessorUnitTest.kt
+++ b/library/runtime/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/internal/AbstractRuntimeEventProcessorUnitTest.kt
@@ -246,6 +246,25 @@ class AbstractRuntimeEventProcessorUnitTest {
     }
 
     @Test
+    fun givenMultipleErrorObservers_whenThrows_thenUncaughtExceptionsStacked() {
+        var invocationO1 = 0
+        var invocationO2 = 0
+        var invocationO3 = 0
+        val o1 = RuntimeEvent.ERROR.observer { invocationO1++ }
+        val o2 = RuntimeEvent.ERROR.observer { invocationO2++; throw it }
+        val o3 = RuntimeEvent.ERROR.observer { invocationO3++ }
+        processor.subscribe(o1, o2, o3)
+
+        assertFailsWith<UncaughtException> {
+            processor.notify(RuntimeEvent.ERROR, IllegalStateException())
+        }
+
+        assertEquals(1, invocationO1)
+        assertEquals(1, invocationO2)
+        assertEquals(1, invocationO3)
+    }
+
+    @Test
     fun givenIsService_whenDestroyed_thenStaticObserversNotRemoved() {
         var invocationDebug = 0
         val processor = TestProcessor(isService = true)


### PR DESCRIPTION
Closes #454 