### PR TITLE
Use `Dispatchers.Default`, instead of `Main`, for Js

### DIFF
--- a/library/runtime-ctrl/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -152,7 +152,7 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
          * */
         @Throws(CancellationException::class, IOException::class)
         public actual suspend fun connectAsync(address: IPSocketAddress): TorCtrl {
-            return withContext(Dispatchers.Main) { connect(address) }
+            return withContext(Dispatchers.Default) { connect(address) }
         }
 
         /**
@@ -166,7 +166,7 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
         @Throws(CancellationException::class, IOException::class, UnsupportedOperationException::class)
         public actual suspend fun connectAsync(path: File): TorCtrl {
             val sanitized = path.sanitizeUnixSocketPath()
-            return withContext(Dispatchers.Main) { connect(sanitized) }
+            return withContext(Dispatchers.Default) { connect(sanitized) }
         }
 
         @Deprecated("Use primary constructor with parameter 'debug: TorCtrl.Debugger' defined instead. See TorCtrl.Debugger.asDebugger()")
@@ -388,7 +388,7 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
                 }
             }
 
-            val ctrl = RealTorCtrl.of(this, Dispatchers.Main, connection, null)
+            val ctrl = RealTorCtrl.of(this, Dispatchers.Default, connection, null)
 
             // A slight delay is needed before returning in order
             // to ensure that the coroutine starts before able

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorListeners.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/TorListeners.kt
@@ -32,9 +32,9 @@ import io.matthewnelson.kmp.tor.runtime.core.config.TorOption
 import io.matthewnelson.kmp.tor.runtime.core.config.TorSetting.Companion.filterByOption
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCmdInterceptor
-import io.matthewnelson.kmp.tor.runtime.internal.timedDelay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.concurrent.Volatile
 import kotlin.jvm.JvmField
@@ -431,7 +431,7 @@ public class TorListeners private constructor(
             // Wait for all of them come in before notifying.
             _notifyJob?.cancel()
             _notifyJob = scope.launch {
-                timedDelay(notifyDelay)
+                delay(notifyDelay)
                 notify(new)
             }
         }

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/-CommonPlatform.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/-CommonPlatform.kt
@@ -23,17 +23,3 @@ import kotlin.time.TimeSource
 
 @Suppress("NOTHING_TO_INLINE")
 internal expect inline fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher
-
-// No matter the Delay implementation (Coroutines Test library)
-// Will delay the specified duration using a TimeSource.
-internal suspend fun timedDelay(duration: Duration) {
-    if (duration <= Duration.ZERO) return
-
-    var remainder = duration
-    val start = TimeSource.Monotonic.markNow()
-
-    while (remainder > Duration.ZERO) {
-        delay(remainder)
-        remainder = duration - start.elapsedNow()
-    }
-}

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/RealTorRuntime.kt
@@ -19,6 +19,7 @@ package io.matthewnelson.kmp.tor.runtime.internal
 
 import io.matthewnelson.immutable.collections.toImmutableSet
 import io.matthewnelson.kmp.file.InterruptedException
+import io.matthewnelson.kmp.file.InterruptedIOException
 import io.matthewnelson.kmp.tor.common.api.ExperimentalKmpTorApi
 import io.matthewnelson.kmp.tor.common.api.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.common.core.synchronized
@@ -948,25 +949,13 @@ internal class RealTorRuntime private constructor(
                     _failure = t
                 }
 
-                // Wait for service startup
-                TimeSource.Monotonic.markNow().let { mark ->
-                    // Node.js uses Dispatchers.Main so the test coroutine
-                    // library will not wait an actual timeout. Make it so
-                    // there's a delay no matter what.
-                    val interval = 100.milliseconds
-
-                    while (isActive) {
-                        if (_failure != null) break
-                        if (_instance != null) break
-                        delay(interval)
-                        if (_instance != null) break
-                        if (mark.elapsedNow() < TIMEOUT_START_SERVICE) continue
-                        _failure = InterruptedException("${name.name} timed out after 1000ms")
-                    }
-                }
+                if (_failure == null) delay(TIMEOUT_START_SERVICE)
 
                 // Has been started
-                val failure = _failure ?: return@launch
+                val failure = _failure ?: run {
+                    if (_instance != null) return@launch
+                    InterruptedException("${name.name} timed out after ${TIMEOUT_START_SERVICE.inWholeMilliseconds}ms")
+                }
 
                 val executables = synchronized(lock) cancel@ {
                     val executables = ArrayList<Executable>(actionStack.size + 3)

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorDaemon.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/TorDaemon.kt
@@ -72,7 +72,7 @@ internal class TorDaemon private constructor(
     private val _toString by lazy { toFIDString(includeHashCode = true) }
 
     @Throws(Throwable::class)
-    private suspend fun <T: Any?> start(
+    private suspend fun <T> start(
         checkCancellationOrInterrupt: () -> Unit,
         connect: suspend CtrlArguments.() -> T
     ): T = state.lock.withLock {
@@ -287,7 +287,7 @@ internal class TorDaemon private constructor(
         controlPortFile: File,
         checkCancellationOrInterrupt: () -> Unit,
     ): CtrlArguments.Connection {
-        timedDelay(100.milliseconds)
+        delay(100.milliseconds)
 
         val lines = controlPortFile
             .awaitRead(10.seconds, checkCancellationOrInterrupt)
@@ -374,7 +374,7 @@ internal class TorDaemon private constructor(
                 NOTIFIER.d(this@TorDaemon, "Waiting for tor to write to $name")
             }
 
-            timedDelay(50.milliseconds)
+            delay(50.milliseconds)
 
             checkCancellationOrInterrupt()
 
@@ -388,7 +388,7 @@ internal class TorDaemon private constructor(
         throw IOException("$TIMED_OUT after ${timeout.inWholeMilliseconds}ms waiting for tor to write to file[$name]")
     }
 
-    public override fun toString(): String = _toString
+    override fun toString(): String = _toString
 
     private class StartArgs private constructor(val cmdLine: List<String>, val load: TorCmd.Config.Load) {
 

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConnectivity.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/observer/ObserverConnectivity.kt
@@ -29,7 +29,6 @@ import io.matthewnelson.kmp.tor.runtime.core.OnEvent
 import io.matthewnelson.kmp.tor.runtime.core.config.TorOption
 import io.matthewnelson.kmp.tor.runtime.core.ctrl.TorCmd
 import io.matthewnelson.kmp.tor.runtime.core.util.executeAsync
-import io.matthewnelson.kmp.tor.runtime.internal.timedDelay
 import kotlinx.coroutines.*
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.cancellation.CancellationException
@@ -65,7 +64,7 @@ internal open class ObserverConnectivity internal constructor(
 
         _job?.cancel()
         _job = scope.launch {
-            timedDelay(executeDelay)
+            delay(executeDelay)
 
             val disabled = when (it) {
                 NetworkObserver.Connectivity.Connected -> false

--- a/library/runtime/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/JsPlatform.kt
+++ b/library/runtime/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/JsPlatform.kt
@@ -21,4 +21,4 @@ import io.matthewnelson.kmp.tor.runtime.TorRuntime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
-internal actual inline fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher = Dispatchers.Main
+internal actual inline fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher = Dispatchers.Default


### PR DESCRIPTION
Changes the `CoroutineDispatcher` utilized for both `TorCtrl` and `TorRuntime` on Node.js to `Dispatchers.Default`. This ensures any potential test coroutine time advancement does not affect things.