### PR TITLE
Clean up Throws annotations

### DIFF
--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/Callbacks.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/Callbacks.kt
@@ -285,7 +285,6 @@ public fun interface Disposable {
              *   of [Once] or [noOp]
              * */
             @JvmStatic
-            @Throws(IllegalArgumentException::class)
             public fun of(disposable: Disposable): Once = of(false, disposable)
 
             /**
@@ -296,7 +295,6 @@ public fun interface Disposable {
              *   of [Once] or [noOp]
              * */
             @JvmStatic
-            @Throws(IllegalArgumentException::class)
             public fun of(concurrent: Boolean, disposable: Disposable): Once {
                 require(disposable !is Once) { "disposable cannot be an instance of Disposable.Once" }
                 require(disposable !is NOOP) { "disposable cannot be an instance of Disposable.NOOP" }
@@ -380,7 +378,6 @@ public fun interface Executable {
              *   of [Once] or [noOp]
              * */
             @JvmStatic
-            @Throws(IllegalArgumentException::class)
             public fun of(executable: Executable): Once = of(false, executable)
 
             /**
@@ -391,7 +388,6 @@ public fun interface Executable {
              *   of [Once] or [noOp]
              * */
             @JvmStatic
-            @Throws(IllegalArgumentException::class)
             public fun of(concurrent: Boolean, executable: Executable): Once {
                 require(executable !is Once) { "executable cannot be an instance of Executable.Once" }
                 require(executable !is NOOP) { "executable cannot be an instance of Executable.NOOP" }

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/Destroyable.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/Destroyable.kt
@@ -31,7 +31,6 @@ public interface Destroyable {
          * @throws [IllegalStateException] If [isDestroyed] is true.
          * */
         @JvmStatic
-        @Throws(IllegalStateException::class)
         public fun Destroyable.checkIsNotDestroyed() {
             if (!isDestroyed()) return
             throw destroyedException()

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/TorOption.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/TorOption.kt
@@ -4849,7 +4849,6 @@ public abstract class TorOption: Comparable<TorOption>, CharSequence {
          * @throws [IllegalArgumentException] if [name] is unknown.
          * */
         @JvmStatic
-        @Throws(IllegalArgumentException::class)
         public fun valueOf(name: String): TorOption = valueOfOrNull(name)
             ?: throw IllegalArgumentException("Unknown name[$name]")
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopeHSPort.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopeHSPort.kt
@@ -92,7 +92,6 @@ public class BuilderScopeHSPort private constructor(
      *   - Configured path is multiple lines.
      * */
     @KmpTorDsl
-    @Throws(UnsupportedOperationException::class)
     public fun target(
         unixSocket: File,
     ): BuilderScopeHSPort {

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopePort.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopePort.kt
@@ -85,7 +85,6 @@ public abstract class BuilderScopePort: TorSetting.BuilderScope {
         ): Control = super.port(value) as Control
 
         @KmpTorDsl
-        @Throws(UnsupportedOperationException::class)
         public override fun unixSocket(
             value: File,
         ): Control = super.unixSocket(value) as Control
@@ -227,7 +226,6 @@ public abstract class BuilderScopePort: TorSetting.BuilderScope {
         ): Socks = super.reassignable(allow) as Socks
 
         @KmpTorDsl
-        @Throws(UnsupportedOperationException::class)
         public override fun unixSocket(
             value: File,
         ): Socks = super.unixSocket(value) as Socks
@@ -403,7 +401,6 @@ public abstract class BuilderScopePort: TorSetting.BuilderScope {
      *   - Configured path is multiple lines.
      * */
     @KmpTorDsl
-    @Throws(UnsupportedOperationException::class)
     protected open fun unixSocket(
         value: File,
     ): BuilderScopePort {

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/Reply.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/ctrl/Reply.kt
@@ -139,9 +139,13 @@ public open class Reply private constructor(
 
         public companion object {
 
+            /**
+             * Converts replies to [Error]
+             *
+             * @throws [IllegalArgumentException] if list of [Reply] is empty
+             * */
             @JvmStatic
             @JvmName("get")
-            @Throws(IllegalArgumentException::class)
             public fun List<Reply>.toError(jobName: String): Error {
                 require(isNotEmpty()) { "replies cannot be empty" }
                 return Error(jobName, this)

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/AuthKey.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/AuthKey.kt
@@ -78,7 +78,6 @@ public class AuthKey private constructor() {
          *   compatible [OnionAddress] for this [algorithm].
          * @throws [IllegalStateException] if [isDestroyed] is `true`.
          * */
-        @Throws(IllegalArgumentException::class, IllegalStateException::class)
         public fun descriptorBase32(
             address: OnionAddress,
         ): String = descriptorBase32(address.asPublicKey())
@@ -92,7 +91,6 @@ public class AuthKey private constructor() {
          *   compatible [AddressKey.Public] for this [algorithm].
          * @throws [IllegalStateException] if [isDestroyed] is `true`.
          * */
-        @Throws(IllegalArgumentException::class, IllegalStateException::class)
         public fun descriptorBase32(
             publicKey: AddressKey.Public,
         ): String {
@@ -142,7 +140,6 @@ public class AuthKey private constructor() {
          *   compatible [OnionAddress] for this [algorithm].
          * @throws [IllegalStateException] if [isDestroyed] is `true`.
          * */
-        @Throws(IllegalArgumentException::class, IllegalStateException::class)
         public fun descriptorBase64(
             address: OnionAddress,
         ): String = descriptorBase64(address.asPublicKey())
@@ -156,7 +153,6 @@ public class AuthKey private constructor() {
          *   compatible [AddressKey.Public] for this [algorithm].
          * @throws [IllegalStateException] if [isDestroyed] is `true`.
          * */
-        @Throws(IllegalArgumentException::class, IllegalStateException::class)
         public fun descriptorBase64(
             publicKey: AddressKey.Public,
         ): String {

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/Key.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/Key.kt
@@ -57,13 +57,32 @@ public expect sealed class Key private constructor() {
         public final override fun destroy()
         public final override fun isDestroyed(): Boolean
 
-        @Throws(IllegalStateException::class)
+        /**
+         * Key bytes
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public fun encoded(): ByteArray
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in uppercase Base16 (hex)
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public fun base16(): String
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in uppercase Base32 without padding
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public fun base32(): String
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in Base64 without padding
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public fun base64(): String
 
         public final override fun encodedOrNull(): ByteArray?

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/OnionAddress.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/net/OnionAddress.kt
@@ -186,14 +186,14 @@ public sealed class OnionAddress private constructor(value: String): Address(val
             @JvmName("get")
             public fun ByteArray.toOnionAddressV3(): V3 {
                 require(size == BYTE_SIZE) { "Invalid array size. expected[$BYTE_SIZE] vs actual[$size]" }
-                require(last() == VERSION_BYTE) { "Invalid version byte. expected[$VERSION_BYTE] vs actual[${last()}]" }
+                require(this[BYTE_SIZE - 1] == VERSION_BYTE) { "Invalid version byte. expected[$VERSION_BYTE] vs actual[${last()}]" }
                 require(containsNon0Byte(ED25519_V3.PublicKey.BYTE_SIZE)) { "ed25519 public key is blank (all 0 bytes)" }
                 val checksum = computeChecksum()
-                val ca0 = this[BYTE_SIZE - 3]
-                val ca1 = this[BYTE_SIZE - 2]
-                val ce0 = checksum[0]
-                val ce1 = checksum[1]
-                require(ca0 == ce0 && ca1 == ce1) { "Invalid checksum byte(s). expected[$ce0, $ce1] vs actual[$ca0, $ca1]" }
+                val t0 = this[BYTE_SIZE - 3]
+                val t1 = this[BYTE_SIZE - 2]
+                val c0 = checksum[0]
+                val c1 = checksum[1]
+                require(t0 == c0 && t1 == c1) { "Invalid checksum byte(s). expected[$c0, $c1] vs actual[$t0, $t1]" }
                 return V3(encodeToString(BASE_32))
             }
 

--- a/library/runtime-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/Key.kt
+++ b/library/runtime-core/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/Key.kt
@@ -93,24 +93,41 @@ public actual sealed class Key private actual constructor(): java.security.Key {
 
         public actual final override fun isDestroyed(): Boolean = _destroyed
 
-        @Throws(IllegalStateException::class)
+        /**
+         * Key bytes
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun encoded(): ByteArray = encodedOrNull() ?: throw destroyedException(algorithm())
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in uppercase Base16 (hex)
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun base16(): String = base16OrNull() ?: throw destroyedException(algorithm())
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in uppercase Base32 without padding
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun base32(): String = base32OrNull() ?: throw destroyedException(algorithm())
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in Base64 without padding
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun base64(): String = base64OrNull() ?: throw destroyedException(algorithm())
 
-        public actual final override fun encodedOrNull(): ByteArray? = withKeyOrNull { it.copyOf() }
-        public actual final override fun base16OrNull(): String? = withKeyOrNull { it.encodeToString(BASE_16) }
-        public actual final override fun base32OrNull(): String? = withKeyOrNull { it.encodeToString(BASE_32) }
-        public actual final override fun base64OrNull(): String? = withKeyOrNull { it.encodeToString(BASE_64) }
+        public actual final override fun encodedOrNull(): ByteArray? = withKeyOrNull { copyOf() }
+        public actual final override fun base16OrNull(): String? = withKeyOrNull { encodeToString(BASE_16) }
+        public actual final override fun base32OrNull(): String? = withKeyOrNull { encodeToString(BASE_32) }
+        public actual final override fun base64OrNull(): String? = withKeyOrNull { encodeToString(BASE_64) }
 
         @OptIn(ExperimentalContracts::class, InternalKmpTorApi::class)
-        private inline fun <T : Any> withKeyOrNull(
-            block: (key: ByteArray) -> T
-        ): T? {
+        private inline fun <T : Any> withKeyOrNull(block: ByteArray.() -> T): T? {
             contract {
                 callsInPlace(block, InvocationKind.AT_MOST_ONCE)
             }

--- a/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
+++ b/library/runtime-core/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/util/PortUtil.kt
@@ -73,7 +73,6 @@ public actual suspend fun Port.Ephemeral.findNextAvailableAsync(
  * @see [isAvailableAsync]
  * @throws [IOException] if the check fails (e.g. calling from Main thread on Android)
  * */
-@Throws(IOException::class)
 public fun Port.isAvailableSync(
     host: LocalHost,
 ): Boolean = host.resolve()
@@ -96,7 +95,6 @@ public fun Port.isAvailableSync(
  * @throws [IllegalArgumentException] if [limit] is not between 1 and 1_000 (inclusive)
  * @throws [IOException] if the check fails (e.g. calling from Main thread on Android)
  * */
-@Throws(IOException::class)
 public fun Port.Ephemeral.findNextAvailableSync(
     limit: Int,
     host: LocalHost,

--- a/library/runtime-core/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/Key.kt
+++ b/library/runtime-core/src/nonJvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/key/Key.kt
@@ -86,24 +86,41 @@ public actual sealed class Key private actual constructor() {
 
         public actual final override fun isDestroyed(): Boolean = _destroyed
 
-        @Throws(IllegalStateException::class)
+        /**
+         * Key bytes
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun encoded(): ByteArray = encodedOrNull() ?: throw destroyedException(algorithm())
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in uppercase Base16 (hex)
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun base16(): String = base16OrNull() ?: throw destroyedException(algorithm())
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in uppercase Base32 without padding
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun base32(): String = base32OrNull() ?: throw destroyedException(algorithm())
-        @Throws(IllegalStateException::class)
+
+        /**
+         * Key bytes formatted in Base64 without padding
+         *
+         * @throws [IllegalStateException] if [isDestroyed] is `true`
+         * */
         public actual fun base64(): String = base64OrNull() ?: throw destroyedException(algorithm())
 
-        public actual final override fun encodedOrNull(): ByteArray? = withKeyOrNull { it.copyOf() }
-        public actual final override fun base16OrNull(): String? = withKeyOrNull { it.encodeToString(BASE_16) }
-        public actual final override fun base32OrNull(): String? = withKeyOrNull { it.encodeToString(BASE_32) }
-        public actual final override fun base64OrNull(): String? = withKeyOrNull { it.encodeToString(BASE_64) }
+        public actual final override fun encodedOrNull(): ByteArray? = withKeyOrNull { copyOf() }
+        public actual final override fun base16OrNull(): String? = withKeyOrNull { encodeToString(BASE_16) }
+        public actual final override fun base32OrNull(): String? = withKeyOrNull { encodeToString(BASE_32) }
+        public actual final override fun base64OrNull(): String? = withKeyOrNull { encodeToString(BASE_64) }
 
         @OptIn(ExperimentalContracts::class, InternalKmpTorApi::class)
-        private inline fun <T : Any> withKeyOrNull(
-            block: (key: ByteArray) -> T
-        ): T? {
+        private inline fun <T : Any> withKeyOrNull(block: ByteArray.() -> T): T? {
             contract {
                 callsInPlace(block, InvocationKind.AT_MOST_ONCE)
             }


### PR DESCRIPTION
This PR removes `@Throws` annotations from public functions, in favor of using documentation to express any exceptions.