### PR TITLE
Do not fail service start if `ACCESS_NETWORK_STATE` permission missing

### DIFF
--- a/library/runtime-service/src/androidInstrumentedTest/AndroidManifest.xml
+++ b/library/runtime-service/src/androidInstrumentedTest/AndroidManifest.xml
@@ -21,7 +21,6 @@
 
     <uses-sdk tools:overrideLibrary="io.matthewnelson.kmp.tor.resource.tor" />
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>

--- a/library/runtime-service/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/runtime/service/AndroidServiceFactoryTest.kt
+++ b/library/runtime-service/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/runtime/service/AndroidServiceFactoryTest.kt
@@ -15,6 +15,7 @@
  **/
 package io.matthewnelson.kmp.tor.runtime.service
 
+import android.Manifest.permission.ACCESS_NETWORK_STATE
 import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
@@ -200,7 +201,7 @@ class AndroidServiceFactoryTest {
         }
 
         assertTrue(config.useNetworkStateObserver)
-        assertFalse(ctx.isPermissionGranted("android.permission.ACCESS_NETWORK_STATE"))
+        assertFalse(ctx.isPermissionGranted(ACCESS_NETWORK_STATE))
         val env = newEnvironment("sf_permissions")
 
         val exceptions = mutableListOf<IllegalStateException>()
@@ -217,7 +218,7 @@ class AndroidServiceFactoryTest {
             synchronized(exceptions) {
                 assertEquals(1, exceptions.size)
                 // Missing permissions exception
-                assertEquals(true, exceptions.first().message?.contains("ACCESS_NETWORK_STATE"))
+                assertEquals(true, exceptions.first().message?.contains(ACCESS_NETWORK_STATE))
             }
         } catch (t: Throwable) {
             factory.enqueue(Action.StopDaemon, {}, {})

--- a/library/runtime-service/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/runtime/service/AndroidServiceFactoryTest.kt
+++ b/library/runtime-service/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/tor/runtime/service/AndroidServiceFactoryTest.kt
@@ -15,7 +15,9 @@
  **/
 package io.matthewnelson.kmp.tor.runtime.service
 
+import android.content.Context
 import android.os.Build
+import androidx.test.core.app.ApplicationProvider
 import io.matthewnelson.kmp.process.Blocking
 import io.matthewnelson.kmp.tor.resource.tor.TorResources
 import io.matthewnelson.kmp.tor.runtime.Action
@@ -26,13 +28,18 @@ import io.matthewnelson.kmp.tor.runtime.RuntimeEvent
 import io.matthewnelson.kmp.tor.runtime.TorRuntime
 import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException
+import io.matthewnelson.kmp.tor.runtime.service.internal.isPermissionGranted
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
 class AndroidServiceFactoryTest {
 
-    private val config = TorServiceConfig.Builder {}
+    private val ctx = ApplicationProvider.getApplicationContext<Context>()
+
+    private val config = TorServiceConfig.Builder {
+        useNetworkStateObserver = true
+    }
 
     private fun newEnvironment(dirName: String): TorRuntime.Environment {
         return config.newEnvironment(
@@ -181,6 +188,39 @@ class AndroidServiceFactoryTest {
         } catch (t: Throwable) {
             factory1.enqueue(Action.StopDaemon, {}, {})
             factory2.enqueue(Action.StopDaemon, {}, {})
+            throw t
+        }
+    }
+
+    @Test
+    fun givenNetworkObserver_whenNoPermissions_thenStillStarts() {
+        if (Build.VERSION.SDK_INT < 21) {
+            println("Skipping...")
+            return
+        }
+
+        assertTrue(config.useNetworkStateObserver)
+        assertFalse(ctx.isPermissionGranted("android.permission.ACCESS_NETWORK_STATE"))
+        val env = newEnvironment("sf_permissions")
+
+        val exceptions = mutableListOf<IllegalStateException>()
+        val factory = TorRuntime.Builder(env) {
+            observerStatic(RuntimeEvent.ERROR) { t ->
+                if (t !is IllegalStateException) throw t
+                synchronized(exceptions) { exceptions.add(t) }
+            }
+        }
+
+        try {
+            factory.startDaemonSync().stopDaemonSync()
+
+            synchronized(exceptions) {
+                assertEquals(1, exceptions.size)
+                // Missing permissions exception
+                assertEquals(true, exceptions.first().message?.contains("ACCESS_NETWORK_STATE"))
+            }
+        } catch (t: Throwable) {
+            factory.enqueue(Action.StopDaemon, {}, {})
             throw t
         }
     }

--- a/library/runtime-service/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/TorService.kt
+++ b/library/runtime-service/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/TorService.kt
@@ -226,24 +226,15 @@ internal class TorService internal constructor(): Service() {
                     })
 
                     if (conn.config.useNetworkStateObserver) {
-                        val observer = try {
-                            AndroidNetworkObserver.of(service, service.serviceJob)
+                        try {
+                            val observer = AndroidNetworkObserver.of(service, service.serviceJob)
+                            service.networkObserver = observer
                         } catch (e: IllegalStateException) {
                             // Configured to be used, but permission was missing.
                             executables.add(Executable {
                                 conn.binder.e(e)
-
-                                val appContext = appContext.get()
-                                appContext.unbindService(conn)
-                                conn.binder.lce(Lifecycle.Event.OnUnbind(service))
-                                appContext.stopService(Intent(appContext, TorService::class.java))
                             })
-                            null
                         }
-
-                        if (observer == null) return@withLock executables
-
-                        service.networkObserver = observer
                     }
 
                     // TorServiceConfig is a singleton and is the same for all

--- a/library/runtime-service/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/internal/AndroidNetworkObserver.kt
+++ b/library/runtime-service/src/androidMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/internal/AndroidNetworkObserver.kt
@@ -111,7 +111,7 @@ internal class AndroidNetworkObserver private constructor(
                     Either:
                      - Set TorServiceConfig.Builder.useNetworkStateObserver to 'false'
                      - Add the following permission to your Manifest:
-                         <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+                         <uses-permission android:name="$ACCESS_NETWORK_STATE" />
                 """.trimIndent()
             }
 


### PR DESCRIPTION
Closes #479

Added note in #481 to add a test for when `ACCESS_NETWORK_STATE` permission is held to ensure the `NetworkStateObserver` is being utilized.