### PR TITLE
Inline `UncaughtException.Handler` helper functions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,14 +57,18 @@ plugins.withType<YarnPlugin> {
 }
 
 apiValidation {
-    // :runtime-service & :runtime-service-ui modules are problematic on
-    // non-macOS hosts because only iOS is enabled for native there.
     @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
-    klib.enabled = HostManager.hostIsMac && findProperty("KMP_TARGETS") == null
+    klib.enabled = findProperty("KMP_TARGETS") == null
 
     if (CHECK_PUBLICATION) {
         ignoredProjects.add("check-publication")
     } else {
         nonPublicMarkers.add("io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi")
+
+        @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
+        if (!HostManager.hostIsMac && klib.enabled) {
+            ignoredProjects.add("runtime-service")
+            ignoredProjects.add("runtime-service-ui")
+        }
     }
 }

--- a/library/runtime-core/api/runtime-core.api
+++ b/library/runtime-core/api/runtime-core.api
@@ -388,10 +388,15 @@ public final class io/matthewnelson/kmp/tor/runtime/core/TorEvent$WARN : io/matt
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/UncaughtException : java/lang/RuntimeException {
+	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Companion;
 	public final field context Ljava/lang/String;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCause ()Ljava/lang/Throwable;
 	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/UncaughtException$Companion {
+	public final synthetic fun of (Ljava/lang/String;Ljava/lang/Throwable;)Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException;
 }
 
 public abstract interface class io/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler : io/matthewnelson/kmp/tor/runtime/core/ItBlock {
@@ -401,21 +406,31 @@ public abstract interface class io/matthewnelson/kmp/tor/runtime/core/UncaughtEx
 	public static final field THROW Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;
 	public static fun fromCoroutineContextOrNull (Lkotlin/coroutines/CoroutineContext;)Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;
 	public static fun tryCatch (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Ljava/lang/Object;Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
+	public static fun tryCatch2 (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
 	public static fun withSuppression (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static fun withSuppression2 (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler$Companion {
 	public final fun fromCoroutineContextOrNull (Lkotlin/coroutines/CoroutineContext;)Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;
 	public final fun tryCatch (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Ljava/lang/Object;Lio/matthewnelson/kmp/tor/runtime/core/ItBlock;)V
+	public final fun tryCatch2 (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
 	public final fun withSuppression (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun withSuppression2 (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class io/matthewnelson/kmp/tor/runtime/core/UncaughtException$SuppressedHandler : io/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler {
+	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$SuppressedHandler$Companion;
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun invoke (Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException;)V
 	public synthetic fun invoke (Ljava/lang/Object;)V
 	public final fun isActive ()Z
+	public final synthetic fun root ()Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/runtime/core/UncaughtException$SuppressedHandler$Companion {
+	public final synthetic fun of (Lkotlin/jvm/functions/Function0;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$Handler;)Lio/matthewnelson/kmp/tor/runtime/core/UncaughtException$SuppressedHandler;
 }
 
 public abstract interface class io/matthewnelson/kmp/tor/runtime/core/config/ConfigurableContract {

--- a/library/runtime-core/api/runtime-core.klib.api
+++ b/library/runtime-core/api/runtime-core.klib.api
@@ -3181,6 +3181,8 @@ final class io.matthewnelson.kmp.tor.runtime.core/UncaughtException : kotlin/Run
             final fun (io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler?).tryCatch(kotlin/Any, io.matthewnelson.kmp.tor.runtime.core/ItBlock<kotlin/Unit>) // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler.Companion.tryCatch|tryCatch@io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler?(kotlin.Any;io.matthewnelson.kmp.tor.runtime.core.ItBlock<kotlin.Unit>){}[0]
             final fun (kotlin.coroutines/CoroutineContext).uncaughtExceptionHandlerOrNull(): io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler? // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler.Companion.uncaughtExceptionHandlerOrNull|uncaughtExceptionHandlerOrNull@kotlin.coroutines.CoroutineContext(){}[0]
             final fun <#A3: kotlin/Any?> (io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler?).withSuppression(kotlin/Function1<io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler, #A3>): #A3 // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler.Companion.withSuppression|withSuppression@io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler?(kotlin.Function1<io.matthewnelson.kmp.tor.runtime.core.UncaughtException.SuppressedHandler,0:0>){0§<kotlin.Any?>}[0]
+            final inline fun (io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler?).tryCatch2(kotlin/Any, kotlin/Function0<kotlin/Unit>) // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler.Companion.tryCatch2|tryCatch2@io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler?(kotlin.Any;kotlin.Function0<kotlin.Unit>){}[0]
+            final inline fun <#A3: kotlin/Any?> (io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler?).withSuppression2(kotlin/Function1<io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler, #A3>): #A3 // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler.Companion.withSuppression2|withSuppression2@io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler?(kotlin.Function1<io.matthewnelson.kmp.tor.runtime.core.UncaughtException.SuppressedHandler,0:0>){0§<kotlin.Any?>}[0]
         }
     }
 
@@ -3189,7 +3191,16 @@ final class io.matthewnelson.kmp.tor.runtime.core/UncaughtException : kotlin/Run
             final fun <get-isActive>(): kotlin/Boolean // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler.isActive.<get-isActive>|<get-isActive>(){}[0]
 
         final fun invoke(io.matthewnelson.kmp.tor.runtime.core/UncaughtException) // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler.invoke|invoke(io.matthewnelson.kmp.tor.runtime.core.UncaughtException){}[0]
+        final fun root(): io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler.root|root(){}[0]
         final fun toString(): kotlin/String // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler.toString|toString(){}[0]
+
+        final object Companion { // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler.Companion|null[0]
+            final fun of(kotlin/Function0<kotlin/Boolean>, io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler, io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Handler): io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.SuppressedHandler.Companion.of|of(kotlin.Function0<kotlin.Boolean>;io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler;io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler){}[0]
+        }
+    }
+
+    final object Companion { // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Companion|null[0]
+        final fun of(kotlin/String, kotlin/Throwable): io.matthewnelson.kmp.tor.runtime.core/UncaughtException // io.matthewnelson.kmp.tor.runtime.core/UncaughtException.Companion.of|of(kotlin.String;kotlin.Throwable){}[0]
     }
 }
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/EnqueuedJob.kt
@@ -23,8 +23,8 @@ import io.matthewnelson.kmp.tor.common.core.synchronized
 import io.matthewnelson.kmp.tor.common.core.synchronizedObject
 import io.matthewnelson.kmp.tor.runtime.core.EnqueuedJob.ExecutionPolicy.Cancellation
 import io.matthewnelson.kmp.tor.runtime.core.EnqueuedJob.State.*
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch2
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression2
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.SuppressedHandler
 import io.matthewnelson.kmp.tor.runtime.core.util.awaitAsync
 import kotlin.concurrent.Volatile
@@ -161,7 +161,7 @@ public abstract class EnqueuedJob protected constructor(
 
         // Invoke immediately
         if (wasAdded == null) {
-            UncaughtException.Handler.THROW.tryCatch(toString()) {
+            UncaughtException.Handler.THROW.tryCatch2(toString()) {
                 handle(_cancellationException)
             }
             return Disposable.noOp()
@@ -705,8 +705,8 @@ public abstract class EnqueuedJob protected constructor(
 
         val context = toString(this)
 
-        _handler.withSuppression {
-            tryCatch(context) { action() }
+        _handler.withSuppression2 {
+            tryCatch2(context) { action() }
 
             @OptIn(InternalKmpTorApi::class)
             synchronized(lock) {
@@ -723,7 +723,7 @@ public abstract class EnqueuedJob protected constructor(
                 _completionCallbacks = null
                 callbacks
             }?.forEach { callback ->
-                tryCatch("$context.invokeOnCompletion") {
+                tryCatch2("$context.invokeOnCompletion") {
                     callback(_cancellationException)
                 }
             }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/UncaughtException.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/UncaughtException.kt
@@ -227,13 +227,7 @@ public class UncaughtException private constructor(
 
             /** @suppress */
             @JvmStatic
-            @Deprecated(
-                "Use withSuppression2",
-                ReplaceWith(
-                    "this.withSuppression2 { block() }",
-                    "io.matthewnelson.kmp.tor.core.UncaughtException.Handler.withSuppression2"
-                )
-            )
+            @Deprecated("Use withSuppression2", ReplaceWith("this.withSuppression2 { block() }"))
             public fun <T: Any?> Handler?.withSuppression(block: SuppressedHandler.() -> T): T {
                 return withSuppression2(block)
             }

--- a/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/UncaughtExceptionUnitTest.kt
+++ b/library/runtime-core/src/commonTest/kotlin/io/matthewnelson/kmp/tor/runtime/core/UncaughtExceptionUnitTest.kt
@@ -15,19 +15,19 @@
  **/
 package io.matthewnelson.kmp.tor.runtime.core
 
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch2
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression2
 import kotlin.test.*
 
 class UncaughtExceptionUnitTest {
 
     @Test
     fun givenHandler_whenEmbeddedWithSuppressionCalls_thenReturnsSameInstance() {
-        UncaughtException.Handler.THROW.withSuppression {
+        UncaughtException.Handler.THROW.withSuppression2 {
             val handler1 = this
-            withSuppression {
+            withSuppression2 {
                 val handler2 = this
-                tryCatch("") {
+                tryCatch2("") {
                     assertEquals(handler1, handler2)
                 }
             }
@@ -37,8 +37,8 @@ class UncaughtExceptionUnitTest {
     @Test
     fun givenHandler_whenWithSuppression_thenAddsMultipleExceptions() {
         val exceptions = mutableListOf<UncaughtException>()
-        UncaughtException.Handler { exceptions.add(it) }.withSuppression {
-            repeat(3) { i -> tryCatch(i) { throw IllegalStateException("$i") } }
+        UncaughtException.Handler { exceptions.add(it) }.withSuppression2 {
+            repeat(3) { i -> tryCatch2(i) { throw IllegalStateException("$i") } }
         }
 
         assertEquals(1, exceptions.size)

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-CommonPlatform.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-CommonPlatform.kt
@@ -24,8 +24,8 @@ import io.matthewnelson.kmp.tor.runtime.core.OnFailure
 import io.matthewnelson.kmp.tor.runtime.core.EnqueuedJob
 import io.matthewnelson.kmp.tor.runtime.core.EnqueuedJob.Companion.toImmediateErrorJob
 import io.matthewnelson.kmp.tor.runtime.core.UncaughtException
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch2
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression2
 import io.matthewnelson.kmp.tor.runtime.core.config.TorOption
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import kotlin.collections.removeFirst as kRemoveFirst
@@ -51,10 +51,10 @@ internal fun <T: TorCmdJob<*>> MutableList<T>.interruptAndClearAll(
 ) {
     if (isEmpty()) return
 
-    handler.withSuppression {
+    handler.withSuppression2 {
         while (isNotEmpty()) {
             val job = kRemoveFirst()
-            tryCatch(job) { job.error(InterruptedException(message)) }
+            tryCatch2(job) { job.error(InterruptedException(message)) }
         }
     }
 }

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/AbstractTorCmdQueue.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/AbstractTorCmdQueue.kt
@@ -20,7 +20,7 @@ import io.matthewnelson.kmp.tor.common.core.synchronized
 import io.matthewnelson.kmp.tor.common.core.synchronizedObject
 import io.matthewnelson.kmp.tor.runtime.core.*
 import io.matthewnelson.kmp.tor.runtime.core.Destroyable.Companion.checkIsNotDestroyed
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression2
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.ctrl.AbstractTorEventProcessor
 import io.matthewnelson.kmp.tor.runtime.ctrl.internal.Debugger.Companion.d
@@ -155,7 +155,7 @@ internal abstract class AbstractTorCmdQueue internal constructor(
         val wasDestroyed = super.onDestroy()
 
         if (wasDestroyed) {
-            handler.withSuppression {
+            handler.withSuppression2 {
                 doCancellations(this)
 
                 @OptIn(InternalKmpTorApi::class)
@@ -182,7 +182,7 @@ internal abstract class AbstractTorCmdQueue internal constructor(
         } ?: return
 
         LOG.d { "Cancelling EnqueuedJobs" }
-        handler.withSuppression {
+        handler.withSuppression2 {
             val suppressed = this
 
             while (interrupts.isNotEmpty()) {

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/AbstractTorCtrl.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/AbstractTorCtrl.kt
@@ -20,8 +20,8 @@ import io.matthewnelson.kmp.tor.common.core.synchronized
 import io.matthewnelson.kmp.tor.common.core.synchronizedObject
 import io.matthewnelson.kmp.tor.runtime.core.*
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch2
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression2
 import io.matthewnelson.kmp.tor.runtime.ctrl.internal.Debugger.Companion.d
 import kotlin.concurrent.Volatile
 
@@ -64,11 +64,11 @@ internal abstract class AbstractTorCtrl internal constructor(
         // check quick win
         if (isDestroyed()) return false
 
-        val wasDestroyed = handler.withSuppression {
+        val wasDestroyed = handler.withSuppression2 {
             // Potential for super invocation to throw when cancelling
             // jobs if Factory.handler is THROW. Need to wrap it up in
             // order to ensure destroy callbacks get invoked.
-            tryCatch("AbstractTorCtrl.onDestroy") {
+            tryCatch2("AbstractTorCtrl.onDestroy") {
                 super.onDestroy()
             }
 
@@ -98,6 +98,6 @@ internal abstract class AbstractTorCtrl internal constructor(
         val context = "AbstractTorCtrl.invokeOnDestroy" +
             if (isImmediate) "[immediate]" else ""
 
-        handler.tryCatch(context) { invoke(this@AbstractTorCtrl) }
+        handler.tryCatch2(context) { invoke(this@AbstractTorCtrl) }
     }
 }

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
@@ -23,8 +23,8 @@ import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.common.core.synchronized
 import io.matthewnelson.kmp.tor.common.core.synchronizedObject
 import io.matthewnelson.kmp.tor.runtime.core.TorEvent
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch2
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression2
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.Reply
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCmdInterceptor
@@ -182,14 +182,12 @@ internal class RealTorCtrl private constructor(
         var threw: Throwable? = null
 
         try {
-            handler.withSuppression {
+            handler.withSuppression2 {
                 val context = "RealTorCtrl.onDestroy"
 
-                tryCatch(context) { super.onDestroy() }
+                tryCatch2(context) { super.onDestroy() }
 
-                _closeException?.let { t ->
-                    tryCatch(context) { throw t }
-                }
+                _closeException?.let { t -> tryCatch2(context) { throw t } }
             }
         } catch (t: Throwable) {
             threw = t

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
@@ -35,8 +35,8 @@ import io.matthewnelson.kmp.tor.runtime.RuntimeEvent.Notifier.Companion.i
 import io.matthewnelson.kmp.tor.runtime.RuntimeEvent.Notifier.Companion.w
 import io.matthewnelson.kmp.tor.runtime.core.Destroyable.Companion.checkIsNotDestroyed
 import io.matthewnelson.kmp.tor.runtime.core.EnqueuedJob.Companion.toImmediateErrorJob
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch
-import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.tryCatch2
+import io.matthewnelson.kmp.tor.runtime.core.UncaughtException.Handler.Companion.withSuppression2
 import io.matthewnelson.kmp.tor.runtime.core.config.TorOption
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
@@ -998,12 +998,11 @@ internal class RealTorRuntime private constructor(
 
                 w(this@RealServiceFactoryDriver, "Failed to start service. Interrupting EnqueuedJobs.")
 
-                handler.withSuppression {
+                handler.withSuppression2 {
 
                     val context = name.name + " timed out"
-
                     executables.forEach { executable ->
-                        tryCatch(context) { executable.execute() }
+                        tryCatch2(context) { executable.execute() }
                     }
                 }
             }


### PR DESCRIPTION
Closes #564 

This PR adds the `tryCatch2` and `withSuppression2` inline functions as drop-in replacements to the now deprecated `tryCatch` and `withsuppression` functions.