### PR TITLE
Remove `AbstractTorServiceUI.InstanceState.Lock` in favor of using `kmp-tor:common-core` synchronization

### DIFF
--- a/library/runtime-service-ui/build.gradle.kts
+++ b/library/runtime-service-ui/build.gradle.kts
@@ -62,6 +62,7 @@ kmpConfiguration {
                 dependencies {
                     api(project(":library:runtime-service"))
                     implementation(libs.immutable.collections)
+                    implementation(libs.kmp.tor.common.core)
                     implementation(libs.kotlinx.coroutines.core)
                 }
             }

--- a/library/runtime-service-ui/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/ui/KmpTorServiceUIInstanceState.kt
+++ b/library/runtime-service-ui/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/ui/KmpTorServiceUIInstanceState.kt
@@ -17,6 +17,9 @@ package io.matthewnelson.kmp.tor.runtime.service.ui
 
 import io.matthewnelson.immutable.collections.immutableSetOf
 import io.matthewnelson.kmp.tor.common.api.ExperimentalKmpTorApi
+import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.common.core.synchronized
+import io.matthewnelson.kmp.tor.common.core.synchronizedObject
 import io.matthewnelson.kmp.tor.runtime.Action
 import io.matthewnelson.kmp.tor.runtime.RuntimeEvent
 import io.matthewnelson.kmp.tor.runtime.TorState
@@ -56,7 +59,8 @@ public class KmpTorServiceUIInstanceState<C: AbstractKmpTorServiceUIConfig> priv
     @Volatile
     private var _stateTor: TorState = TorState(_state.title, TorState.Network.Disabled)
 
-    private val lockUpdate = Lock()
+    @OptIn(InternalKmpTorApi::class)
+    private val lockUpdate = synchronizedObject()
 
     @get:JvmName("state")
     internal val state: UIState get() = _state
@@ -77,7 +81,8 @@ public class KmpTorServiceUIInstanceState<C: AbstractKmpTorServiceUIConfig> priv
     }
 
     private fun update(block: (current: UIState) -> UIState?) {
-        lockUpdate.withLock {
+        @OptIn(InternalKmpTorApi::class)
+        synchronized(lockUpdate) {
             val old = _state
             val new = block(old)
             if (new == null || old == new) {
@@ -96,7 +101,8 @@ public class KmpTorServiceUIInstanceState<C: AbstractKmpTorServiceUIConfig> priv
     private fun postMessage(message: ContentMessage<*>, duration: Duration) {
         if (duration <= Duration.ZERO) return
 
-        lockUpdate.withLock {
+        @OptIn(InternalKmpTorApi::class)
+        synchronized(lockUpdate) {
             val oldJob = _messageJob
             _messageJob = instanceScope.launch {
                 oldJob?.cancelAndJoin()
@@ -164,10 +170,12 @@ public class KmpTorServiceUIInstanceState<C: AbstractKmpTorServiceUIConfig> priv
         }
 
         var newNymObserver: Disposable.Once? = null
-        val stateLock = Lock()
+        @OptIn(InternalKmpTorApi::class)
+        val stateLock = synchronizedObject()
 
         val oSTATE = RuntimeEvent.STATE.observer(tag, executor) { new ->
-            stateLock.withLock {
+            @OptIn(InternalKmpTorApi::class)
+            synchronized(stateLock) {
                 val old = _stateTor
                 _stateTor = new
 
@@ -244,7 +252,8 @@ public class KmpTorServiceUIInstanceState<C: AbstractKmpTorServiceUIConfig> priv
         }
 
         val oREADY = RuntimeEvent.READY.observer(tag, executor) {
-            stateLock.withLock {
+            @OptIn(InternalKmpTorApi::class)
+            synchronized(stateLock) {
                 newNymObserver?.dispose()
                 newNymObserver = observeSignalNewNym(tag, executor) { line ->
                     val message = if (line == null) {

--- a/library/runtime-service/api/runtime-service.api
+++ b/library/runtime-service/api/runtime-service.api
@@ -64,11 +64,6 @@ public abstract class io/matthewnelson/kmp/tor/runtime/service/AbstractTorServic
 	public final fun toString ()Ljava/lang/String;
 }
 
-protected final class io/matthewnelson/kmp/tor/runtime/service/AbstractTorServiceUI$InstanceState$Lock {
-	public fun <init> ()V
-	public final fun withLock (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
 public class io/matthewnelson/kmp/tor/runtime/service/TorServiceConfig {
 	public static final field Companion Lio/matthewnelson/kmp/tor/runtime/service/TorServiceConfig$Companion;
 	public final field stopServiceOnTaskRemoved Z

--- a/library/runtime-service/api/runtime-service.klib.api
+++ b/library/runtime-service/api/runtime-service.klib.api
@@ -62,12 +62,6 @@ abstract class <#A: io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceU
         final fun processorTorCmd(): io.matthewnelson.kmp.tor.runtime.core.ctrl/TorCmd.Unprivileged.Processor? // io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceUI.InstanceState.processorTorCmd|processorTorCmd(){}[0]
         final fun toString(): kotlin/String // io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceUI.InstanceState.toString|toString(){}[0]
         open fun onDestroy() // io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceUI.InstanceState.onDestroy|onDestroy(){}[0]
-
-        final class Lock { // io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceUI.InstanceState.Lock|null[0]
-            constructor <init>() // io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceUI.InstanceState.Lock.<init>|<init>(){}[0]
-
-            final fun <#A3: kotlin/Any?> withLock(kotlin/Function0<#A3>): #A3 // io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceUI.InstanceState.Lock.withLock|withLock(kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
-        }
     }
 
     abstract class Config { // io.matthewnelson.kmp.tor.runtime.service/AbstractTorServiceUI.Config|null[0]

--- a/library/runtime-service/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/AbstractTorServiceUI.kt
+++ b/library/runtime-service/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/AbstractTorServiceUI.kt
@@ -613,21 +613,6 @@ internal constructor(
             args.debugger()?.invoke(lazyMessage)
         }
 
-        /**
-         * Helper for exporting synchronization functionality to implementors
-         * for thread safety.
-         * */
-        protected class Lock {
-
-            @OptIn(InternalKmpTorApi::class)
-            private val lock = synchronizedObject()
-
-            public fun <T: Any?> withLock(block: () -> T): T {
-                @OptIn(InternalKmpTorApi::class)
-                return synchronized(lock, block)
-            }
-        }
-
         init {
             instanceJob.invokeOnCompletion {
                 // Remove instance from states before calling

--- a/library/runtime-service/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/internal/SynchronizedInstance.kt
+++ b/library/runtime-service/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/service/internal/SynchronizedInstance.kt
@@ -18,13 +18,20 @@ package io.matthewnelson.kmp.tor.runtime.service.internal
 import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.common.core.synchronized
 import io.matthewnelson.kmp.tor.common.core.synchronizedObject
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @OptIn(InternalKmpTorApi::class)
 internal class SynchronizedInstance<T: Any> private constructor(private val instance: T) {
 
     private val lock = synchronizedObject()
 
-    internal fun <R: Any?> withLock(block: T.() -> R): R = synchronized(lock) { block(instance) }
+    @OptIn(ExperimentalContracts::class)
+    internal inline fun <R: Any?> withLock(block: T.() -> R): R {
+        contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+        return synchronized(lock) { block(instance) }
+    }
 
     internal companion object {
 


### PR DESCRIPTION
Closes #568 