### PR TITLE
Remove use of `ExperimentalCoroutinesApi` when instantiating `CoroutineDispatchers` for Native/Jvm

### DIFF
--- a/library/runtime-ctrl/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-JvmPlatform.kt
+++ b/library/runtime-ctrl/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-JvmPlatform.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.matthewnelson.kmp.tor.runtime.ctrl.internal
 
 import io.matthewnelson.kmp.file.ANDROID
@@ -25,8 +27,8 @@ import io.matthewnelson.kmp.tor.runtime.core.Disposable
 import io.matthewnelson.kmp.tor.runtime.core.net.IPSocketAddress
 import io.matthewnelson.kmp.tor.runtime.core.util.toInetAddress
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
-import kotlinx.coroutines.CloseableCoroutineDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.io.InputStream
 import java.io.OutputStream
@@ -45,16 +47,26 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.concurrent.Volatile
 
-@OptIn(ExperimentalCoroutinesApi::class)
-internal actual fun TorCtrl.Factory.newTorCtrlDispatcher(): CloseableCoroutineDispatcher {
+private val TOR_CTRL_NO = AtomicLong(0L)
+
+internal actual fun TorCtrl.Factory.newTorCtrlDispatcher(): CoroutineDispatcher {
     val threadNo = AtomicLong()
-    val executor = Executors.newFixedThreadPool(2) { runnable ->
-        val t = Thread(runnable, "TorCtrl-${threadNo.incrementAndGet()}")
+    val torCtrlNo = TOR_CTRL_NO.incrementAndGet()
+    val executor = Executors.newScheduledThreadPool(2) { task ->
+        val t = Thread(task)
         t.isDaemon = true
+        t.name = "TorCtrl{$torCtrlNo}-${threadNo.incrementAndGet()}"
         t.priority = Thread.MAX_PRIORITY
         t
     }
-    return executor.asCoroutineDispatcher()
+    // Before making the Executor unconfigurable, want to ensure
+    // setRemoveOnCancelPolicy(true) is called (if possible).
+    executor.asCoroutineDispatcher()
+    return Executors.unconfigurableScheduledExecutorService(executor).asCoroutineDispatcher()
+}
+
+internal actual inline fun CoroutineDispatcher.destroy() {
+    (this as? ExecutorCoroutineDispatcher)?.close()
 }
 
 @Throws(Throwable::class)

--- a/library/runtime-ctrl/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/NativePlatform.kt
+++ b/library/runtime-ctrl/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/NativePlatform.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("UnnecessaryOptInAnnotation")
+@file:Suppress("NOTHING_TO_INLINE")
 
 package io.matthewnelson.kmp.tor.runtime.ctrl.internal
 
@@ -27,14 +27,22 @@ import io.matthewnelson.kmp.tor.runtime.core.net.IPSocketAddress
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
 import kotlinx.cinterop.*
 import kotlinx.coroutines.CloseableCoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.newFixedThreadPoolContext
 import platform.posix.*
+import kotlin.concurrent.AtomicLong
 
-@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
-internal actual fun TorCtrl.Factory.newTorCtrlDispatcher(): CloseableCoroutineDispatcher {
-    return newFixedThreadPoolContext(2, "TorCtrl")
+private val TOR_CTRL_NO = AtomicLong(0L)
+
+@OptIn(DelicateCoroutinesApi::class)
+internal actual fun TorCtrl.Factory.newTorCtrlDispatcher(): CoroutineDispatcher {
+    val torCtrlNo = TOR_CTRL_NO.incrementAndGet()
+    return newFixedThreadPoolContext(2, "TorCtrl{$torCtrlNo}")
+}
+
+internal actual inline fun CoroutineDispatcher.destroy() {
+    (this as? CloseableCoroutineDispatcher)?.close()
 }
 
 @Throws(Throwable::class)

--- a/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
+++ b/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/TorCtrl.kt
@@ -240,17 +240,17 @@ public actual interface TorCtrl : Destroyable, TorEvent.Processor, TorCmd.Privil
             val connection = try {
                 connect(dispatcher)
             } catch (t: Throwable) {
-                dispatcher.close()
+                dispatcher.destroy()
                 if (t is CancellationException) throw t
                 throw t.wrapIOException()
             }
 
-            val close = Executable.Once.of(concurrent = true) { dispatcher.close() }
+            val close = Executable.Once.of(concurrent = true) { dispatcher.destroy() }
 
             return RealTorCtrl.of(this, dispatcher, connection, closeDispatcher = { LOG ->
                 try {
                     @OptIn(DelicateCoroutinesApi::class)
-                    GlobalScope.launch(Dispatchers.IO) {
+                    GlobalScope.launch(Dispatchers.IO, start = CoroutineStart.ATOMIC) {
                         try {
                             delay(250.milliseconds)
                         } finally {

--- a/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-NonJsPlatform.kt
+++ b/library/runtime-ctrl/src/nonJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/ctrl/internal/-NonJsPlatform.kt
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("NOTHING_TO_INLINE")
+
 package io.matthewnelson.kmp.tor.runtime.ctrl.internal
 
 import io.matthewnelson.kmp.file.File
 import io.matthewnelson.kmp.process.ReadBuffer
 import io.matthewnelson.kmp.tor.runtime.core.net.IPSocketAddress
 import io.matthewnelson.kmp.tor.runtime.ctrl.TorCtrl
-import kotlinx.coroutines.CloseableCoroutineDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineDispatcher
 
-@OptIn(ExperimentalCoroutinesApi::class)
-internal expect fun TorCtrl.Factory.newTorCtrlDispatcher(): CloseableCoroutineDispatcher
+internal expect fun TorCtrl.Factory.newTorCtrlDispatcher(): CoroutineDispatcher
+
+internal expect inline fun CoroutineDispatcher.destroy()
 
 @Throws(Throwable::class)
 internal expect fun IPSocketAddress.connect(): CtrlConnection

--- a/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/-CommonPlatform.kt
+++ b/library/runtime/src/commonMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/-CommonPlatform.kt
@@ -17,9 +17,5 @@ package io.matthewnelson.kmp.tor.runtime.internal
 
 import io.matthewnelson.kmp.tor.runtime.TorRuntime
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.delay
-import kotlin.time.Duration
-import kotlin.time.TimeSource
 
-@Suppress("NOTHING_TO_INLINE")
-internal expect inline fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher
+internal expect fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher

--- a/library/runtime/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/JsPlatform.kt
+++ b/library/runtime/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/JsPlatform.kt
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.matthewnelson.kmp.tor.runtime.internal
 
 import io.matthewnelson.kmp.tor.runtime.TorRuntime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
-internal actual inline fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher = Dispatchers.Default
+internal actual fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher = Dispatchers.Default

--- a/library/runtime/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/-JvmPlatform.kt
+++ b/library/runtime/src/jvmMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/-JvmPlatform.kt
@@ -22,15 +22,18 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
-@Suppress("NOTHING_TO_INLINE")
-internal actual inline fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher {
+internal actual fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher {
     val threadNo = AtomicLong()
     val name = "Tor[$fidEllipses]"
-    val executor = Executors.newSingleThreadExecutor { runnable ->
-        val t = Thread(runnable, "$name-${threadNo.incrementAndGet()}")
+    val executor = Executors.newScheduledThreadPool(1) { task ->
+        val t = Thread(task)
         t.isDaemon = true
+        t.name = "$name-${threadNo.incrementAndGet()}"
         t.priority = Thread.MAX_PRIORITY
         t
     }
-    return executor.asCoroutineDispatcher()
+    // Before making the Executor unconfigurable, want to ensure
+    // setRemoveOnCancelPolicy(true) is called (if possible).
+    executor.asCoroutineDispatcher()
+    return Executors.unconfigurableScheduledExecutorService(executor).asCoroutineDispatcher()
 }

--- a/library/runtime/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/NativePlatform.kt
+++ b/library/runtime/src/nativeMain/kotlin/io/matthewnelson/kmp/tor/runtime/internal/NativePlatform.kt
@@ -13,19 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("KotlinRedundantDiagnosticSuppress")
-
 package io.matthewnelson.kmp.tor.runtime.internal
 
 import io.matthewnelson.kmp.tor.runtime.FileID.Companion.fidEllipses
 import io.matthewnelson.kmp.tor.runtime.TorRuntime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.newFixedThreadPoolContext
 
-@Suppress("NOTHING_TO_INLINE")
-internal actual inline fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher {
-    @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
-    return newSingleThreadContext("Tor[$fidEllipses]")
+internal actual fun TorRuntime.Environment.newRuntimeDispatcher(): CoroutineDispatcher {
+    @OptIn(DelicateCoroutinesApi::class)
+    return newFixedThreadPoolContext(1, "Tor[$fidEllipses]")
 }


### PR DESCRIPTION
This PR updates Native/Jvm platform specific code for when `CoroutineDispatcher` are instantiated such that `ExperimentalCoroutinesApi` is no longer relied on. It also ensures that for Jvm, the backing `Executor` is a `ScheduledThreadPoolExecutor` configured such that `setRemoveOnCancelPolicy` is `true`.