### PR TITLE
Use `encoding:utf8` when converting `TorCmd` to `UTF-8` bytes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,10 +33,10 @@ ktor                        = "3.3.3"
 [libraries]
 androidx-startup-runtime    = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
 
-encoding-core               = { module = "io.matthewnelson.encoding:core", version.ref = "encoding" }
 encoding-base16             = { module = "io.matthewnelson.encoding:base16", version.ref = "encoding" }
 encoding-base32             = { module = "io.matthewnelson.encoding:base32", version.ref = "encoding" }
 encoding-base64             = { module = "io.matthewnelson.encoding:base64", version.ref = "encoding" }
+encoding-utf8               = { module = "io.matthewnelson.encoding:utf8", version.ref = "encoding" }
 
 gradle-android              = { module = "com.android.tools.build:gradle", version.ref = "gradle-android" }
 gradle-dokka                = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "gradle-dokka" }

--- a/library/runtime-ctrl/build.gradle.kts
+++ b/library/runtime-ctrl/build.gradle.kts
@@ -23,7 +23,7 @@ kmpConfiguration {
             sourceSetMain {
                 dependencies {
                     api(project(":library:runtime-core"))
-                    implementation(libs.encoding.core) // TODO: utf8
+                    implementation(libs.encoding.utf8)
                     implementation(libs.immutable.collections)
                     implementation(libs.kmp.process)
                     implementation(libs.kmp.tor.common.core)

--- a/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
+++ b/library/runtime-ctrl/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/RealTorCtrl.kt
@@ -284,7 +284,7 @@ internal class RealTorCtrl private constructor(
                         intercepted = result
                     }
 
-                    (intercepted ?: cmdJob.cmd).encodeToByteArray(LOG)
+                    (intercepted ?: cmdJob.cmd).toByteArray(LOG)
                 } catch (t: Throwable) {
                     cmdJob.error(t)
                     continue


### PR DESCRIPTION
Closes #615 