### PR TITLE
Fix tor start failure when Java9+ module `java.management` is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See [kmp-tor-samples][url-kmp-tor-samples]
 
 <!-- TAG_DEPENDENCIES -->
 [badge-androidx-startup]: https://img.shields.io/badge/androidx.startup-1.1.1-6EDB8D.svg?logo=android
-[badge-coroutines]: https://img.shields.io/badge/kotlinx.coroutines-1.10.1-blue.svg?logo=kotlin
+[badge-coroutines]: https://img.shields.io/badge/kotlinx.coroutines-1.10.2-blue.svg?logo=kotlin
 [badge-encoding]: https://img.shields.io/badge/encoding-2.4.0-blue.svg?style=flat
 [badge-kmp-process]: https://img.shields.io/badge/kmp--process-0.2.1-blue.svg?style=flat
 [badge-kmp-tor-common]: https://img.shields.io/badge/kmp--tor--common-2.2.0-blue.svg?style=flat

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ runtime.enqueue(
   }
   ```
 
+- If using Java9+, ensure you have defined module `java.management` for your application.
+
 - Configure tor resources
     - See [kmp-tor-resource#Get Started][url-kmp-tor-resource-start]
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ See [kmp-tor-samples][url-kmp-tor-samples]
 [badge-androidx-startup]: https://img.shields.io/badge/androidx.startup-1.1.1-6EDB8D.svg?logo=android
 [badge-coroutines]: https://img.shields.io/badge/kotlinx.coroutines-1.10.1-blue.svg?logo=kotlin
 [badge-encoding]: https://img.shields.io/badge/encoding-2.4.0-blue.svg?style=flat
-[badge-kmp-process]: https://img.shields.io/badge/kmp--process-0.2.0-blue.svg?style=flat
+[badge-kmp-process]: https://img.shields.io/badge/kmp--process-0.2.1-blue.svg?style=flat
 [badge-kmp-tor-common]: https://img.shields.io/badge/kmp--tor--common-2.2.0-blue.svg?style=flat
 [badge-kotlin]: https://img.shields.io/badge/kotlin-2.1.10-blue.svg?logo=kotlin
 [badge-kotlincrypto-bitops]: https://img.shields.io/badge/kotlincrypto.bitops-0.2.0-blue.svg?style=flat

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ kmp-process                 = "0.2.1"
 kmp-tor-common              = "2.2.0"
 kmp-tor-resource            = "408.16.0" # Upgrade yarn.lock when updating via `./gradlew kotlinUpgradeYarnLock`
 kotlincrypto-catalog        = "0.7.0" # Utilized from settings.gradle.kts
-kotlinx-coroutines          = "1.10.1"
+kotlinx-coroutines          = "1.10.2"
 ktor                        = "3.1.0"
 
 okio                        = "3.10.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ gradle-publish-maven        = "0.30.0"
 
 immutable                   = "0.2.0"
 
-kmp-process                 = "0.2.0"
+kmp-process                 = "0.2.1"
 kmp-tor-common              = "2.2.0"
 kmp-tor-resource            = "408.16.0" # Upgrade yarn.lock when updating via `./gradlew kotlinUpgradeYarnLock`
 kotlincrypto-catalog        = "0.7.0" # Utilized from settings.gradle.kts

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/TorOption.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/TorOption.kt
@@ -4708,13 +4708,20 @@ public abstract class TorOption: Comparable<TorOption>, CharSequence {
         isCmdLineArg = true,
         isUnique = true,
     ), ConfigureBuildable<BuilderScopeOwningCtrlProcess> {
+        // Cannot change ConfigureBuildable to ConfigureBuildableTry as that would break the API.
 
+        /**
+         * See [BuilderScopeOwningCtrlProcess]
+         *
+         * @throws [UnsupportedOperationException] if on Java9+ and module 'java.management' is not present
+         * */
         @JvmStatic
         @JvmOverloads
         public fun asSetting(
             block: ThisBlock<BuilderScopeOwningCtrlProcess> = ThisBlock { /* use current process' PID */ },
         ): TorSetting = buildContract(block)
 
+        @Throws(UnsupportedOperationException::class)
         override fun buildable(): BuilderScopeOwningCtrlProcess = BuilderScopeOwningCtrlProcess.get()
     }
 

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopeOwningCtrlProcess.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/config/builder/BuilderScopeOwningCtrlProcess.kt
@@ -28,11 +28,16 @@ import kotlin.jvm.JvmSynthetic
  *
  * By default, the [argument] is set to [Process.Current.pid] upon instantiation.
  *
+ * **NOTE:** Java9+ consumers **must** have module 'java.management' declared when
+ * using this option. Otherwise, an [UnsupportedOperationException] may be thrown
+ * upon class instantiation.
+ *
  * @see [TorOption.__OwningControllerProcess.asSetting]
  * */
 @KmpTorDsl
 public class BuilderScopeOwningCtrlProcess: TorSetting.BuilderScope {
 
+    @Throws(UnsupportedOperationException::class)
     private constructor(): super(TorOption.__OwningControllerProcess, INIT) {
         argument = Process.Current.pid().toString()
     }
@@ -55,6 +60,7 @@ public class BuilderScopeOwningCtrlProcess: TorSetting.BuilderScope {
     internal companion object {
 
         @JvmSynthetic
+        @Throws(UnsupportedOperationException::class)
         internal fun get(): BuilderScopeOwningCtrlProcess {
             return BuilderScopeOwningCtrlProcess()
         }


### PR DESCRIPTION
Closes #589 

`RuntimeEvent.ERROR` observers are now notified when the exception is encountered, and startup continues without the `__OwningControllerProcess` option configured.

`kotlinx.coroutines` is also updated in this PR, as the fix required updating `kmp-process`, which updated `kotlinx.coroutines`, so.