### PR TITLE
Throw `KeyException` instead of `IllegalArgumentException`

### DIFF
--- a/build-logic/src/main/kotlin/dokka.gradle.kts
+++ b/build-logic/src/main/kotlin/dokka.gradle.kts
@@ -26,7 +26,7 @@ rootProject.dependencies { dokka(project(project.path)) }
 
 extensions.configure<DokkaExtension> {
     dokkaPublications.configureEach {
-        suppressInheritedMembers.set(true)
+        suppressObviousFunctions.set(true)
     }
 
     dokkaSourceSets.configureEach {
@@ -34,6 +34,9 @@ extensions.configure<DokkaExtension> {
         enableKotlinStdLibDocumentationLink.set(false)
 
         externalDocumentationLinks {
+            register(project.path + ":error") {
+                url.set(URI("https://error.kotlincrypto.org/"))
+            }
             register(project.path + ":kmp-file") {
                 url.set(URI("https://kmp-file.matthewnelson.io/"))
             }

--- a/library/runtime-core/build.gradle.kts
+++ b/library/runtime-core/build.gradle.kts
@@ -38,6 +38,7 @@ kmpConfiguration {
                     api(libs.kmp.tor.common.api)
                     implementation(libs.kmp.tor.common.core)
                     implementation(libs.kotlinx.coroutines.core)
+                    api(kotlincrypto.error.error)
                 }
             }
             sourceSetTest {

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/TorSetting.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/TorSetting.kt
@@ -394,6 +394,7 @@ public class TorSetting private constructor(
             }
         }
 
+        /** @suppress */
         protected companion object {
             @JvmSynthetic
             internal val INIT = Any()

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopeAutoBoolean.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopeAutoBoolean.kt
@@ -67,7 +67,7 @@ public class BuilderScopeAutoBoolean: TorSetting.BuilderScope {
             // TorOption.default is checked for "auto", "1", or "0"
             // in tests to ensure proper default is always had for
             // TorSetting.BuilderScope.argument, and mitigate runtime
-            // overhead a `require` block would have here. Test fails
+            // overhead of a `require` block would have here. Test fails
             // if default for given TorOption is invalid.
             return BuilderScopeAutoBoolean(this)
         }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ClientAuthEntry.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ClientAuthEntry.kt
@@ -47,7 +47,6 @@ public class ClientAuthEntry private constructor(
          * @throws [IllegalArgumentException] if key types are incompatible.
          * */
         @JvmStatic
-        @Throws(IllegalArgumentException::class)
         public fun of(
             address: OnionAddress,
             privateKey: AuthKey.Private,

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ClientAuthEntry.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/ClientAuthEntry.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.tor.runtime.core.ctrl
 import io.matthewnelson.immutable.collections.toImmutableSet
 import io.matthewnelson.kmp.tor.runtime.core.net.OnionAddress
 import io.matthewnelson.kmp.tor.runtime.core.key.AuthKey
+import org.kotlincrypto.error.KeyException
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -44,7 +45,7 @@ public class ClientAuthEntry private constructor(
         /**
          * Creates a new [ClientAuthEntry] for provided key(s).
          *
-         * @throws [IllegalArgumentException] if key types are incompatible.
+         * @throws [KeyException] if key types are incompatible.
          * */
         @JvmStatic
         public fun of(
@@ -55,10 +56,12 @@ public class ClientAuthEntry private constructor(
         ): ClientAuthEntry {
             val addressKey = address.asPublicKey()
 
-            require(privateKey.isCompatibleWith(addressKey)) {
-                "Incompatible key types." +
-                " AddressKey.Public[${addressKey.algorithm()}]." +
-                " AuthKey.Private[${privateKey.algorithm()}]"
+            if (!privateKey.isCompatibleWith(addressKey)) {
+                throw KeyException(
+                    "Incompatible key types." +
+                    " AddressKey.Public[${addressKey.algorithm()}]." +
+                    " AuthKey.Private[${privateKey.algorithm()}]"
+                )
             }
 
             return ClientAuthEntry(

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/HiddenServiceEntry.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/HiddenServiceEntry.kt
@@ -47,7 +47,6 @@ public class HiddenServiceEntry private constructor(
          * @throws [IllegalArgumentException] if key algorithms do not match.
          * */
         @JvmStatic
-        @Throws(IllegalArgumentException::class)
         public fun of(
             publicKey: AddressKey.Public,
             privateKey: AddressKey.Private?,

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/HiddenServiceEntry.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/HiddenServiceEntry.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.tor.runtime.core.ctrl
 import io.matthewnelson.immutable.collections.toImmutableSet
 import io.matthewnelson.kmp.tor.runtime.core.key.AddressKey
 import io.matthewnelson.kmp.tor.runtime.core.key.AuthKey
+import org.kotlincrypto.error.KeyException
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -44,7 +45,7 @@ public class HiddenServiceEntry private constructor(
         /**
          * Creates a new [HiddenServiceEntry] for provided key(s).
          *
-         * @throws [IllegalArgumentException] if key algorithms do not match.
+         * @throws [KeyException] if key algorithms do not match.
          * */
         @JvmStatic
         public fun of(
@@ -59,10 +60,12 @@ public class HiddenServiceEntry private constructor(
             val aPublic = publicKey.algorithm()
             val aPrivate = privateKey.algorithm()
 
-            require(aPublic == aPrivate) {
-                "Incompatible key types. " +
-                "AddressKey.PublicKey[$aPublic]. " +
-                "AddressKey.PrivateKey[$aPrivate]"
+            if (aPublic != aPrivate) {
+                throw KeyException(
+                    "Incompatible key types. " +
+                    "AddressKey.PublicKey[$aPublic]. " +
+                    "AddressKey.PrivateKey[$aPrivate]"
+                )
             }
 
             return HiddenServiceEntry(

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-StringExt.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-StringExt.kt
@@ -17,9 +17,6 @@
 
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
-import io.matthewnelson.encoding.base16.Base16
-import io.matthewnelson.encoding.base32.Base32
-import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/ED25519_V3.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/ED25519_V3.kt
@@ -22,6 +22,7 @@ import io.matthewnelson.kmp.tor.runtime.core.net.OnionAddress.V3.Companion.toOni
 import io.matthewnelson.kmp.tor.runtime.core.internal.tryDecodeOrNull
 import io.matthewnelson.kmp.tor.runtime.core.key.ED25519_V3.PublicKey.Companion.toED25519_V3PublicKey
 import io.matthewnelson.kmp.tor.runtime.core.key.ED25519_V3.PublicKey.Companion.toED25519_V3PublicKeyOrNull
+import org.kotlincrypto.error.InvalidKeyException
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 
@@ -60,26 +61,26 @@ public object ED25519_V3: KeyType.Address<ED25519_V3.PublicKey, ED25519_V3.Priva
              * address itself, or Base 16/32/64 encoded raw value.
              *
              * @return [ED25519_V3.PublicKey]
-             * @throws [IllegalArgumentException] if no key is found
+             * @throws [InvalidKeyException] if no key is found
              * */
             @JvmStatic
             @JvmName("get")
             public fun String.toED25519_V3PublicKey(): PublicKey {
                 return toED25519_V3PublicKeyOrNull()
-                    ?: throw IllegalArgumentException("$this is not an ${algorithm()} public key")
+                    ?: throw InvalidKeyException("$this is not an ${algorithm()} public key")
             }
 
             /**
              * Transforms provided bytes into a ED25519-V3 public key.
              *
              * @return [ED25519_V3.PublicKey]
-             * @throws [IllegalArgumentException] if byte array size is inappropriate
+             * @throws [InvalidKeyException] if byte array size is inappropriate
              * */
             @JvmStatic
             @JvmName("get")
             public fun ByteArray.toED25519_V3PublicKey(): PublicKey {
                 return toED25519_V3PublicKeyOrNull()
-                    ?: throw IllegalArgumentException("bytes are not an ${algorithm()} public key")
+                    ?: throw InvalidKeyException("bytes are not an ${algorithm()} public key")
             }
 
             /**
@@ -145,26 +146,26 @@ public object ED25519_V3: KeyType.Address<ED25519_V3.PublicKey, ED25519_V3.Priva
              * String can be a Base 16/32/64 encoded raw value.
              *
              * @return [ED25519_V3.PrivateKey]
-             * @throws [IllegalArgumentException] if no key is found
+             * @throws [InvalidKeyException] if no key is found
              * */
             @JvmStatic
             @JvmName("get")
             public fun String.toED25519_V3PrivateKey(): PrivateKey {
                 return toED25519_V3PrivateKeyOrNull()
-                    ?: throw IllegalArgumentException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
+                    ?: throw InvalidKeyException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
             }
 
             /**
              * Transforms provided bytes into a ED25519-V3 private key.
              *
              * @return [ED25519_V3.PrivateKey]
-             * @throws [IllegalArgumentException] if byte array size is inappropriate
+             * @throws [InvalidKeyException] if byte array size is inappropriate
              * */
             @JvmStatic
             @JvmName("get")
             public fun ByteArray.toED25519_V3PrivateKey(): PrivateKey {
                 return toED25519_V3PrivateKeyOrNull()
-                    ?: throw IllegalArgumentException("Invalid key size. Must be $BYTE_SIZE bytes")
+                    ?: throw InvalidKeyException("Invalid key size. Must be $BYTE_SIZE bytes")
             }
 
             /**

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/ED25519_V3.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/ED25519_V3.kt
@@ -64,7 +64,6 @@ public object ED25519_V3: KeyType.Address<ED25519_V3.PublicKey, ED25519_V3.Priva
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toED25519_V3PublicKey(): PublicKey {
                 return toED25519_V3PublicKeyOrNull()
                     ?: throw IllegalArgumentException("$this is not an ${algorithm()} public key")
@@ -78,7 +77,6 @@ public object ED25519_V3: KeyType.Address<ED25519_V3.PublicKey, ED25519_V3.Priva
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun ByteArray.toED25519_V3PublicKey(): PublicKey {
                 return toED25519_V3PublicKeyOrNull()
                     ?: throw IllegalArgumentException("bytes are not an ${algorithm()} public key")
@@ -151,7 +149,6 @@ public object ED25519_V3: KeyType.Address<ED25519_V3.PublicKey, ED25519_V3.Priva
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toED25519_V3PrivateKey(): PrivateKey {
                 return toED25519_V3PrivateKeyOrNull()
                     ?: throw IllegalArgumentException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
@@ -165,7 +162,6 @@ public object ED25519_V3: KeyType.Address<ED25519_V3.PublicKey, ED25519_V3.Priva
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun ByteArray.toED25519_V3PrivateKey(): PrivateKey {
                 return toED25519_V3PrivateKeyOrNull()
                     ?: throw IllegalArgumentException("Invalid key size. Must be $BYTE_SIZE bytes")

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/X25519.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/X25519.kt
@@ -64,7 +64,6 @@ public object X25519: KeyType.Auth<X25519.PublicKey, X25519.PrivateKey>() {
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toX25519PublicKey(): PublicKey {
                 return toX25519PublicKeyOrNull()
                     ?: throw IllegalArgumentException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
@@ -78,7 +77,6 @@ public object X25519: KeyType.Auth<X25519.PublicKey, X25519.PrivateKey>() {
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun ByteArray.toX25519PublicKey(): PublicKey {
                 return toX25519PublicKeyOrNull()
                     ?: throw IllegalArgumentException("Invalid key size. Must be $BYTE_SIZE bytes")
@@ -147,7 +145,6 @@ public object X25519: KeyType.Auth<X25519.PublicKey, X25519.PrivateKey>() {
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toX25519PrivateKey(): PrivateKey {
                 return toX25519PrivateKeyOrNull()
                     ?: throw IllegalArgumentException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
@@ -161,7 +158,6 @@ public object X25519: KeyType.Auth<X25519.PublicKey, X25519.PrivateKey>() {
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun ByteArray.toX25519PrivateKey(): PrivateKey {
                 return toX25519PrivateKeyOrNull()
                     ?: throw IllegalArgumentException("Invalid key size. Must be $BYTE_SIZE bytes")

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/X25519.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/X25519.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.tor.runtime.core.key
 import io.matthewnelson.kmp.tor.runtime.core.internal.tryDecodeOrNull
 import io.matthewnelson.kmp.tor.runtime.core.key.X25519.PublicKey.Companion.toX25519PublicKey
 import io.matthewnelson.kmp.tor.runtime.core.key.X25519.PublicKey.Companion.toX25519PublicKeyOrNull
+import org.kotlincrypto.error.InvalidKeyException
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
@@ -60,26 +61,26 @@ public object X25519: KeyType.Auth<X25519.PublicKey, X25519.PrivateKey>() {
              * String can be a Base 16/32/64 encoded raw value.
              *
              * @return [X25519.PublicKey]
-             * @throws [IllegalArgumentException] if no key is found
+             * @throws [InvalidKeyException] if no key is found
              * */
             @JvmStatic
             @JvmName("get")
             public fun String.toX25519PublicKey(): PublicKey {
                 return toX25519PublicKeyOrNull()
-                    ?: throw IllegalArgumentException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
+                    ?: throw InvalidKeyException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
             }
 
             /**
              * Transforms provided bytes into a x25519 public key.
              *
              * @return [X25519.PublicKey]
-             * @throws [IllegalArgumentException] if byte array size is inappropriate
+             * @throws [InvalidKeyException] if byte array size is inappropriate
              * */
             @JvmStatic
             @JvmName("get")
             public fun ByteArray.toX25519PublicKey(): PublicKey {
                 return toX25519PublicKeyOrNull()
-                    ?: throw IllegalArgumentException("Invalid key size. Must be $BYTE_SIZE bytes")
+                    ?: throw InvalidKeyException("Invalid key size. Must be $BYTE_SIZE bytes")
             }
 
             /**
@@ -141,26 +142,26 @@ public object X25519: KeyType.Auth<X25519.PublicKey, X25519.PrivateKey>() {
              * String can be a Base 16/32/64 encoded raw value.
              *
              * @return [X25519.PrivateKey]
-             * @throws [IllegalArgumentException] if no key is found
+             * @throws [InvalidKeyException] if no key is found
              * */
             @JvmStatic
             @JvmName("get")
             public fun String.toX25519PrivateKey(): PrivateKey {
                 return toX25519PrivateKeyOrNull()
-                    ?: throw IllegalArgumentException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
+                    ?: throw InvalidKeyException("Tried base 16/32/64 decoding, but failed to find a $BYTE_SIZE byte key")
             }
 
             /**
              * Transforms provided bytes into a x25519 private key.
              *
              * @return [X25519.PrivateKey]
-             * @throws [IllegalArgumentException] if byte array size is inappropriate
+             * @throws [InvalidKeyException] if byte array size is inappropriate
              * */
             @JvmStatic
             @JvmName("get")
             public fun ByteArray.toX25519PrivateKey(): PrivateKey {
                 return toX25519PrivateKeyOrNull()
-                    ?: throw IllegalArgumentException("Invalid key size. Must be $BYTE_SIZE bytes")
+                    ?: throw InvalidKeyException("Invalid key size. Must be $BYTE_SIZE bytes")
             }
 
             /**

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/IPAddress.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/IPAddress.kt
@@ -80,7 +80,6 @@ public sealed class IPAddress private constructor(
          * */
         @JvmStatic
         @JvmName("get")
-        @Throws(IllegalArgumentException::class)
         public fun String.toIPAddress(): IPAddress {
             return toIPAddressOrNull()
                 ?: throw IllegalArgumentException("$this does not contain an IP address")
@@ -94,7 +93,6 @@ public sealed class IPAddress private constructor(
          * */
         @JvmStatic
         @JvmName("get")
-        @Throws(IllegalArgumentException::class)
         public fun ByteArray.toIPAddress(): IPAddress {
             return toIPAddressOrNull()
                 ?: throw IllegalArgumentException("Invalid array size[$size]")
@@ -163,7 +161,6 @@ public sealed class IPAddress private constructor(
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toIPAddressV4(): V4 {
                 return toIPAddressV4OrNull()
                     ?: throw IllegalArgumentException("$this does not contain an IPv4 address")
@@ -177,7 +174,6 @@ public sealed class IPAddress private constructor(
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun ByteArray.toIPAddressV4(): V4 {
                 return toIPAddressV4(copy = true)
             }
@@ -322,7 +318,6 @@ public sealed class IPAddress private constructor(
                  *   string, or an integer less than 1.
                  * */
                 @JvmStatic
-                @Throws(IllegalArgumentException::class)
                 public fun of(scope: String?): AnyHost {
                     if (scope == null) return NoScope
                     val msg = scope.isValidScopeOrErrorMessage()
@@ -345,7 +340,6 @@ public sealed class IPAddress private constructor(
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toIPAddressV6(): V6 {
                 return toIPAddressV6OrNull()
                     ?: throw IllegalArgumentException("$this does not contain a valid IPv6 address")
@@ -362,7 +356,6 @@ public sealed class IPAddress private constructor(
             @JvmStatic
             @JvmOverloads
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun ByteArray.toIPAddressV6(scope: String? = null): V6 {
                 return toIPAddressV6(scope, copy = true)
             }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/IPSocketAddress.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/IPSocketAddress.kt
@@ -64,7 +64,6 @@ public class IPSocketAddress(
          * */
         @JvmStatic
         @JvmName("get")
-        @Throws(IllegalArgumentException::class)
         public fun String.toIPSocketAddress(): IPSocketAddress {
             return toIPSocketAddressOrNull()
                 ?: throw IllegalArgumentException("$this does not contain a valid IP address & port")

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/LocalHost.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/LocalHost.kt
@@ -45,13 +45,11 @@ public sealed class LocalHost private constructor(): Address("localhost") {
      * @throws [IOException] if there were any errors (e.g. calling
      *   from Main thread on Android)
      * */
-    @Throws(IOException::class)
     public abstract fun resolve(): IPAddress
 
     public object IPv4: LocalHost() {
 
-        @Throws(IOException::class)
-        override fun resolve(): IPAddress.V4 = Cache.resolve(checkCache = true).firstOrThrow()
+        public override fun resolve(): IPAddress.V4 = Cache.resolve(checkCache = true).firstOrThrow()
 
         @JvmSynthetic
         internal override fun fromCache(): IPAddress.V4? = Cache.getOrNull()?.firstOrNull()
@@ -59,8 +57,7 @@ public sealed class LocalHost private constructor(): Address("localhost") {
 
     public object IPv6: LocalHost() {
 
-        @Throws(IOException::class)
-        override fun resolve(): IPAddress.V6 = Cache.resolve(checkCache = true).firstOrThrow()
+        public override fun resolve(): IPAddress.V6 = Cache.resolve(checkCache = true).firstOrThrow()
 
         @JvmSynthetic
         internal override fun fromCache(): IPAddress.V6? = Cache.getOrNull()?.firstOrNull()

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/OnionAddress.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/OnionAddress.kt
@@ -70,7 +70,6 @@ public sealed class OnionAddress private constructor(value: String): Address(val
          * */
         @JvmStatic
         @JvmName("get")
-        @Throws(IllegalArgumentException::class)
         public fun String.toOnionAddress(): OnionAddress {
             return toOnionAddressOrNull()
                 ?: throw IllegalArgumentException("$this does not contain an onion address")
@@ -86,7 +85,6 @@ public sealed class OnionAddress private constructor(value: String): Address(val
          * */
         @JvmStatic
         @JvmName("get")
-        @Throws(IllegalArgumentException::class)
         public fun ByteArray.toOnionAddress(): OnionAddress {
             return toOnionAddressOrNull()
                 ?: throw IllegalArgumentException("bytes are not an onion address")
@@ -161,7 +159,6 @@ public sealed class OnionAddress private constructor(value: String): Address(val
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toOnionAddressV3(): V3 {
                 return toOnionAddressV3OrNull()
                     ?: throw IllegalArgumentException("$this does not contain a v3 onion address")
@@ -175,7 +172,6 @@ public sealed class OnionAddress private constructor(value: String): Address(val
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun ByteArray.toOnionAddressV3(): V3 {
                 return toOnionAddressV3OrNull()
                     ?: throw IllegalArgumentException("bytes are not a v3 onion address")
@@ -204,13 +200,7 @@ public sealed class OnionAddress private constructor(value: String): Address(val
             @JvmName("getOrNull")
             public fun ByteArray.toOnionAddressV3OrNull(): V3? {
                 if (size != BYTE_SIZE) return null
-
-                val encoded = encodeToString(Base32Default {
-                    encodeToLowercase = true
-                    padEncoded = false
-                })
-
-                return V3(encoded)
+                return V3(encodeToString(BASE32_ENCODE))
             }
 
             @JvmSynthetic
@@ -226,6 +216,10 @@ public sealed class OnionAddress private constructor(value: String): Address(val
 
             internal const val BYTE_SIZE: Int = 35
             private val REGEX: Regex = "[${Base32.Default.CHARS_LOWER}]{56}".toRegex()
+            private val BASE32_ENCODE = Base32Default {
+                encodeToLowercase = true
+                padEncoded = false
+            }
         }
     }
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/Port.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/Port.kt
@@ -85,7 +85,6 @@ public open class Port private constructor(
          * */
         @JvmStatic
         @JvmName("get")
-        @Throws(IllegalArgumentException::class)
         public fun Int.toPort(): Port {
             return toPortOrNull()
                 ?: throw IllegalArgumentException("$this is not a valid port")
@@ -104,7 +103,6 @@ public open class Port private constructor(
          * */
         @JvmStatic
         @JvmName("get")
-        @Throws(IllegalArgumentException::class)
         public fun String.toPort(): Port {
             return toPortOrNull()
                 ?: throw IllegalArgumentException("$this does not contain a port")
@@ -225,7 +223,6 @@ public open class Port private constructor(
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun Int.toPortEphemeral(): Ephemeral {
                 return toPortEphemeralOrNull()
                     ?: throw IllegalArgumentException("$this is not a valid ephemeral port")
@@ -241,7 +238,6 @@ public open class Port private constructor(
              * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun String.toPortEphemeral(): Ephemeral {
                 return toPortEphemeralOrNull()
                     ?: throw IllegalArgumentException("$this does not contain a valid ephemeral port")

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
@@ -44,7 +44,6 @@ public expect suspend fun Port.isAvailableAsync(
  * @throws [IOException] if no ports are available
  * @throws [CancellationException] if underlying coroutine was cancelled
  * */
-@Throws(IOException::class, CancellationException::class)
 public expect suspend fun Port.Ephemeral.findNextAvailableAsync(
     limit: Int,
     host: LocalHost,

--- a/library/runtime-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
+++ b/library/runtime-core/src/jsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
@@ -55,7 +55,6 @@ public actual suspend fun Port.isAvailableAsync(
  * @throws [IOException] if no ports are available
  * @throws [CancellationException] if underlying coroutine was cancelled
  * */
-// @Throws(IOException::class, CancellationException::class)
 public actual suspend fun Port.Ephemeral.findNextAvailableAsync(
     limit: Int,
     host: LocalHost,

--- a/library/runtime-core/src/jvmMain/java9/module-info.java
+++ b/library/runtime-core/src/jvmMain/java9/module-info.java
@@ -9,6 +9,7 @@ module io.matthewnelson.kmp.tor.runtime.core {
     requires transitive io.matthewnelson.kmp.tor.common.api;
     requires io.matthewnelson.kmp.tor.common.core;
     requires kotlinx.coroutines.core;
+    requires transitive org.kotlincrypto.error;
 
     exports io.matthewnelson.kmp.tor.runtime.core;
     exports io.matthewnelson.kmp.tor.runtime.core.config;

--- a/library/runtime-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/IPAddressUtil.kt
+++ b/library/runtime-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/IPAddressUtil.kt
@@ -58,7 +58,6 @@ public fun Inet6Address.toIPAddressV6(): IPAddress.V6 {
  *   network interface name that does not exist on the host machine.
  * */
 @JvmName("inetAddressOf")
-@Throws(SocketException::class)
 public fun IPAddress.toInetAddress(): InetAddress = when(this) {
     is IPAddress.V4 -> toInet4Address()
     is IPAddress.V6 -> toInet6Address()
@@ -79,7 +78,6 @@ public fun IPAddress.V4.toInet4Address(): Inet4Address {
  *   network interface name that does not exist on the host machine.
  * */
 @JvmName("inet6AddressOf")
-@Throws(SocketException::class)
 public fun IPAddress.V6.toInet6Address(): Inet6Address {
     val scope = scope
     val scopeId = scope?.toIntOrNull()

--- a/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
+++ b/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
@@ -56,7 +56,6 @@ public actual suspend fun Port.isAvailableAsync(
  * @throws [IOException] if no ports are available
  * @throws [CancellationException] if underlying coroutine was cancelled
  * */
-@Throws(IOException::class, CancellationException::class)
 public actual suspend fun Port.Ephemeral.findNextAvailableAsync(
     limit: Int,
     host: LocalHost,

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-TorCmdJob.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-TorCmdJob.kt
@@ -32,8 +32,9 @@ import io.matthewnelson.kmp.tor.runtime.core.key.ED25519_V3.PublicKey.Companion.
 import io.matthewnelson.kmp.tor.runtime.core.key.X25519
 import io.matthewnelson.kmp.tor.runtime.core.key.X25519.PrivateKey.Companion.toX25519PrivateKeyOrNull
 import io.matthewnelson.kmp.tor.runtime.core.key.X25519.PublicKey.Companion.toX25519PublicKeyOrNull
+import org.kotlincrypto.error.KeyException
 
-@Throws(IllegalArgumentException::class, NoSuchElementException::class)
+@Throws(IllegalArgumentException::class, KeyException::class, NoSuchElementException::class)
 internal fun TorCmdJob<*>.respond(replies: ArrayList<Reply>) {
     // waiters were destroyed while awaiting server response (i.e. EOS)
     if (replies.isEmpty()) {
@@ -117,7 +118,7 @@ private fun TorCmd.MapAddress.complete(job: TorCmdJob<*>, replies: ArrayList<Rep
     job.unsafeCast<Set<AddressMapping.Result>>().completion(set.toImmutableSet())
 }
 
-@Throws(IllegalArgumentException::class, NoSuchElementException::class)
+@Throws(KeyException::class, NoSuchElementException::class)
 private fun TorCmd.Onion.Add.complete(job: TorCmdJob<*>, replies: ArrayList<Reply.Success>) {
     @Suppress("LocalVariableName")
     var _publicKey: AddressKey.Public? = null
@@ -159,7 +160,7 @@ private fun TorCmd.Onion.Add.complete(job: TorCmdJob<*>, replies: ArrayList<Repl
     job.unsafeCast<HiddenServiceEntry>().completion(entry)
 }
 
-@Throws(IllegalArgumentException::class, NoSuchElementException::class)
+@Throws(KeyException::class, NoSuchElementException::class)
 private fun TorCmd.OnionClientAuth.View.complete(job: TorCmdJob<*>, replies: ArrayList<Reply.Success>) {
     // 250 CLIENT {onion address} {algorithm}:[Blob Redacted] Flags=Permanent ClientName=test0
     // 250 CLIENT {onion address} {algorithm}:[Blob Redacted] ClientName=test1

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
@@ -334,7 +334,7 @@ internal class RealTorCtrl private constructor(
 
                 try {
                     cmdJob.respond(replies)
-                } catch (e: RuntimeException) {
+                } catch (e: Exception) {
                     cmdJob.error(e)
                 }
             }.invokeOnCompletion { t ->

--- a/library/runtime/src/jvmMain/java9/module-info.java
+++ b/library/runtime/src/jvmMain/java9/module-info.java
@@ -6,8 +6,8 @@ module io.matthewnelson.kmp.tor.runtime {
     requires io.matthewnelson.kmp.tor.runtime.ctrl;
     requires transitive io.matthewnelson.kmp.tor.runtime.core;
     requires kotlinx.coroutines.core;
-    requires org.kotlincrypto.random;
     requires org.kotlincrypto.hash.sha2;
+    requires org.kotlincrypto.random;
 
     exports io.matthewnelson.kmp.tor.runtime;
 }


### PR DESCRIPTION
Closes #572 

This PR also has some QOL improvements for Java by removing `@Throws` annotations from wrapper type classes' public `get` functions, in favor of simply documenting the exception.