### PR TITLE
Use `sockaddr_un` struct when pre-calculating `UnixDomainSocket` max path length

### DIFF
--- a/library/runtime-core/src/androidNativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/AndroidNativePlatform.kt
+++ b/library/runtime-core/src/androidNativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/AndroidNativePlatform.kt
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
 import kotlinx.cinterop.ExperimentalForeignApi
 
-@OptIn(ExperimentalForeignApi::class)
-internal actual val AFUnixPathBufSize: Int = UNIX_PATH_MAX
+internal actual inline val AFUnixSunPathSize: Int get() {
+    @OptIn(ExperimentalForeignApi::class)
+    return UNIX_PATH_MAX
+}

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-CommonPlatform.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-CommonPlatform.kt
@@ -29,13 +29,13 @@ import kotlin.coroutines.cancellation.CancellationException
 
 internal expect val UnixSocketsNotSupportedMessage: String?
 
-internal expect val AFUnixPathBufSize: Int
+internal expect inline val AFUnixSunPathSize: Int
 
-internal expect val IsUnixLikeHost: Boolean
+internal expect inline val IsUnixLikeHost: Boolean
 
-internal expect val IsAndroidHost: Boolean
+internal expect inline val IsAndroidHost: Boolean
 
-internal expect val IsDarwinMobile: Boolean
+internal expect inline val IsDarwinMobile: Boolean
 
 @InternalKmpTorApi
 @Throws(Throwable::class)

--- a/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-FileExt.kt
+++ b/library/runtime-core/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-FileExt.kt
@@ -36,8 +36,8 @@ internal fun File.toUnixSocketPath(): String {
     // Darwin  -> MAX 102 chars
     // Linux   -> MAX 106 chars
     // Windows -> MAX 106 chars
-    // else    -> MAX 106 chars
-    if (path.length > (AFUnixPathBufSize - 2)) {
+    // else    -> MAX 104 chars
+    if (path.length > (AFUnixSunPathSize - 2)) {
         throw UnsupportedOperationException("path too long")
     }
 

--- a/library/runtime-core/src/iosMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/IosPlatform.kt
+++ b/library/runtime-core/src/iosMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/IosPlatform.kt
@@ -17,22 +17,17 @@
 
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
-import kotlin.experimental.ExperimentalNativeApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.sizeOf
+import platform.posix.sa_family_tVar
+import platform.posix.u_charVar
 
-internal actual inline val IsAndroidHost: Boolean get() {
-    @OptIn(ExperimentalNativeApi::class)
-    return when (Platform.osFamily) {
-        OsFamily.ANDROID -> true
-        else -> false
-    }
-}
-
-internal actual inline val IsDarwinMobile: Boolean get() {
-    @OptIn(ExperimentalNativeApi::class)
-    return when (Platform.osFamily) {
-        OsFamily.IOS,
-        OsFamily.TVOS,
-        OsFamily.WATCHOS-> true
-        else -> false
-    }
+internal actual inline val AFUnixSunPathSize: Int get() {
+    // struct  sockaddr_un {
+    //	 unsigned char   sun_len;        /* sockaddr len including null */
+    //	 sa_family_t     sun_family;     /* [XSI] AF_UNIX */
+    //	 char            sun_path[104];  /* [XSI] path name (gag) */
+    // };
+    @OptIn(ExperimentalForeignApi::class)
+    return (sizeOf<sockaddr_un>() -  sizeOf<u_charVar>() - sizeOf<sa_family_tVar>()).toInt()
 }

--- a/library/runtime-core/src/linuxMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/LinuxPlatform.kt
+++ b/library/runtime-core/src/linuxMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/LinuxPlatform.kt
@@ -13,7 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
-// sockaddr_un.sun_path buffer size as defined in sys/un.h
-internal actual val AFUnixPathBufSize: Int = 108
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.sizeOf
+import platform.linux.sockaddr_un
+import platform.posix.sa_family_tVar
+
+internal actual inline val AFUnixSunPathSize: Int get() {
+    // struct sockaddr_un
+    //   {
+    //     __SOCKADDR_COMMON (sun_);
+    //     char sun_path[108];		/* Path name.  */
+    //   };
+    @OptIn(ExperimentalForeignApi::class)
+    return (sizeOf<sockaddr_un>() - sizeOf<sa_family_tVar>()).toInt()
+}

--- a/library/runtime-core/src/macosMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/MacosPlatform.kt
+++ b/library/runtime-core/src/macosMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/MacosPlatform.kt
@@ -13,7 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
-// sockaddr_un.sun_path buffer size as defined in sys/un.h
-internal actual val AFUnixPathBufSize: Int = 104
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.sizeOf
+import platform.osx.sockaddr_un
+import platform.posix.sa_family_tVar
+import platform.posix.u_charVar
+
+internal actual inline val AFUnixSunPathSize: Int get() {
+    // struct  sockaddr_un {
+    //	 unsigned char   sun_len;        /* sockaddr len including null */
+    //	 sa_family_t     sun_family;     /* [XSI] AF_UNIX */
+    //	 char            sun_path[104];  /* [XSI] path name (gag) */
+    // };
+    @OptIn(ExperimentalForeignApi::class)
+    return (sizeOf<sockaddr_un>() -  sizeOf<u_charVar>() - sizeOf<sa_family_tVar>()).toInt()
+}

--- a/library/runtime-core/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-NonNativePlatform.kt
+++ b/library/runtime-core/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/-NonNativePlatform.kt
@@ -13,35 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
 import io.matthewnelson.kmp.file.SysDirSep
 import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.common.core.OSHost
 import io.matthewnelson.kmp.tor.common.core.OSInfo
-import kotlin.jvm.JvmSynthetic
 
-@OptIn(InternalKmpTorApi::class)
-internal actual val AFUnixPathBufSize: Int get() {
+internal actual inline val AFUnixSunPathSize: Int get() {
+    @OptIn(InternalKmpTorApi::class)
     return when (OSInfo.INSTANCE.osHost) {
-        // sockaddr_un.sun_path buffer size as defined in sys/un.h
+        // sockaddr_un.sun_path size as defined in sys/un.h
         is OSHost.FreeBSD,
         is OSHost.MacOS -> 104
 
         // UNIX_PATH_MAX as defined in afunix.h
         is OSHost.Windows -> 108
 
-        // sockaddr_un.sun_path buffer size as defined in sys/un.h
+        // sockaddr_un.sun_path size as defined in sys/un.h
         is OSHost.Linux -> 108
 
-        // Unknown (assuming Non-BSD)
-        else -> 108
+        // Unknown (assume some BSD flavor or AIX)
+        else -> 104
     }
 }
 
-@get:JvmSynthetic
-@OptIn(InternalKmpTorApi::class)
-internal actual val IsUnixLikeHost: Boolean get() {
+internal actual inline val IsUnixLikeHost: Boolean get() {
+    @OptIn(InternalKmpTorApi::class)
     return when (OSInfo.INSTANCE.osHost) {
         is OSHost.FreeBSD,
         is OSHost.Linux,
@@ -51,11 +51,9 @@ internal actual val IsUnixLikeHost: Boolean get() {
     }
 }
 
-@get:JvmSynthetic
-@OptIn(InternalKmpTorApi::class)
-internal actual val IsAndroidHost: Boolean get() {
-    // Could be Java running on Android via Termux if JVM
+internal actual inline val IsAndroidHost: Boolean get() {
+    @OptIn(InternalKmpTorApi::class)
     return OSInfo.INSTANCE.osHost is OSHost.Linux.Android
 }
 
-internal actual val IsDarwinMobile: Boolean get() = false
+internal actual inline val IsDarwinMobile: Boolean get() = false

--- a/library/runtime-core/src/unixMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/UnixPlatform.kt
+++ b/library/runtime-core/src/unixMain/kotlin/io/matthewnelson/kmp/tor/runtime/core/internal/UnixPlatform.kt
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.matthewnelson.kmp.tor.runtime.core.internal
 
 internal actual val UnixSocketsNotSupportedMessage: String? = null
 
-internal actual val IsUnixLikeHost: Boolean get() = true
+internal actual inline val IsUnixLikeHost: Boolean get() = true


### PR DESCRIPTION
Closes #604 